### PR TITLE
Importer index page counters improvements

### DIFF
--- a/app/jobs/bulkrax/export_work_job.rb
+++ b/app/jobs/bulkrax/export_work_job.rb
@@ -11,13 +11,16 @@ module Bulkrax
         entry.save
       rescue StandardError => e
         ExporterRun.find(args[1]).increment!(:failed_records)
+        ExporterRun.find(args[1]).decrement!(:enqueued_records)
         raise e
       else
         if entry.last_exception
           ExporterRun.find(args[1]).increment!(:failed_records)
+          ExporterRun.find(args[1]).decrement!(:enqueued_records)
           raise entry.last_exception
         else
           ExporterRun.find(args[1]).increment!(:processed_records)
+          ExporterRun.find(args[1]).decrement!(:enqueued_records)
         end
       end
     end

--- a/app/jobs/bulkrax/import_work_collection_job.rb
+++ b/app/jobs/bulkrax/import_work_collection_job.rb
@@ -10,8 +10,10 @@ module Bulkrax
         entry.build
         entry.save
         ImporterRun.find(args[1]).increment!(:processed_collections)
+        ImporterRun.find(args[1]).decrement!(:enqueued_records)
       rescue => e
         ImporterRun.find(args[1]).increment!(:failed_collections)
+        ImporterRun.find(args[1]).decrement!(:enqueued_records)
         raise e
       end
     end

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -43,7 +43,7 @@ module Bulkrax
     end
 
     def current_exporter_run
-      @current_exporter_run ||= self.exporter_runs.create!(total_work_entries: self.limit)
+      @current_exporter_run ||= self.exporter_runs.create!(total_work_entries: self.limit || parser.total)
     end
 
     def setup_export_path

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -53,7 +53,7 @@ module Bulkrax
     end
 
     def current_importer_run
-      @current_importer_run ||= self.importer_runs.create!(total_work_entries: self.limit)
+      @current_importer_run ||= self.importer_runs.create!(total_work_entries: self.limit || parser.total, total_collection_entries: parser.collections_total)
     end
 
     def seen

--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -17,13 +17,7 @@ module Bulkrax
     end
 
     def increment_counters(index)
-      current_importer_run.total_work_entries = if limit.to_i.positive?
-                                                  limit
-                                                elsif parser.total.positive?
-                                                  parser.total
-                                                else
-                                                  index + 1
-                                                end
+      current_importer_run.total_work_entries = index + 1 unless limit.to_i.positive? || parser.total.positive?
       current_importer_run.enqueued_records = index + 1
       current_importer_run.save!
     end

--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -5,7 +5,11 @@ module Bulkrax
     extend ActiveSupport::Concern
 
     def parser
-      @parser ||= self.parser_klass.constantize.new(self)
+      @parser ||= parser_class.new(self)
+    end
+
+    def parser_class
+      self.parser_klass.constantize
     end
 
     def last_imported_at

--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -20,8 +20,13 @@ module Bulkrax
       (last_imported_at || Time.current) + frequency.to_seconds if schedulable? && last_imported_at.present?
     end
 
-    def increment_counters(index)
-      current_importer_run.total_work_entries = index + 1 unless limit.to_i.positive? || parser.total.positive?
+    def increment_counters(index, collection=false)
+      # Only set the totals if they were not set on initialization
+      if collection
+        current_importer_run.total_collection_entries = index + 1 unless parser.collections_total.positive?
+      else
+        current_importer_run.total_work_entries = index + 1 unless limit.to_i.positive? || parser.total.positive?
+      end
       current_importer_run.enqueued_records = index + 1
       current_importer_run.save!
     end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -52,6 +52,7 @@ module Bulkrax
           }
           new_entry = find_or_create_entry(collection_entry_class, collection, 'Bulkrax::Importer', metadata)
           ImportWorkCollectionJob.perform_now(new_entry.id, current_importer_run.id)
+          increment_counters(index)
         end
       end
     end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -51,7 +51,7 @@ module Bulkrax
         }
         new_entry = find_or_create_entry(collection_entry_class, collection, 'Bulkrax::Importer', metadata)
         ImportWorkCollectionJob.perform_now(new_entry.id, current_importer_run.id)
-        increment_counters(index)
+        increment_counters(index, true)
       end
     end
 

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -41,19 +41,17 @@ module Bulkrax
     # If the import data also contains records for these works, they will be updated
     # during create works
     def create_collections
-      collections.each do |collection_record|
-        # split by ; |
-        collection_record.split(/\s*[;|]\s*/).each do |collection|
-          metadata = {
-            title: [collection],
-            Bulkrax.system_identifier_field => [collection],
-            visibility: 'open',
-            collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid
-          }
-          new_entry = find_or_create_entry(collection_entry_class, collection, 'Bulkrax::Importer', metadata)
-          ImportWorkCollectionJob.perform_now(new_entry.id, current_importer_run.id)
-          increment_counters(index)
-        end
+      collections.each_with_index do |collection, index|
+        next if collection.blank?
+        metadata = {
+          title: [collection],
+          Bulkrax.system_identifier_field => [collection],
+          visibility: 'open',
+          collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid
+        }
+        new_entry = find_or_create_entry(collection_entry_class, collection, 'Bulkrax::Importer', metadata)
+        ImportWorkCollectionJob.perform_now(new_entry.id, current_importer_run.id)
+        increment_counters(index)
       end
     end
 
@@ -72,7 +70,7 @@ module Bulkrax
     end
 
     def collections
-      records.map { |record| record[:collection] }.flatten.compact.uniq
+      records.map { |r| r[:collection].split(/\s*[;|]\s*/) unless r[:collection].blank? }.flatten.compact.uniq
     end
 
     def collections_total

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -58,7 +58,7 @@ module Bulkrax
         }
         new_entry = find_or_create_entry(collection_entry_class, collection, 'Bulkrax::Importer', metadata)
         ImportWorkCollectionJob.perform_now(new_entry.id, current_importer_run.id)
-        increment_counters(index)
+        increment_counters(index, true))
       end
     end
 

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -73,7 +73,7 @@ module Bulkrax
         collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid
       }
 
-      list_sets.each do |set|
+      list_sets.each_with_index do | set, index |
         next unless collection_name == 'all' || collection_name == set.spec
         unique_collection_identifier = importerexporter.unique_collection_identifier(set.spec)
         metadata[:title] = [set.name]

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -82,7 +82,7 @@ module Bulkrax
         new_entry = collection_entry_class.where(importerexporter: importerexporter, identifier: unique_collection_identifier, raw_metadata: metadata).first_or_create!
         # perform now to ensure this gets created before work imports start
         ImportWorkCollectionJob.perform_now(new_entry.id, importerexporter.current_importer_run.id)
-        increment_counters(index)
+        increment_counters(index, true))
       end
     end
 

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -82,6 +82,7 @@ module Bulkrax
         new_entry = collection_entry_class.where(importerexporter: importerexporter, identifier: unique_collection_identifier, raw_metadata: metadata).first_or_create!
         # perform now to ensure this gets created before work imports start
         ImportWorkCollectionJob.perform_now(new_entry.id, importerexporter.current_importer_run.id)
+        increment_counters(index)
       end
     end
 
@@ -98,7 +99,7 @@ module Bulkrax
             seen[record.identifier] = true
             new_entry = entry_class.where(importerexporter: self.importerexporter, identifier: record.identifier).first_or_create!
             ImportWorkJob.perform_later(new_entry.id, importerexporter.current_importer_run.id)
-            importerexporter.increment_counters(index)
+            increment_counters(index)
           end
         end
       end

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -73,7 +73,7 @@ module Bulkrax
         collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid
       }
 
-      list_sets.each_with_index do | set, index |
+      collections.each_with_index do | set, index |
         next unless collection_name == 'all' || collection_name == set.spec
         unique_collection_identifier = importerexporter.unique_collection_identifier(set.spec)
         metadata[:title] = [set.name]
@@ -102,6 +102,18 @@ module Bulkrax
             increment_counters(index)
           end
         end
+      end
+    end
+
+    def collections
+      @collections ||= list_sets
+    end
+
+    def collections_total
+      if collection_name == 'all' 
+        collections.count
+      else
+        1
       end
     end
 

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -34,8 +34,8 @@
               <td><%= importer.last_imported_at.strftime("%b %d, %Y") if importer.last_imported_at %></td>
               <td><%= importer.next_import_at.strftime("%b %d, %Y") if importer.next_import_at %></td>
               <td><%= importer.importer_runs.last&.enqueued_records %></td>
-              <td><%= importer.importer_runs.last&.processed_records %></td>
-              <td><%= importer.importer_runs.last&.failed_records %></td>
+              <td><%= (importer.importer_runs.last&.processed_collections || 0) + (importer.importer_runs.last&.processed_records || 0)  %></td>
+              <td><%= (importer.importer_runs.last&.failed_collections || 0) + (importer.importer_runs.last&.failed_records || 0)  %></td>
               <td><%= importer.importer_runs.last&.deleted_records %></td>
               <td><%= importer.importer_runs.last&.total_collection_entries %></td>
               <td><%= importer.importer_runs.last&.total_work_entries %></td>

--- a/spec/fixtures/csv/good.csv
+++ b/spec/fixtures/csv/good.csv
@@ -1,3 +1,3 @@
-source_identifier,title,
-1,Lovely Title
-2,Another Title
+source_identifier,title,collection
+1,Lovely Title,A Collection;Another Collection,
+2,Another Title,A Collection,

--- a/spec/jobs/bulkrax/export_work_job_spec.rb
+++ b/spec/jobs/bulkrax/export_work_job_spec.rb
@@ -17,8 +17,9 @@ module Bulkrax
       before do
         allow(entry).to receive(:save).and_return(true)
       end
-      it 'increments :processed_records' do
+      it 'increments :processed_records and decrements enqueued record' do
         expect(exporter_run).to receive(:increment!).with(:processed_records)
+        expect(exporter_run).to receive(:decrement!).with(:enqueued_records)
         subject.perform(1, 1)
       end
     end

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -22,11 +22,12 @@ module Bulkrax
       end
     end
 
-    describe 'unsuccessful job' do
+    describe 'failed job' do
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv_bad) }
 
-      it 'raises an error with an invalid import' do
-        expect { subject.perform(1) }.to raise_error(RuntimeError, 'Missing required elements, required elements are: title, source_identifier')
+      it 'returns for an invalid import' do
+        expect(importer).not_to receive(:import_collections)
+        expect(importer).not_to receive(:import_works)
       end
     end
 

--- a/spec/models/bulkrax/importer_spec.rb
+++ b/spec/models/bulkrax/importer_spec.rb
@@ -21,9 +21,14 @@ module Bulkrax
     end
 
     describe 'importer run' do
+      before do
+        allow_any_instance_of(Bulkrax::OaiDcParser).to receive(:collections_total).and_return(1)
+      end
+
       it 'creates an ImporterRun with total_work_entries set to the value of limit' do
         importer.current_importer_run
         expect(importer.current_importer_run.total_work_entries).to eq(10)
+        expect(importer.current_importer_run.total_collection_entries).to eq(1)
       end
     end
 
@@ -69,6 +74,7 @@ module Bulkrax
 
         it 'creates a default mapping from the column headers' do
           expect(importer.mapping).to eq(
+            "collection" => {"excluded"=>false, "from"=>["collection"], "if"=>nil, "parsed"=>false, "split"=>false},
             "source_identifier" => { "excluded" => false, "from" => ["source_identifier"], "if" => nil, "parsed" => false, "split" => false },
             "title" => { "excluded" => false, "from" => ["title"], "if" => nil, "parsed" => false, "split" => false }
           )

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -57,6 +57,11 @@ module Bulkrax
           expect(subject).to receive(:increment_counters).twice
           subject.create_works
         end
+
+        it 'counts the correct number of works and collections' do
+          expect(subject.total).to eq(2)
+          expect(subject.collections_total).to eq(2)
+        end
       end
     end
 


### PR DESCRIPTION
This PR does the following ensures that both collections and works are counted in the enqueued, processed and failed columns. It also adds the total collections to the `current_importer_run.create!` call and streamlines `increment_counters`.