### PR TITLE
Replace files for an OAI re-harvest of all items

### DIFF
--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -72,8 +72,8 @@ module Bulkrax
         # OAI-only - selective re-harvest
         elsif params[:commit] == 'Update and Harvest Updated Items'
           Bulkrax::ImporterJob.perform_later(@importer.id, true)
-        # Perform a full metadata and files re-import
-        elsif params[:commit] == 'Update and Re-Import (update metadata and replace files)'
+        # Perform a full metadata and files re-import; do the same for an OAI re-harvest of all items
+        elsif params[:commit] == ('Update and Re-Import (update metadata and replace files)' || 'Update and Re-Harvest All Items')
           @importer.parser_fields['replace_files'] = true
           @importer.save
           Bulkrax::ImporterJob.perform_later(@importer.id)


### PR DESCRIPTION
We've had problems in Atla where the thumbnail were initially wrong and a re-run doesn't seem to fix it, because it's appending a second fileset, but the original 'broken' one is still set as the representative. By having a full re-harvest support replace, we will get rid of the old file_sets.