### PR TITLE
matcher_class should be a class method

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -89,7 +89,7 @@ module Bulkrax
       @record ||= raw_metadata
     end
 
-    def matcher_class
+    def self.matcher_class
       Bulkrax::CsvMatcher
     end
 


### PR DESCRIPTION
Fixes a bug where the matcher_class method on CSVEntry should be a class method.