### PR TITLE
Fixes for CSV Import

### DIFF
--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -57,14 +57,10 @@ module Bulkrax
     # @param field [String] the importer field name
     # @return [Array] hyrax fields
     def field_to(field)
-      return [field] if mapping.blank?
-      # retrieve the mapping
-      fields = mapping.map {
-        |key,value| 
-        key if (value['from'] && value['from'].include?(field)) || key == field 
-      }.compact
-      return fields unless fields.blank?
-      return [field]
+      fields = mapping&.map { |key, value|
+        key if (value['from'] && value['from'].include?(field)) || key == field
+      }&.compact
+      return fields || [field]
     end
   end
 end

--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -58,11 +58,13 @@ module Bulkrax
     # @return [Array] hyrax fields
     def field_to(field)
       return [field] if mapping.blank?
-      
-      mapping.map {
+      # retrieve the mapping
+      fields = mapping.map {
         |key,value| 
         key if (value['from'] && value['from'].include?(field)) || key == field 
       }.compact
+      return fields unless fields.blank?
+      return [field]
     end
   end
 end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -1,3 +1,4 @@
+require 'csv'
 module Bulkrax
   class CsvParser < ApplicationParser
     
@@ -6,7 +7,6 @@ module Bulkrax
     end
 
     def records(_opts = {})
-      require 'csv'
       # there's a risk that this reads the whole file into memory and could cause a memory leak
       @records ||= CSV.foreach(
         parser_fields['csv_path'],

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -6,6 +6,7 @@ module Bulkrax
     end
 
     def records(_opts = {})
+      require 'csv'
       # there's a risk that this reads the whole file into memory and could cause a memory leak
       @records ||= CSV.foreach(
         parser_fields['csv_path'],


### PR DESCRIPTION
Newer versions of rails need `require 'csv'` in the CSV parser.

There is an issue where an incomplete mapping will omit unmapped (but valid) fields. The only time fields should be omitted is if they are explicitly declared as excluded or not supported by hyrax.