### PR TITLE
fix change_entry_last_error migration, tweak rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,10 @@ inherit_gem:
 
 # Notch8 coding conventions
 # @see https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - spec/test_app/db/schema.rb
+
 Style/RedundantReturn:
   Enabled: false
 

--- a/db/migrate/20191212155530_change_entry_last_error.rb
+++ b/db/migrate/20191212155530_change_entry_last_error.rb
@@ -1,6 +1,6 @@
 class ChangeEntryLastError < ActiveRecord::Migration[5.1]
 
-  class Bulkrax::Entry < ApplicationRecord
+  class ::Bulkrax::Entry < ApplicationRecord
   end
 
   def change

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
**This PR contains two changes:** 

1. Fixed a migration 

Was encountering a `TypeError: superclass mismatch for class Entry` when running the migrations against the test database. Judging by the fix, this appeared to be a scoping problem. 

2. Tweaked the rubocop config 

Rubocop's auto-fix command added a magic comment to the top of the test_app's database schema, but when the migrations are run against the test database, the comment gets removed automatically. So we'll just remove the comment and ignore the rule for that one  file. 