### PR TITLE
Add a server_name config for the oai headers

### DIFF
--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -116,7 +116,7 @@ module Bulkrax
       def setup_client(url)
         return false if url.nil?
 
-        headers = { from: 'server@atla.com' }
+        headers = { from: Bulkrax.server_name }
 
         @client ||= OAI::Client.new(url, headers: headers, parser: 'libxml', metadata_prefix: 'oai_dc')
       end

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -8,7 +8,8 @@ module Bulkrax
       :reserved_properties,
       :field_mappings,
       :import_path,
-      :export_path
+      :export_path,
+      :server_name
 
     self.parsers = [
       { name: "OAI - Dublin Core", class_name: "Bulkrax::OaiDcParser", partial: "oai_fields" },
@@ -19,11 +20,12 @@ module Bulkrax
     self.system_identifier_field = "source"
     self.import_path = 'tmp/imports'
     self.export_path = 'tmp/exports'
+    self.server_name = 'bulkrax@example.com'
 
     # Hash of Generic field_mappings for use in the view
     # There must be one field_mappings hash per view parial
     # Based on Hyrax CoreMetadata && BasicMetadata
-    # Override at appliation level to change
+    # Override at application level to change
     self.field_mappings = {
       "Bulkrax::OaiDcParser" => {
         "contributor" => { from: ["contributor"] },

--- a/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
+++ b/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
@@ -14,6 +14,9 @@ Bulkrax.setup do |config|
   # Path to store exports before download
   # self.export_path = 'tmp/exports'
 
+  # Server name for oai request header
+  # config.server_name = 'my_server@name.com'
+
   # Field mappings
   # Create a completely new set of mappings by replacing the whole set as follows
   #   config.field_mappings = {

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe Bulkrax do
       end
     end
 
+    context 'server_name' do
+      it 'has a default' do
+        expect(described_class.server_name).to eq('bulkrax@example.com')
+      end
+
+      it 'is settable' do
+        expect(described_class).to respond_to(:server_name=)
+      end
+    end
+
     context 'reserved_properties' do
       it 'has a default' do
         expect(described_class.reserved_properties).to eq(%w[


### PR DESCRIPTION
There was a hard coded value, that's been turned into a config.