### PR TITLE
Fixes bug in valid_system_id where logic was reversed

### DIFF
--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -94,7 +94,7 @@ module Bulkrax
     end
 
     def valid_system_id(model_class)
-      return unless model_class.properties.keys.include?(Bulkrax.system_identifier_field)
+      return true if unless model_class.properties.keys.include?(Bulkrax.system_identifier_field)
       raise(
         "#{model_class} does not implement the system_identifier_field: #{Bulkrax.system_identifier_field}"
       )


### PR DESCRIPTION
`valid_system_id` should only raise an error if the class *doesn't* support the property.