### PR TITLE
Improvements to CSV Importer

### DIFF
--- a/app/factories/bulkrax/image_factory.rb
+++ b/app/factories/bulkrax/image_factory.rb
@@ -5,7 +5,7 @@ if defined?(Image)
 
       self.klass = Image
       # A way to identify objects that are not Hydra minted identifiers
-      self.system_identifier_field = :identifier
+      self.system_identifier_field = Bulkrax.system_identifier_field
 
       # TODO: add resource type?
       # def create_attributes

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -25,7 +25,6 @@ module Bulkrax
 
     def reschedule(entry_id, run_id)
       ImportWorkJob.set(wait: 1.minutes).perform_later(entry_id, run_id)
-      true
     end
   end
 end

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -4,22 +4,28 @@ module Bulkrax
 
     def perform(*args)
       entry = Entry.find(args[0])
-      build = entry.build
-      entry.save
-      if build == true
+      build_result = entry.build
+      if build_result.present?
+        entry.save!
         ImporterRun.find(args[1]).increment!(:processed_records)
-      elsif build == false && entry.last_exception.blank?
-        reschedule(entry.id, ImporterRun.find(args[1]).id)
-      elsif entry.last_exception.present?
-        raise entry.last_exception
-      end
-      rescue StandardError => e
+      else
+        # do not retry here because whatever parse error kept you from creating a work will likely
+        # keep preventing you from doing so.
+        entry.save!
         ImporterRun.find(args[1]).increment!(:failed_records)
+      end
+      rescue CollectionsCreatedError => e
+        reschedule(args[0], args[1])
+      # Exceptions here are not an issue with building the work.
+      # Those are caught seperately, these are more likely network, db or other unexpected issues.
+      # Note that these temporary type issues do not raise the failure count
+      rescue StandardError => e
         raise e
     end
 
     def reschedule(entry_id, run_id)
       ImportWorkJob.set(wait: 1.minutes).perform_later(entry_id, run_id)
+      true
     end
   end
 end

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -4,23 +4,18 @@ module Bulkrax
 
     def perform(*args)
       entry = Entry.find(args[0])
-      begin
-        if entry.build.present?
-          entry.save
-        elsif entry.last_exception.blank?
-          reschedule(entry.id, ImporterRun.find(args[1]).id)
-        end
+      build = entry.build
+      entry.save
+      if build == true
+        ImporterRun.find(args[1]).increment!(:processed_records)
+      elsif build == false && entry.last_exception.blank?
+        reschedule(entry.id, ImporterRun.find(args[1]).id)
+      elsif entry.last_exception.present?
+        raise entry.last_exception
+      end
       rescue StandardError => e
         ImporterRun.find(args[1]).increment!(:failed_records)
         raise e
-      else
-        if entry.last_exception
-          ImporterRun.find(args[1]).increment!(:failed_records)
-          raise entry.last_exception
-        else
-          ImporterRun.find(args[1]).increment!(:processed_records)
-        end
-      end
     end
 
     def reschedule(entry_id, run_id)

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -10,6 +10,7 @@ module Bulkrax
     end
 
     def import(importer, only_updates_since_last_import)
+      importer.validate_import
       importer.import_collections
       importer.import_works(only_updates_since_last_import)
     end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -7,8 +7,8 @@ module Bulkrax
     def build_metadata
       if record.nil?
         raise StandardError, 'Record not found'
-      elsif required_elements?(record.keys) == false
-        raise StandardError, "Missing required elements, required elements are: #{required_elements.join(', ')}"
+      elsif importerexporter.parser.required_elements?(record.keys) == false
+        raise StandardError, "Missing required elements, required elements are: #{importerexporter.parser.required_elements.join(', ')}"
       end
 
       self.parsed_metadata = {}
@@ -61,19 +61,12 @@ module Bulkrax
 
     def find_or_create_collection_ids
       return self.collection_ids if collections_created?
+      valid_system_id(Collection)
       record['collection'].split(/\s*[:;|]\s*/).each do | collection |
-        c = Collection.where(Bulkrax.system_identifier_field => collection).first
+        c = find_collection(collection)
         self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
       end unless record['collection'].blank?
       return self.collection_ids
-    end
-
-    def required_elements?(keys)
-      !required_elements.map { |el| keys.include?(el) }.include?(false)
-    end
-
-    def required_elements
-      %w[title source_identifier]
     end
   end
 end

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -1,5 +1,8 @@
 module Bulkrax
+  # Custom error class for collections_created?
+  class CollectionsCreatedError < StandardError; end
   class Entry < ApplicationRecord
+
     include Bulkrax::HasMatchers
     include Bulkrax::HasLocalProcessing
     include Bulkrax::ImportBehavior

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -26,11 +26,11 @@ module Bulkrax
     end
 
     def importer?
-      true if self.importerexporter_type == 'Bulkrax::Importer'
+      self.importerexporter_type == 'Bulkrax::Importer'
     end
 
     def exporter?
-      true if self.importerexporter_type == 'Bulkrax::Exporter'
+      self.importerexporter_type == 'Bulkrax::Exporter'
     end
 
     def status
@@ -65,5 +65,16 @@ module Bulkrax
       end
     end
     
+    def valid_system_id(model_class)
+      raise(
+        "#{model_class} does not implement the system_identifier_field: #{Bulkrax.system_identifier_field}"
+      ) unless model_class.properties.keys.include?(Bulkrax.system_identifier_field)
+    end
+
+    def find_collection(collection_identifier)
+      Collection.where(
+        Bulkrax.system_identifier_field => collection_identifier
+      ).detect { |m| m.send(Bulkrax.system_identifier_field).include?(collection_identifier) }
+    end
   end
 end

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -15,6 +15,8 @@ module Bulkrax
     validates :admin_set_id, presence: true
     validates :parser_klass, presence: true
 
+    delegate :validate_import, to: :parser
+
     attr_accessor :only_updates
     # TODO validates :metadata_prefix, presence: true
     # TODO validates :base_url, presence: true
@@ -69,6 +71,7 @@ module Bulkrax
     end
 
     # Prepend the base_url to ensure unique set identifiers
+    # @todo - move to parser, as this is OAI specific
     def unique_collection_identifier(id)
       "#{self.parser_fields['base_url'].split('/')[2]}_#{id}"
     end

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -59,7 +59,8 @@ module Bulkrax
       return self.collection_ids if collections_created?
 
       if sets.blank? || parser.collection_name != 'all'
-        c = Collection.where(Bulkrax.system_identifier_field => importerexporter.unique_collection_identifier(parser.collection_name)).first
+        #c = Collection.where(Bulkrax.system_identifier_field => importerexporter.unique_collection_identifier(parser.collection_name)).first
+        c = find_collection(importerexporter.unique_collection_identifier(parser.collection_name))
         if c.present? && !self.collection_ids.include?(c.id)
           self.collection_ids << c.id
         end

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -7,13 +7,12 @@ module Bulkrax
       build_metadata
       return false unless collections_created?
       begin
-        @item = factory.run
+        factory.run
+        return true
       rescue StandardError => e
         status_info(e)
-      else
-        status_info
+        return false
       end
-      return @item
     end
 
     def find_or_create_collection_ids

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -3,16 +3,16 @@ module Bulkrax
     extend ActiveSupport::Concern
 
     def build_for_importer
-      # attributes, files_dir = nil, files = [], user = nil
       build_metadata
-      return false unless collections_created?
+      raise CollectionsCreatedError unless collections_created?
       begin
-        factory.run
-        return true
+        @item = factory.run
       rescue StandardError => e
         status_info(e)
-        return false
+      else
+        status_info
       end
+      return @item
     end
 
     def find_or_create_collection_ids

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -49,6 +49,8 @@ module Bulkrax
       importerexporter.is_a?(Bulkrax::Exporter)
     end
 
+    def validate_import; end
+
     def files_path; end
 
     def find_or_create_entry(entryclass, identifier, type, raw_metadata = nil)

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -17,7 +17,20 @@ module Bulkrax
     end
 
     def import_fields
-      @import_fields ||= records.map {|r| r.headers }.flatten
+      @import_fields ||= records.map {|r| r.headers }.flatten.uniq.compact
+    end
+
+    def required_elements?(keys)
+      return if keys.blank?
+      !required_elements.map { |el| keys.map(&:to_s).include?(el) }.include?(false)
+    end
+
+    def required_elements
+      %w[title source_identifier]
+    end
+
+    def validate_import
+      raise "Missing required elements, required elements are: #{required_elements.join(', ')}" unless required_elements?(import_fields)
     end
 
     def create_collections

--- a/spec/factories/bulkrax_entries.rb
+++ b/spec/factories/bulkrax_entries.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :bulkrax_entry, class: 'Bulkrax::Entry' do
     identifier { "MyString" }
     type { "" }
-    importerexporter { nil }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
     raw_metadata { "MyText" }
     parsed_metadata { "MyText" }
   end

--- a/spec/factories/bulkrax_importers.rb
+++ b/spec/factories/bulkrax_importers.rb
@@ -36,4 +36,15 @@ FactoryBot.define do
     parser_fields { { 'csv_path' => 'spec/fixtures/csv/good.csv' } }
     field_mapping { {} }
   end
+
+  factory :bulkrax_importer_csv_bad, class: 'Bulkrax::Importer' do
+    name { 'CSV Import' }
+    admin_set_id { 'MyString' }
+    user { FactoryBot.build(:base_user) }
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::CsvParser' }
+    limit { 10 }
+    parser_fields { { 'csv_path' => 'spec/fixtures/csv/bad.csv' } }
+    field_mapping { {} }
+  end
 end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :collection, class: 'Collection' do
     id { 'collection_id' }
     title { ['MyCollection'] }
+    source { ['commons.ptsem.edu_MyCollection'] }
   end
 end

--- a/spec/jobs/bulkrax/import_work_job_spec.rb
+++ b/spec/jobs/bulkrax/import_work_job_spec.rb
@@ -8,16 +8,44 @@ module Bulkrax
     before(:each) do
       allow(Bulkrax::Entry).to receive(:find).with(1).and_return(entry)
       allow(Bulkrax::ImporterRun).to receive(:find).with(2).and_return(importer_run)
-      allow(entry).to receive(:build)
     end
 
     describe 'successful job' do
       before do
-        allow(entry).to receive(:save).and_return(true)
+        allow(entry).to receive(:build).and_return(true)
+        allow(entry).to receive(:save)
       end
       it 'increments :processed_records' do
         expect(importer_run).to receive(:increment!).with(:processed_records)
         subject.perform(1, 2)
+      end
+    end
+
+    describe 'unsuccessful job - collections not created' do
+      before do
+        allow(entry).to receive(:build).and_return(false)
+        allow(entry).to receive(:collections_created?).and_return(false)
+        allow(entry).to receive(:save)
+      end
+      it 'does not call increment' do
+        expect(importer_run).not_to receive(:increment!)
+        subject.perform(1, 2)
+      end
+      it 'reschedules the job' do
+        expect(subject).to receive(:reschedule)
+        subject.perform(1, 2)
+      end
+    end
+
+    describe 'unsuccessful job - error caught by build' do
+      before do
+        allow(entry).to receive(:build).and_return(false)
+        allow(entry).to receive(:last_exception).and_return(StandardError)
+        allow(entry).to receive(:save)
+      end
+      it 'increments :failed_records' do
+        expect(importer_run).to receive(:increment!).with(:failed_records)
+        expect { subject.perform(1, 2) }.to raise_error(StandardError)
       end
     end
   end

--- a/spec/jobs/bulkrax/import_work_job_spec.rb
+++ b/spec/jobs/bulkrax/import_work_job_spec.rb
@@ -12,7 +12,8 @@ module Bulkrax
 
     describe 'successful job' do
       before do
-        allow(entry).to receive(:build).and_return(true)
+        allow(entry).to receive(:collections_created?).and_return(true)
+        allow(entry).to receive(:build).and_return(instance_of(Work))
         allow(entry).to receive(:save)
       end
       it 'increments :processed_records' do
@@ -23,8 +24,7 @@ module Bulkrax
 
     describe 'unsuccessful job - collections not created' do
       before do
-        allow(entry).to receive(:build).and_return(false)
-        allow(entry).to receive(:collections_created?).and_return(false)
+        allow(entry).to receive(:build_for_importer).and_raise(CollectionsCreatedError)
         allow(entry).to receive(:save)
       end
       it 'does not call increment' do
@@ -39,13 +39,13 @@ module Bulkrax
 
     describe 'unsuccessful job - error caught by build' do
       before do
-        allow(entry).to receive(:build).and_return(false)
+        allow(entry).to receive(:build).and_return(nil)
         allow(entry).to receive(:last_exception).and_return(StandardError)
         allow(entry).to receive(:save)
       end
       it 'increments :failed_records' do
         expect(importer_run).to receive(:increment!).with(:failed_records)
-        expect { subject.perform(1, 2) }.to raise_error(StandardError)
+        subject.perform(1, 2)
       end
     end
   end

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -20,6 +20,14 @@ module Bulkrax
       end
     end
 
+    describe 'unsuccessful job' do
+      let(:importer) { FactoryBot.create(:bulkrax_importer_csv_bad) }
+
+      it 'raises an error with an invalid import' do
+        expect { subject.perform(1) }.to raise_error(RuntimeError, 'Missing required elements, required elements are: title, source_identifier')
+      end
+    end
+
     describe 'schedulable' do
       before do
         allow(importer).to receive(:schedulable?).and_return(true)

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -6,6 +6,10 @@ module Bulkrax
       let(:importer) { FactoryBot.build(:bulkrax_importer_csv) }
       subject { described_class.new(importerexporter: importer) }
 
+      before do
+        allow(Bulkrax).to receive(:default_work_type).and_return('Work')
+      end
+
       context 'without required metadata' do
         before(:each) do
           allow(subject).to receive(:record).and_return(source_identifier: '1', some_field: 'some data')

--- a/spec/models/bulkrax/entry_spec.rb
+++ b/spec/models/bulkrax/entry_spec.rb
@@ -4,16 +4,26 @@ module Bulkrax
   RSpec.describe Entry, type: :model do
     describe 'field_mappings' do
       let(:importer) { FactoryBot.build(:bulkrax_importer) }
+      let(:collection) { FactoryBot.build(:collection) }
       subject { described_class.new(importerexporter: importer) }
 
       before do
+        allow(Collection).to receive(:where).and_return([collection])
         allow(Bulkrax).to receive(:default_work_type).and_return('Work')
       end
 
       context '.mapping' do
-
         it 'is delegated to importer and returns the default set of 15 dc properties' do
           expect(subject.mapping.keys.length).to eq(15)
+        end
+      end
+
+      context '.find_collection' do
+        it 'it finds the collection' do
+          expect(subject.find_collection('commons.ptsem.edu_MyCollection')).to eq(collection)
+        end
+        it 'it does find the collection with a partial match' do
+          expect(subject.find_collection('MyCollection')).not_to eq(collection)
         end
       end
 

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -54,7 +54,7 @@ module Bulkrax
 
     describe "find_or_create_collection_ids" do
       before do
-        importer.parser_fields['set'] = 'some_set'
+        importer.parser_fields['set'] = 'MyCollection'
         allow(entry).to receive_message_chain(:sets, :blank?).and_return(false)
       end
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -18,7 +18,7 @@ module Bulkrax
           importer.parser_fields = { csv_path: './spec/fixtures/csv/malformed.csv' }
         end
 
-        it 'returns and empty array, and records the error on the importer' do
+        it 'returns an empty array, and records the error on the importer' do
           subject.create_works
           expect(importer.errors.details[:base].first[:error]).to eq('CSV::MalformedCSVError'.to_sym)
         end


### PR DESCRIPTION
This PR:

* makes it explicit when a CSV won't import because of missing required fields - previously, this would silently fail with no error message. Now an error is raised and will be seen in sidekiq.
* adds a `#validate_import` method to the parser, which can be expanded on for the validation work. Here it is used to check for required fields in CSV.
* returns a sensible error message if Collection doesn't implement/index the sytem identifier field - previously a Solr error would be thrown which didn't easily identify the issue
* dries up the find_collection methods used by the entries
* sets the image application factory system identifier to be the Bulkrax system identifier (if different identifiers are supplied, we'll get duplicate records) - this will be removed in #77 
* refactors the ImportWorkJob and Entry#build method to make the code clearer and more logical; added tests for the Job