### PR TITLE
File path validation

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -35,7 +35,7 @@ module Bulkrax
       end
 
       # construct full file path
-      self.parsed_metadata['file'] = self.parsed_metadata['file'].map {|f| file_path(f)} if self.parsed_metadata['file'].present?
+      self.parsed_metadata['file'] = self.parsed_metadata['file'].split(/\s*[:;|]\s*/).map {|f| file_path(f)} if self.parsed_metadata['file'].present?
 
       add_visibility
       add_rights_statement
@@ -100,10 +100,13 @@ module Bulkrax
     def file_path(file)
       # return if we already have the full file path
       return file if File.exist?(file)
-      path = self.importerexporter.parser_fields['import_file_path'].split('/')
-      # remove the metadata filename from the end of the import path
-      path.pop
-      File.join(path.join('/'), 'files', file)
+      path = importerexporter.parser.files_path
+      f = File.join(path, file)
+      if File.exist?(f)
+        return f
+      else
+        raise "File #{f} does not exist"
+      end
     end
 
   end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -58,10 +58,6 @@ module Bulkrax
       raise 'must be defined' if exporter?
     end
 
-    def files_path
-      raise 'must be defined' if exporter?
-    end
-
     def importer?
       importerexporter.is_a?(Bulkrax::Importer)
     end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -4,6 +4,10 @@ module Bulkrax
       false # @todo will be supported
     end
 
+    def validate_import
+      return true if import_fields.present?
+    end
+
     def entry_class
       self.parser_fields['metadata_format'].constantize
     end
@@ -82,11 +86,6 @@ module Bulkrax
       %w[title source_identifier]
     end
 
-    # @todo - remove/refactor after factory refactory
-    def files_path
-      Rails.root.to_s
-    end
-
     # private
 
       def real_import_file_path
@@ -139,9 +138,10 @@ module Bulkrax
       # Are the immediate sub-directories of this directory bags?
       # All or nothing
       def bags?(path)
-        result = true
+        result = nil 
         Dir.glob("#{path}/*").reject { |d| File.file?(d) }.each do |dir|
-          result = false unless bag?(dir)
+          result = bag?(dir)
+          break if result == false
         end
         result
       end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -42,6 +42,8 @@ module Bulkrax
 
     def validate_import
       raise "Missing required elements, required elements are: #{required_elements.join(', ')}" unless required_elements?(import_fields)
+      # check file_paths; this will raise an error if any files are missing
+      true if file_paths.present?
     end
 
     def create_collections
@@ -94,13 +96,6 @@ module Bulkrax
       end
     end
 
-    def files_path
-      arr = parser_fields['import_file_path'].split('/')
-      arr.pop
-      arr << 'files'
-      arr.join('/')
-    end
-
     def entry_class
       CsvEntry
     end
@@ -144,6 +139,31 @@ module Bulkrax
     # in the parser as it is specific to the format
     def setup_export_file
       File.open(File.join(importerexporter.exporter_export_path, 'export.csv'), 'w')
+    end
+
+    private 
+
+    # @todo check after latest merge, this might have changed to 'file'
+    def file_paths
+      @file_paths ||= records.map do | r | 
+        if r[:file].present?
+          r[:file].split(/\s*[:;|]\s*/).map do | f |
+            file = File.join(files_path, f)
+            if File.exist?(file)
+              file
+            else
+              raise "File #{file} does not exist"
+            end
+          end.compact.uniq
+        end
+      end.flatten.compact
+    end
+
+    def files_path
+      path = self.importerexporter.parser_fields['import_file_path'].split('/')
+      # remove the metadata filename from the end of the import path
+      path.pop
+      path.join('/')
     end
   end
 end


### PR DESCRIPTION
- Validates that files in the CSV exist at the assumed path (sub-directory called files).
- Adds this validation to parser#validate_import
- Adds similar validation to the Bagit parser