### PR TITLE
Bugfixes

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -42,14 +42,6 @@ module Bulkrax
       log_updated(object)
     end
 
-    def create_attributes
-      transform_attributes
-    end
-
-    def update_attributes
-      transform_attributes.except(:id)
-    end
-
     def find
       return find_by_id if attributes[:id]
       return search_by_identifier if attributes[system_identifier_field].present?

--- a/app/factories/bulkrax/with_associated_collection.rb
+++ b/app/factories/bulkrax/with_associated_collection.rb
@@ -6,15 +6,15 @@ module Bulkrax
     # which is used by Hyrax::Actors::AddAsMemberOfCollectionsActor
     def create_attributes
       if attributes[:collection].present?
-        super.except(:collections).merge(member_of_collections_attributes: {0 => {id: collection.id}})
+        transform_attributes.except(:collections).merge(member_of_collections_attributes: {0 => {id: collection.id}})
       elsif attributes[:collections].present?
         collection_ids = attributes[:collections].each.with_index.inject({}) do |ids, (element, index)|
           ids[index] = element
           ids
         end
-        super.except(:collections).merge(member_of_collections_attributes: collection_ids)
+        transform_attributes.except(:collections).merge(member_of_collections_attributes: collection_ids)
       else
-        super
+        transform_attributes
       end
     end
 
@@ -22,15 +22,15 @@ module Bulkrax
     # which is used by Hyrax::Actors::AddAsMemberOfCollectionsActor
     def update_attributes
       if attributes[:collection].present?
-        super.except(:collections).merge(member_of_collections_attributes: {0 => {id: collection.id}})
+        transform_attributes.except(:id).except(:collections).merge(member_of_collections_attributes: {0 => {id: collection.id}})
       elsif attributes[:collections].present?
         collection_ids = attributes[:collections].each.with_index.inject({}) do |ids, (element, index)|
           ids[index] = element
           ids
         end
-        super.except(:collections).merge(member_of_collections_attributes: collection_ids)
+        transform_attributes.except(:id).except(:collections).merge(member_of_collections_attributes: collection_ids)
       else
-        super
+        transform_attributes.except(:id)
       end
     end
   end

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -1,6 +1,6 @@
 module Bulkrax
   # Custom error class for collections_created?
-  class CollectionsCreatedError < StandardError; end
+  class CollectionsCreatedError < Exception; end
   class Entry < ApplicationRecord
 
     include Bulkrax::HasMatchers

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -24,8 +24,8 @@ module Bulkrax
 
     def build
       return false if type.nil?
-      build_for_importer if importer?
-      build_for_exporter if exporter?
+      return build_for_importer if importer?
+      return build_for_exporter if exporter?
     end
 
     def importer?

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -3,9 +3,9 @@ module Bulkrax
     extend ActiveSupport::Concern
 
     def build_for_importer
-      build_metadata
-      raise CollectionsCreatedError unless collections_created?
       begin
+        build_metadata
+        raise CollectionsCreatedError unless collections_created?
         @item = factory.run
       rescue StandardError => e
         status_info(e)

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -49,6 +49,9 @@ module Bulkrax
       importerexporter.is_a?(Bulkrax::Exporter)
     end
 
+    # Override to add specific validations
+    def def validate_import; end
+
     def find_or_create_entry(entryclass, identifier, type, raw_metadata = nil)
       entryclass.where(
         importerexporter_id: importerexporter.id,


### PR DESCRIPTION
- Move build_metadata into the begin otherwise errors in build_metadata won't be caught
- Change CollectionsCreatedError to an Exception so it won't be caught as StandardError
- Add a default `validate_import` method to ApplicationParser
- Reinstate collections creation in object factory