### PR TITLE
Singular properties

### DIFF
--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -6,9 +6,9 @@ module Bulkrax
   class OAIError < RuntimeError; end
   class Entry < ApplicationRecord
     include Bulkrax::HasMatchers
-    include Bulkrax::HasLocalProcessing
     include Bulkrax::ImportBehavior
     include Bulkrax::ExportBehavior
+    include Bulkrax::HasLocalProcessing
 
     belongs_to :importerexporter, polymorphic: true
     serialize :parsed_metadata, JSON

--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -30,22 +30,25 @@ module Bulkrax
       field_to(node_name).each do |name|
         next unless field_supported?(name)
         matcher = self.class.matcher(name, mapping[name].symbolize_keys) if mapping[name]
-
+        multiple = multiple?(name)
         if matcher
           result = matcher.result(self, node_content)
           if result
-            parsed_metadata[name] ||= []
-
-            if result.is_a?(Array)
-              parsed_metadata[name] += result
+            if multiple
+              parsed_metadata[name] ||= []
+              parsed_metadata[name] += Array.wrap(result)
             else
-              parsed_metadata[name] << result
+              parsed_metadata[name] = Array.wrap(result).join('; ')
             end
           end
         else
           # we didn't find a match, add by default
-          parsed_metadata[name] ||= []
-          parsed_metadata[name] << node_content.strip
+          if multiple
+            parsed_metadata[name] ||= []
+            parsed_metadata[name] << Array.wrap(node_content.strip)
+          else
+            parsed_metadata[name] = Array.wrap(node_content.strip).join('; ')
+          end
         end
       end
     end
@@ -53,6 +56,12 @@ module Bulkrax
     def field_supported?(field)
       field = field.gsub('_attributes', '')
       (factory_class.method_defined?(field) && !excluded?(field)) || field == 'file' || field == 'remote_files' || field == 'model'
+    end
+
+    def multiple?(field)
+      return true if field == 'file' || field == 'remote_files'
+      return false if field == 'model'
+      field_supported?(field) && factory_class.properties[field]['multiple']
     end
 
     # Hyrax field to use for the given import field

--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -51,6 +51,7 @@ module Bulkrax
     end
 
     def field_supported?(field)
+      field = field.gsub('_attributes', '')
       (factory_class.method_defined?(field) && !excluded?(field)) || field == 'file' || field == 'remote_files' || field == 'model'
     end
 
@@ -59,8 +60,8 @@ module Bulkrax
     # @return [Array] hyrax fields
     def field_to(field)
       fields = mapping&.map do |key, value|
-        key if (value['from']&.include?(field)) || key == field
-      end&.compact
+        key if (value.present? && value['from']&.include?(field)) || key == field
+      end.compact
       fields = nil if fields.blank?
       return fields || [field]
     end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -11,11 +11,11 @@ module Bulkrax
     end
 
     def entry_class
-      self.parser_fields['metadata_format'].constantize
+      parser_fields['metadata_format'].constantize
     end
 
     def collection_entry_class
-      self.parser_fields['metadata_format'].gsub('Entry', 'CollectionEntry').constantize
+      parser_fields['metadata_format'].gsub('Entry', 'CollectionEntry').constantize
     rescue
       Entry
     end
@@ -111,10 +111,10 @@ module Bulkrax
 
     def real_import_file_path
       if file? && zip?
-        unzip(self.parser_fields['import_file_path'])
-        return File.join(importer_unzip_path, self.parser_fields['import_file_path'].split('/').last.gsub('.zip', ''))
+        unzip(parser_fields['import_file_path'])
+        return File.join(importer_unzip_path, parser_fields['import_file_path'].split('/').last.gsub('.zip', ''))
       else
-        self.parser_fields['import_file_path']
+        parser_fields['import_file_path']
       end
     end
 
@@ -130,8 +130,8 @@ module Bulkrax
     end
 
     def metadata_file_name
-      raise 'The metadata file name must be specified' if self.parser_fields['metadata_file_name'].blank?
-      self.parser_fields['metadata_file_name']
+      raise 'The metadata file name must be specified' if parser_fields['metadata_file_name'].blank?
+      parser_fields['metadata_file_name']
     end
 
     # Gather the paths to all metadata files matching the metadata_file_name
@@ -143,12 +143,12 @@ module Bulkrax
 
     # Is this a file?
     def file?
-      File.file?(self.parser_fields['import_file_path'])
+      File.file?(parser_fields['import_file_path'])
     end
 
     # Is this a zip file?
     def zip?
-      MIME::Types.type_for(self.parser_fields['import_file_path']).include?('application/zip')
+      MIME::Types.type_for(parser_fields['import_file_path']).include?('application/zip')
     end
 
     # Is the directory is a bag?

--- a/lib/generators/bulkrax/templates/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/lib/generators/bulkrax/templates/app/models/concerns/bulkrax/has_local_processing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Bulkrax::Concerns::HasLocalProcessing
+module Bulkrax::HasLocalProcessing
   # This method is called during build_metadata
   # add any special processing here, for example to reset a metadata property
   # to add a custom property from outside of the import data

--- a/spec/models/bulkrax/entry_spec.rb
+++ b/spec/models/bulkrax/entry_spec.rb
@@ -66,6 +66,16 @@ module Bulkrax
         end
       end
 
+      context '.multiple?' do
+        it 'returns true if the field is multi-valued' do
+          expect(subject.multiple?('title')).to be_truthy
+        end
+
+        it 'returns false when field is singular' do
+          expect(subject.multiple?('owner')).to be_falsey
+        end
+      end
+
       context 'factory_class' do
         it 'returns Work' do
           expect(subject.factory_class).to eq(Work)


### PR DESCRIPTION
This PR fixes #86 whereby bulkrax assumes all properties are multi-valued and therefore the factory.run will fail if there are arrays supplied for singular properties.

Now we check the property and act accordingly in building the parsed_metadata.

Also includes a fix for the generator, which was putting the has_local_processing in the wrong place.