### PR TITLE
I17 browse everything

### DIFF
--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -5,8 +5,8 @@ function prepBulkrax(event) {
   var refresh_button = $('.refresh-set-source')
   var base_url = $('#importer_parser_fields_base_url')
   var initial_base_url = base_url.val()
-  var file_path = $('#importer_parser_fields_import_file_path').val()
-  handleFileToggle(file_path)
+  var file_path_value = $('#importer_parser_fields_import_file_path').val()
+  handleFileToggle(file_path_value)
 
   // handle refreshing/loading of external sets via button click
   $('body').on('click', '.refresh-set-source', function(e) {
@@ -36,29 +36,66 @@ function prepBulkrax(event) {
     handleParserKlass()
   })
   handleParserKlass()
+
+  // observer for cloud files being added
+  var form = document.getElementById('new_importer'); 
+  var config = { childList: true, attributes: true };
+  var callback = function(mutationsList) {
+    for(var mutation of mutationsList) {
+      if (mutation.type == 'childList') {
+        browseButton = document.getElementById('browse');
+        var exp = /selected_files\[[0-9*]\]\[url\]/
+        for (var node of mutation.addedNodes) {
+          if (node.attributes != undefined) {
+            var name = node.attributes.name.value
+            if (exp.test(name)) {
+              browseButton.innerHTML = 'Cloud Files Added';
+              browseButton.style.backgroundColor = 'green';
+              browseButton.after(document.createElement("br"), node.value.toString())
+            }
+          }
+        }
+      }
+    }
+  };
+  var observer = new MutationObserver (callback);
+  observer.observe (form, config);
 }
 
-<<<<<<< HEAD
 function handleFileToggle(file_path) {
-  if (file_path != undefined) {
+  if (file_path === undefined || file_path.length === 0) {
+    $('#file_path').hide()
+    $('#file_upload').hide()
+    $('#cloud').hide()
+    $('#file_path input').attr('required', null)
+    $('#file_upload input').attr('required', null)
+  } else {
     $('#file_path').show()
     $('#file_upload').hide()
+    $('#cloud').hide()
     $('#file_path input').attr('required', 'required')
     $('#file_upload input').attr('required', null)
   }
-=======
-function handleFileToggle() {
->>>>>>> csv upload complete
+
   $('#importer_parser_fields_file_style_upload_a_file').click(function(e){
     $('#file_path').hide()
     $('#file_upload').show()
+    $('#cloud').hide()
     $('#file_path input').attr('required', null)
     $('#file_upload input').attr('required', 'required')
   })
   $('#importer_parser_fields_file_style_specify_a_path_on_the_server').click(function(e){
     $('#file_path').show()
     $('#file_upload').hide()
+    $('#cloud').hide()
     $('#file_path input').attr('required', 'required')
+    $('#file_upload input').attr('required', null)
+  })
+  $('#importer_parser_fields_file_style_add_cloud_file').click(function(e){
+    $('#file_path').hide()
+    $('#file_upload').hide()
+    $('#cloud').show()
+    $('#file_path input').attr('required', null)
     $('#file_upload input').attr('required', null)
   })
 }
@@ -75,6 +112,8 @@ function handleParserKlass(){
   if(parser_klass.length > 0 && parser_klass.data('partial') && parser_klass.data('partial').length > 0 ) {
     $('.parser_fields').append(window[parser_klass.data('partial')])
   }
+  var file_path_value = $('#importer_parser_fields_import_file_path').val()
+  handleFileToggle(file_path_value)
 }
 
 function handleSourceLoad(refresh_button, base_url, external_set_select) {
@@ -99,6 +138,10 @@ function handleSourceLoad(refresh_button, base_url, external_set_select) {
     refresh_button.html(initial_button_text)
     refresh_button.attr('disabled', false)
   })
+}
+
+function handleSelectedFiles() {
+  console.log('YO!')
 }
 
 function genExternalSetOptions(selector, sets) {

--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -38,6 +38,7 @@ function prepBulkrax(event) {
   handleParserKlass()
 }
 
+<<<<<<< HEAD
 function handleFileToggle(file_path) {
   if (file_path != undefined) {
     $('#file_path').show()
@@ -45,6 +46,9 @@ function handleFileToggle(file_path) {
     $('#file_path input').attr('required', 'required')
     $('#file_upload input').attr('required', null)
   }
+=======
+function handleFileToggle() {
+>>>>>>> csv upload complete
   $('#importer_parser_fields_file_style_upload_a_file').click(function(e){
     $('#file_path').hide()
     $('#file_upload').show()

--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -38,28 +38,34 @@ function prepBulkrax(event) {
   handleParserKlass()
 
   // observer for cloud files being added
-  var form = document.getElementById('new_importer'); 
-  var config = { childList: true, attributes: true };
-  var callback = function(mutationsList) {
-    for(var mutation of mutationsList) {
-      if (mutation.type == 'childList') {
-        browseButton = document.getElementById('browse');
-        var exp = /selected_files\[[0-9*]\]\[url\]/
-        for (var node of mutation.addedNodes) {
-          if (node.attributes != undefined) {
-            var name = node.attributes.name.value
-            if (exp.test(name)) {
-              browseButton.innerHTML = 'Cloud Files Added';
-              browseButton.style.backgroundColor = 'green';
-              browseButton.after(document.createElement("br"), node.value.toString())
+  var form = document.getElementById('new_importer');
+  if (form == null) {
+    var form = document.getElementsByClassName('edit_importer')[0];
+  }
+  // only setup the observer on the new and edit importer pages
+  if (form != null) {
+    var config = { childList: true, attributes: true };
+    var callback = function(mutationsList) {
+      for(var mutation of mutationsList) {
+        if (mutation.type == 'childList') {
+          browseButton = document.getElementById('browse');
+          var exp = /selected_files\[[0-9*]\]\[url\]/
+          for (var node of mutation.addedNodes) {
+            if (node.attributes != undefined) {
+              var name = node.attributes.name.value
+              if (exp.test(name)) {
+                browseButton.innerHTML = 'Cloud Files Added';
+                browseButton.style.backgroundColor = 'green';
+                browseButton.after(document.createElement("br"), node.value.toString())
+              }
             }
           }
         }
       }
-    }
-  };
-  var observer = new MutationObserver (callback);
-  observer.observe (form, config);
+    };
+    var observer = new MutationObserver (callback);
+    observer.observe (form, config);
+  }
 }
 
 function handleFileToggle(file_path) {

--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -140,10 +140,6 @@ function handleSourceLoad(refresh_button, base_url, external_set_select) {
   })
 }
 
-function handleSelectedFiles() {
-  console.log('YO!')
-}
-
 function genExternalSetOptions(selector, sets) {
   out = '<option value="">- Select One -</option>'
 

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -64,7 +64,7 @@ module Bulkrax
     # PATCH/PUT /importers/1
     def update
       file = params[:importer][:parser_fields].delete(:file)
-      cloud_files = params.delete(:selected_files)
+      cloud_files = params[:importer].delete(:selected_files)
       field_mapping_params
       if @importer.update(importer_params)
         files_for_import(file, cloud_files)
@@ -108,31 +108,16 @@ module Bulkrax
       def files_for_import(file, cloud_files)
         return if file.blank? && cloud_files.blank?
         if file.present?
-          @importer[:parser_fields]['import_file_path'] = write_import_file(file)
+          @importer[:parser_fields]['import_file_path'] = @importer.parser.write_import_file(file)
         end
         if cloud_files.present?
-          # For BagIt, there will only be one bag, so we get the file_path back
-          # For Csv, we expect only file uploads, so we won't get the file_path back
-          target = retrieve_files(cloud_files)
+          # For BagIt, there will only be one bag, so we get the file_path back and set import_file_path
+          # For CSV, we expect only file uploads, so we won't get the file_path back
+          # and we expect the import_file_path to be set already
+          target = @importer.parser.retrieve_cloud_files(cloud_files)
           @importer[:parser_fields]['import_file_path'] = target unless target.blank?
-          retrieve_files(cloud_files)
         end
         @importer.save
-      end
-
-      def write_import_file(file)
-        path = File.join(path_for_import, file.original_filename)
-        FileUtils.mv(
-          file.path,
-          path
-        )
-        path
-      end
-
-      def path_for_import
-        path = File.join(Bulkrax.import_path, @importer.id.to_s)
-        FileUtils.mkdir_p(path) unless File.exist?(path)
-        path
       end
 
       # Use callbacks to share common setup or constraints between actions.
@@ -143,40 +128,6 @@ module Bulkrax
       # Only allow a trusted parameter "white list" through.
       def importer_params
         params.require(:importer).permit(:name, :admin_set_id, :user_id, :frequency, :parser_klass, :limit, :selected_files, field_mapping: {}, parser_fields: {})
-      end
-
-      # @todo - investigate getting directory structure
-      # @todo - investigate using perform_later, and haveing the importer check for
-      #   DownloadCloudFileJob before it starts
-      def retrieve_files(files)
-        # For CSV, write the files into a files sub-directory
-        if params[:importer][:parser_klass].downcase.include?('bagit')
-          files_path = path_for_import
-          # There should only be one zip file for Bagit, take the first
-          if files['0'].present?
-            target_file = File.join(files_path, files['0']['file_name'])
-            # Now because we want the files in place before the importer runs
-            # Problematic for a large upload
-            Bulkrax::DownloadCloudFileJob.perform_now(files['0'], target_file)
-            return target_file
-          end
-        else
-          files_path = File.join(path_for_import, 'files')  
-          FileUtils.mkdir_p(files_path) unless File.exists?(files_path)
-          files.each_pair do | key, file |
-            # this only works for uniquely named files
-            target_file = File.join(files_path, file['file_name'])
-            # Now because we want the files in place before the importer runs
-            # Problematic for a large upload
-            Bulkrax::DownloadCloudFileJob.perform_now(file, target_file)
-          end
-        end
-      end
-
-      def path_for_import
-        path = File.join(Bulkrax.import_path, @importer.id.to_s)
-        FileUtils.mkdir_p(path) unless File.exists?(path)
-        path
       end
 
       def list_external_sets

--- a/app/jobs/bulkrax/download_cloud_file_job.rb
+++ b/app/jobs/bulkrax/download_cloud_file_job.rb
@@ -1,0 +1,18 @@
+module Bulkrax
+  class DownloadCloudFileJob < ApplicationJob
+    queue_as :import
+
+    # Retrieve cloud file and write to the imports directory
+    # Note: if using the file system, the mounted directory in browse_everything MUST
+    #   be shared by web and worker servers
+
+    def perform(file, target_file)
+      retriever = BrowseEverything::Retriever.new
+      retriever.download(file, target_file) do |filename, retrieved, total|
+        # The block is still useful for showing progress, but the
+        # first argument is the filename instead of a chunk of data.
+      end
+    end
+
+  end
+end

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -12,10 +12,11 @@ module Bulkrax
     end
 
     def import(importer, only_updates_since_last_import)
-      importer.validate_import
-      importer.import_collections
-      importer.import_works(only_updates_since_last_import)
-      importer.create_parent_child_relationships
+      if importer.valid_import?
+        importer.import_collections
+        importer.import_works(only_updates_since_last_import)
+        importer.create_parent_child_relationships
+      end
     end
 
     def schedule(importer)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -53,7 +53,7 @@ module Bulkrax
       end
 
       # construct full file path
-      self.parsed_metadata['file'] = self.parsed_metadata['file'].split(/\s*[:;|]\s*/).map { |f| file_path(f) } if self.parsed_metadata['file'].present?
+      self.parsed_metadata['file'] = record['file'].split(/\s*[:;|]\s*/).map {|f| file_path(f)} if record['file'].present?
 
       add_visibility
       add_rights_statement

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -17,7 +17,7 @@ module Bulkrax
     validates :admin_set_id, presence: true
     validates :parser_klass, presence: true
 
-    delegate :validate_import, :create_parent_child_relationships, to: :parser
+    delegate :valid_import?, :create_parent_child_relationships, to: :parser
 
     attr_accessor :only_updates, :file_style, :file
     # TODO: validates :metadata_prefix, presence: true

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -52,6 +52,24 @@ module Bulkrax
       raise 'must be defined' if importer?
     end
 
+    # Optional, define if using browse everything for file upload
+    def retrieve_cloud_files(files); end
+
+    def write_import_file(file)
+      path = File.join(path_for_import, file.original_filename)
+      FileUtils.mv(
+        file.path,
+        path
+      )
+      path
+    end
+
+    def path_for_import
+      path = File.join(Bulkrax.import_path, importerexporter.id.to_s)
+      FileUtils.mkdir_p(path) unless File.exists?(path)
+      path
+    end
+
     # Optional, only used by certain parsers
     # Other parsers should override with a custom or empty method
     # Will be skipped unless the record is a Hash

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -148,7 +148,9 @@ module Bulkrax
     end
 
     # Override to add specific validations
-    def validate_import; end
+    def valid_import?
+      true
+    end
 
     def find_or_create_entry(entryclass, identifier, type, raw_metadata = nil)
       entryclass.where(

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -6,8 +6,8 @@ module Bulkrax
       false # @todo will be supported
     end
 
-    def validate_import
-      return true if import_fields.present?
+    def valid_import?
+      import_fields.present?
     end
 
     def entry_class

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -95,6 +95,19 @@ module Bulkrax
       %w[title source_identifier]
     end
 
+    # @todo - investigate getting directory structure
+    # @todo - investigate using perform_later, and having the importer check for
+    #   DownloadCloudFileJob before it starts
+    def retrieve_cloud_files(files)
+      # There should only be one zip file for Bagit, take the first
+      if files['0'].present?
+        target_file = File.join(path_for_import, files['0']['file_name'])
+        # Now because we want the files in place before the importer runs
+        Bulkrax::DownloadCloudFileJob.perform_now(files['0'], target_file)
+        return target_file
+      end
+    end
+
     # private
 
     def real_import_file_path

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -121,6 +121,22 @@ module Bulkrax
       @total = 0
     end
 
+    # @todo - investigate getting directory structure
+    # @todo - investigate using perform_later, and having the importer check for
+    #   DownloadCloudFileJob before it starts
+    def retrieve_cloud_files(files)
+      files_path = File.join(path_for_import, 'files')  
+      FileUtils.mkdir_p(files_path) unless File.exists?(files_path)
+      files.each_pair do | key, file |
+        # this only works for uniquely named files
+        target_file = File.join(files_path, file['file_name'])
+        # Now because we want the files in place before the importer runs
+        # Problematic for a large upload
+        Bulkrax::DownloadCloudFileJob.perform_now(file, target_file)
+      end
+      return nil
+    end
+
     # export methods
 
     def write_files
@@ -143,15 +159,12 @@ module Bulkrax
     # in the parser as it is specific to the format
     def setup_export_file
       File.open(File.join(importerexporter.exporter_export_path, 'export.csv'), 'w')
-    end
+    end 
 
-    private
-
-      # @todo check after latest merge, this might have changed to 'file'
-      def file_paths
-        @file_paths ||= records.map do |r|
-          next unless r[:file].present?
-          r[:file].split(/\s*[:;|]\s*/).map do |f|
+    def file_paths
+      @file_paths ||= records.map do | r | 
+        if r[:file].present?
+          r[:file].split(/\s*[:;|]\s*/).map do | f |
             file = File.join(files_path, f)
             if File.exist?(file)
               file
@@ -162,11 +175,11 @@ module Bulkrax
         end.flatten.compact
       end
 
-      def files_path
-        path = self.importerexporter.parser_fields['import_file_path'].split('/')
-        # remove the metadata filename from the end of the import path
-        path.pop
-        path.join('/')
-      end
+    def files_path
+      path = self.importerexporter.parser_fields['import_file_path'].split('/')
+      # remove the metadata filename from the end of the import path
+      path.pop
+      File.join(path.join('/'), 'files')
+    end
   end
 end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -40,10 +40,11 @@ module Bulkrax
       %w[title source_identifier]
     end
 
-    def validate_import
-      raise "Missing required elements, required elements are: #{required_elements.join(', ')}" unless required_elements?(import_fields)
-      # check file_paths; this will raise an error if any files are missing
-      true if file_paths.present?
+    def valid_import?
+      required_elements?(import_fields) && file_paths.present?
+    rescue StandardError => e
+      errors.add(:base, e.class.to_s.to_sym, message: e.message)
+      return false
     end
 
     def create_collections

--- a/app/views/bulkrax/importers/_bagit_fields.html.erb
+++ b/app/views/bulkrax/importers/_bagit_fields.html.erb
@@ -14,7 +14,6 @@
     include_blank: true,
     input_html: { class: 'form-control' }
     %>
-  <%= fi.input :import_file_path, as: :string, input_html: { value: importer.parser_fields['import_file_path'] } %>
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,
         collection: rights_statements.select_active_options,
@@ -23,4 +22,23 @@
         item_helper: rights_statements.method(:include_current_value),
         input_html: { class: 'form-control' } %>
   <%= fi.input :override_rights_statement, as: :boolean, hint: 'If checked, always use the selected rights statment. If unchecked, use rights or rights_statement from the record and only use the provided value if dc:rights is blank.', input_html: { checked: (importer.parser_fields['override_rights_statement'] == "1") } %>
+
+  <h4>Bag or Bags to Import:</h4>
+  <p>File upload and Cloud File upload must be a Zip file containing a single BagIt Bag, or a folder containing multiple BagIt Bags.</p>
+  <p>The Server Path can point to a BagIt Bag, a folder containing BagIt Bags, or a zip file containing either.</p>
+
+  <% selected = 'Specify a Path on the Server' if importer.parser_fields['import_file_path'].present? %>
+
+  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server', 'Add Cloud File'], checked: selected, as: :radio_buttons, label: false %>
+  <div id='file_upload'>
+    <%= fi.input 'file', as: :file, input_html: {accept: 'application/zip'} %><br />
+  </div>
+  <div id='file_path'>
+    <%= fi.input :import_file_path, as: :string, input_html: { value: importer.parser_fields['import_file_path'] } %>
+  </div>
+  <div id='cloud'>
+    <% if Hyrax.config.browse_everything? %>
+      <%= render 'browse_everything', form: form %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/bulkrax/importers/_browse_everything.html.erb
+++ b/app/views/bulkrax/importers/_browse_everything.html.erb
@@ -1,0 +1,12 @@
+
+<%
+	f = "#{form.lookup_action}_importer"
+	f = "#{f}_#{@importer.id}" unless @importer.new_record?
+%>
+<div id='cloud-files'> 
+	<button type="button" data-toggle="browse-everything" data-route="<%=browse_everything_engine.root_path%>"
+		data-target="#<%= f %>" class="btn btn-primary" id="browse">
+		<span class="glyphicon glyphicon-plus"></span>
+		Add Cloud Files
+	</button>
+</div>

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -20,6 +20,4 @@
   <div id='file_path'>
     <%= fi.input :import_file_path, as: :string, input_html: { value: importer.parser_fields['import_file_path'] } %>
   </div>
-
-
 </div>

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -20,4 +20,10 @@
   <div id='file_path'>
     <%= fi.input :import_file_path, as: :string, input_html: { value: importer.parser_fields['import_file_path'] } %>
   </div>
+  <% if Hyrax.config.browse_everything? %>
+	  <h4>Add Files to Import:</h4>
+	  <p>Choose files to upload. The filenames must be unique, and the filenames must be referenced in a column called 'file' in the accompanying CSV file.</p>
+    <%= render 'browse_everything', form: form %>
+  <% end %>
+  <br />
 </div>

--- a/app/views/bulkrax/importers/edit.html.erb
+++ b/app/views/bulkrax/importers/edit.html.erb
@@ -9,7 +9,7 @@
         <%= render 'form', importer: @importer, form: form %>
         <div class="panel-footer">
           <div class='pull-right'>
-            <%= render 'edit_form_buttons', form: form%>
+            <%= render 'edit_form_buttons', form: form %>
            <% cancel_path = form.object.persisted? ? importer_path(form.object) : importers_path %>
             | <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>
           </div>

--- a/spec/controllers/bulkrax/importers_controller_spec.rb
+++ b/spec/controllers/bulkrax/importers_controller_spec.rb
@@ -46,7 +46,8 @@ module Bulkrax
         name: 'Test Importer',
         admin_set_id: 'admin_set/default',
         user_id: FactoryBot.create(:user).id,
-        parser_klass: 'Bulkrax::CsvParser'
+        parser_klass: 'Bulkrax::CsvParser',
+        parser_fields: { }
       }
     end
 
@@ -122,7 +123,8 @@ module Bulkrax
           {
             name: 'Test Importer Updated',
             admin_set_id: 'admin_set/default',
-            user_id: FactoryBot.create(:user).id
+            user_id: FactoryBot.create(:user).id,
+            parser_fields: { }
           }
         end
 

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191204223857) do
+ActiveRecord::Schema.define(version: 20191212155530) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -78,6 +78,8 @@ ActiveRecord::Schema.define(version: 20191204223857) do
     t.integer "processed_collections", default: 0
     t.integer "failed_collections", default: 0
     t.integer "total_collection_entries", default: 0
+    t.integer "processed_children", default: 0
+    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 


### PR DESCRIPTION
Adds Browse Everything for file system (mount) and cloud file upload.

Features:
* For CSV, used only for the files, not the CSV itself, and so separate to to the file upload toggle
* For BagIt, as option alongside the others
* Selected files are listed, and the button turns green

Issues:
* perform_now in download job will not work for large uploads - needs a mechanism from stopping the importer from running until all downloads are done
* it is not clear how to get the directory structure of an upload, therefore we need to accept only zipped files for BagIt

<img width="900" alt="Screenshot 2019-12-11 at 14 13 55" src="https://user-images.githubusercontent.com/722117/70628730-960a2580-1c20-11ea-91b1-6956bb0a5982.png">

For Bagit - one upload / file path only

<img width="942" alt="Screenshot 2019-12-11 at 14 14 18" src="https://user-images.githubusercontent.com/722117/70628770-ac17e600-1c20-11ea-8f84-32eb7d6ff8b6.png">

