### PR TITLE
Create and Validate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/test_app/log/*.log
 spec/test_app/tmp/
 coverage/**
 .byebug_history
+tmp/**

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -118,7 +118,7 @@ module Bulkrax
         files_for_import(file, cloud_files) unless file.nil? && cloud_files.nil?
         # do not perform the import
         if params[:commit] == 'Update Importer'
-          # do nothing
+        # do nothing
         # OAI-only - selective re-harvest
         elsif params[:commit] == 'Update and Harvest Updated Items'
           Bulkrax::ImporterJob.perform_later(@importer.id, true)
@@ -131,7 +131,11 @@ module Bulkrax
         else
           Bulkrax::ImporterJob.perform_later(@importer.id)
         end
+<<<<<<< HEAD
         
+=======
+
+>>>>>>> 4eacfc4... rudimentary controller spec
         if api_request?
           json_response('updated', :ok, 'Importer was successfully updated.')
         else

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -82,14 +82,13 @@ module Bulkrax
         files_for_import(file, cloud_files)
         if params[:commit] == 'Create and Import'
           Bulkrax::ImporterJob.perform_later(@importer.id)
-          if api_request?
-            json_response('create', :created, 'Importer was successfully created.')
-          else
-            redirect_to importers_path, notice: 'Importer was successfully created.'
-          end
         elsif params[:commit] == 'Create and Validate'
           Bulkrax::ImporterJob.perform_now(@importer.id)
-          redirect_to importer_path(@importer), notice: 'Importer was successfully validated.'
+        end
+        if api_request?
+          json_response('create', :created, 'Importer was successfully created.')
+        else
+          redirect_to importers_path, notice: 'Importer was successfully created.'
         end
       else
         if api_request?
@@ -98,6 +97,7 @@ module Bulkrax
           render :new
         end
       end
+
       # rubocop:enable Style/IfInsideElse
     end
 
@@ -131,6 +131,7 @@ module Bulkrax
         else
           Bulkrax::ImporterJob.perform_later(@importer.id)
         end
+        
         if api_request?
           json_response('updated', :ok, 'Importer was successfully updated.')
         else

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -80,11 +80,7 @@ module Bulkrax
       @importer.validate_only = true if params[:commit] == 'Create and Validate'
       if @importer.save
         files_for_import(file, cloud_files)
-        if params[:commit] == 'Create and Import'
-          Bulkrax::ImporterJob.perform_later(@importer.id)
-        elsif params[:commit] == 'Create and Validate'
-          Bulkrax::ImporterJob.perform_now(@importer.id)
-        end
+        Bulkrax::ImporterJob.send(@importer.parser.perform_method, @importer.id)
         if api_request?
           json_response('create', :created, 'Importer was successfully created.')
         else
@@ -131,11 +127,6 @@ module Bulkrax
         else
           Bulkrax::ImporterJob.perform_later(@importer.id)
         end
-<<<<<<< HEAD
-        
-=======
-
->>>>>>> 4eacfc4... rudimentary controller spec
         if api_request?
           json_response('updated', :ok, 'Importer was successfully updated.')
         else

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -79,11 +79,19 @@ module Bulkrax
       field_mapping_params
       if @importer.save
         files_for_import(file, cloud_files)
-        Bulkrax::ImporterJob.perform_later(@importer.id) if params[:commit] == 'Create and Import'
-        if api_request?
-          json_response('create', :created, 'Importer was successfully created.')
-        else
-          redirect_to importers_path, notice: 'Importer was successfully created.'
+        if params[:commit] == 'Create and Import'
+          Bulkrax::ImporterJob.perform_later(@importer.id)
+          if api_request?
+            json_response('create', :created, 'Importer was successfully created.')
+          else
+            redirect_to importers_path, notice: 'Importer was successfully created.'
+          end
+        elsif params[:commit] == 'Create and Validate'
+          validate_only = true
+          Bulkrax::ImporterJob.perform_now(@importer.id)
+          redirect_to importers_path, notice: 'Importer was successfully validated.'
+          # call the Job from 56
+          # route to importers_path showpage
         end
       else
         if api_request?

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -115,10 +115,10 @@ module Bulkrax
       end
 
       if @importer.update(importer_params)
-        files_for_import(file, cloud_files)
+        files_for_import(file, cloud_files) unless file.nil? && cloud_files.nil?
         # do not perform the import
         if params[:commit] == 'Update Importer'
-        # do nothing
+          # do nothing
         # OAI-only - selective re-harvest
         elsif params[:commit] == 'Update and Harvest Updated Items'
           Bulkrax::ImporterJob.perform_later(@importer.id, true)

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -107,10 +107,12 @@ module Bulkrax
       if api_request?
         return return_json_response unless valid_update_params?
       end
-
-      file = params[:importer][:parser_fields].delete(:file)
-      cloud_files = params[:importer].delete(:selected_files)
-      field_mapping_params
+      # skipped for calls from continue
+      if params[:importer][:parser_fields].present?
+        file = params[:importer][:parser_fields].delete(:file)
+        cloud_files = params[:importer].delete(:selected_files)
+        field_mapping_params
+      end
 
       if @importer.update(importer_params)
         files_for_import(file, cloud_files)
@@ -153,6 +155,14 @@ module Bulkrax
       else
         redirect_to importers_url, notice: 'Importer was successfully destroyed.'
       end
+    end
+
+    # PUT /importers/1
+    def continue
+      @importer = Importer.find(params[:importer_id])
+      params[:importer] = { name: @importer.name }
+      @importer.validate_only = false
+      update
     end
 
     # GET /importer/1/upload_corrected_entries
@@ -216,7 +226,18 @@ module Bulkrax
 
       # Only allow a trusted parameter "white list" through.
       def importer_params
-        params.require(:importer).permit(:name, :admin_set_id, :user_id, :frequency, :parser_klass, :limit, :selected_files, field_mapping: {}, parser_fields: {})
+        params.require(:importer).permit(
+          :name,
+          :admin_set_id,
+          :user_id,
+          :frequency,
+          :parser_klass,
+          :limit,
+          :validate_only,
+          :selected_files,
+          field_mapping: {},
+          parser_fields: {}
+        )
       end
 
       def list_external_sets
@@ -244,9 +265,7 @@ module Bulkrax
 
       def setup_client(url)
         return false if url.nil?
-
         headers = { from: Bulkrax.server_name }
-
         @client ||= OAI::Client.new(url, headers: headers, parser: 'libxml', metadata_prefix: 'oai_dc')
       end
 

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -106,9 +106,6 @@ module Bulkrax
       cloud_files = params[:importer].delete(:selected_files)
       field_mapping_params
 
-      Rails.logger.info('HELLO')
-      Rails.logger.info(importer_params)
-
       if @importer.update(importer_params)
         files_for_import(file, cloud_files)
         # do not perform the import

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -77,6 +77,7 @@ module Bulkrax
       cloud_files = params.delete(:selected_files)
       @importer = Importer.new(importer_params)
       field_mapping_params
+      @importer.validate_only = true if params[:commit] == 'Create and Validate'
       if @importer.save
         files_for_import(file, cloud_files)
         if params[:commit] == 'Create and Import'
@@ -87,11 +88,8 @@ module Bulkrax
             redirect_to importers_path, notice: 'Importer was successfully created.'
           end
         elsif params[:commit] == 'Create and Validate'
-          validate_only = true
           Bulkrax::ImporterJob.perform_now(@importer.id)
-          redirect_to importers_path, notice: 'Importer was successfully validated.'
-          # call the Job from 56
-          # route to importers_path showpage
+          redirect_to importer_path(@importer), notice: 'Importer was successfully validated.'
         end
       else
         if api_request?

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -15,7 +15,7 @@ module Bulkrax
       return unless importer.valid_import?
       importer.import_collections
       importer.import_works(only_updates_since_last_import)
-      importer.create_parent_child_relationships
+      importer.create_parent_child_relationships unless importer.validate_only
     end
 
     def schedule(importer)

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -4,7 +4,7 @@ module Bulkrax
   class ImporterJob < ApplicationJob
     queue_as :import
 
-    def perform(importer_id, only_updates_since_last_import = false)
+    def perform(importer_id, only_updates_since_last_import = false, validate_only = false)
       importer = Importer.find(importer_id)
 
       import(importer, only_updates_since_last_import)

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -4,7 +4,7 @@ module Bulkrax
   class ImporterJob < ApplicationJob
     queue_as :import
 
-    def perform(importer_id, only_updates_since_last_import = false, validate_only = false)
+    def perform(importer_id, only_updates_since_last_import = false)
       importer = Importer.find(importer_id)
 
       import(importer, only_updates_since_last_import)

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
 module Bulkrax
+  # Import Behavior for Entry classes
   module ImportBehavior
     extend ActiveSupport::Concern
 
     def build_for_importer
       begin
         build_metadata
-        # if !validate_only
+        unless self.importerexporter.validate_only
           raise CollectionsCreatedError unless collections_created?
           @item = factory.run
-        # end
+        end
       rescue RSolr::Error::Http, CollectionsCreatedError => e
         raise e
       rescue StandardError => e
@@ -25,9 +26,9 @@ module Bulkrax
       self.collection_ids
     end
 
-    # override this to ensure any collections have been created before building the work
+    # override this in a sub-class of Entry to ensure any collections have been created before building the work
     def collections_created?
-      false
+      true
     end
 
     def build_metadata

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -7,8 +7,10 @@ module Bulkrax
     def build_for_importer
       begin
         build_metadata
-        raise CollectionsCreatedError unless collections_created?
-        @item = factory.run
+        # if !validate_only
+          raise CollectionsCreatedError unless collections_created?
+          @item = factory.run
+        # end
       rescue RSolr::Error::Http, CollectionsCreatedError => e
         raise e
       rescue StandardError => e
@@ -25,7 +27,7 @@ module Bulkrax
 
     # override this to ensure any collections have been created before building the work
     def collections_created?
-      true
+      false
     end
 
     def build_metadata

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -5,7 +5,7 @@ module Bulkrax
     attr_accessor :importerexporter
     delegate :only_updates, :limit, :current_exporter_run, :current_importer_run, :errors,
              :seen, :increment_counters, :parser_fields, :user,
-             :exporter_export_path, :exporter_export_zip_path, :importer_unzip_path,
+             :exporter_export_path, :exporter_export_zip_path, :importer_unzip_path, :validate_only,
              to: :importerexporter
 
     def self.parser_fields

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -39,6 +39,14 @@ module Bulkrax
       raise 'must be defined'
     end
 
+    def perform_method
+      if self.validate_only
+        'perform_now'
+      else
+        'perform_later'
+      end
+    end
+
     def import_file_path
       @import_file_path ||= self.parser_fields['import_file_path']
     end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -62,7 +62,7 @@ module Bulkrax
 
         seen[record[:source_identifier]] = true
         new_entry = find_or_create_entry(entry_class, record[:source_identifier], 'Bulkrax::Importer', record)
-        ImportWorkJob.perform_later(new_entry.id, current_importer_run.id)
+        ImportWorkJob.send(perform_method, new_entry.id, current_importer_run.id)
         increment_counters(index)
       end
     rescue StandardError => e

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -71,7 +71,7 @@ module Bulkrax
 
         seen[record[:source_identifier]] = true
         new_entry = find_or_create_entry(entry_class, record[:source_identifier], 'Bulkrax::Importer', record.to_h.compact)
-        ImportWorkJob.perform_later(new_entry.id, current_importer_run.id)
+        ImportWorkJob.send(perform_method, new_entry.id, current_importer_run.id)
         increment_counters(index)
       end
     rescue StandardError => e

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -91,7 +91,7 @@ module Bulkrax
         else
           seen[record.identifier] = true
           new_entry = entry_class.where(importerexporter: self.importerexporter, identifier: record.identifier).first_or_create!
-          ImportWorkJob.perform_later(new_entry.id, importerexporter.current_importer_run.id)
+          ImportWorkJob.send(perform_method, new_entry.id, importerexporter.current_importer_run.id)
           increment_counters(index)
         end
       end

--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -62,7 +62,8 @@
     </p>
 
     <p>
-      <% if @entry.last_succeeded_at != nil %>
+      <% factory_record = @entry.factory.find %>
+      <% if @entry.last_succeeded_at != nil && factory_record.present? %>
         <strong><%= @entry.factory_class.to_s %> Link:</strong>
         <% if @entry.factory_class.to_s == "Collection" %>
           <%= link_to @entry.factory_class.to_s, hyrax.polymorphic_path(@entry.factory.find) %>

--- a/app/views/bulkrax/importers/new.html.erb
+++ b/app/views/bulkrax/importers/new.html.erb
@@ -9,6 +9,7 @@
         <%= render 'form', importer: @importer, form: form %>
         <div class="panel-footer">
           <div class='pull-right'>
+            <%= form.button :submit, value: 'Create and Validate', class: 'btn btn-primary' %>
            <%= form.button :submit, value: 'Create and Import', class: 'btn btn-primary' %>
             | <%= form.button :submit, value: 'Create', class: 'btn btn-primary' %>
             <% cancel_path = form.object.persisted? ? importer_path(form.object) : importers_path %>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -152,7 +152,7 @@
 
     <% if @importer.validate_only == true %>
         <div class='pull-left'>
-          <%= button_to 'Continue', @importer, method: :update, class: 'btn btn-primary' %>
+          <%= button_to 'Continue', importer_continue_path(@importer), method: :put, class: 'btn btn-primary' %>
         </div>
         <div class='pull-right'>
           <%= button_to 'Discard', @importer, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-primary' %>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -148,7 +148,16 @@
     <%= paginate(@work_entries, param_name: :work_entries_page) %>
     <br />
     <%= link_to 'Edit', edit_importer_path(@importer) %> |
-    <%= link_to 'Back', importers_path %>
+    <%= link_to 'Back', importers_path %><br /><br />
+
+    <% if @importer.validate_only == true %>
+        <div class='pull-left'>
+          <%= button_to 'Continue', @importer, method: :update, class: 'btn btn-primary' %>
+        </div>
+        <div class='pull-right'>
+          <%= button_to 'Discard', @importer, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-primary' %>
+        </div>
+    <% end %>
 
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Bulkrax::Engine.routes.draw do
     get :download
   end
   resources :importers do
+    put :continue
     get :export_errors
     collection do
       post :external_sets

--- a/db/migrate/20200108194557_add_validate_only_to_bulkrax_importers.rb
+++ b/db/migrate/20200108194557_add_validate_only_to_bulkrax_importers.rb
@@ -1,0 +1,5 @@
+class AddValidateOnlyToBulkraxImporters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bulkrax_importers, :validate_only, :boolean
+  end
+end

--- a/spec/controllers/bulkrax/importers_controller_spec.rb
+++ b/spec/controllers/bulkrax/importers_controller_spec.rb
@@ -173,18 +173,29 @@ module Bulkrax
           validate_only: false
         }
       end
+<<<<<<< HEAD
       
       it 'sets validate_only to false' do
         put :continue, params: { importer_id: importer.to_param, }, session: valid_session
+=======
+
+      it 'sets validate_only to false' do
+        put :continue, params: { importer_id: importer.to_param }, session: valid_session
+>>>>>>> 4eacfc4... rudimentary controller spec
         importer.reload
         expect(importer.validate_only).to eq(false)
       end
 
       it 'calls update' do
         expect(controller).to receive(:update)
+<<<<<<< HEAD
         put :continue, params: { importer_id: importer.to_param, }, session: valid_session
       end
 
+=======
+        put :continue, params: { importer_id: importer.to_param }, session: valid_session
+      end
+>>>>>>> 4eacfc4... rudimentary controller spec
     end
 
     describe 'DELETE #destroy' do

--- a/spec/controllers/bulkrax/importers_controller_spec.rb
+++ b/spec/controllers/bulkrax/importers_controller_spec.rb
@@ -173,29 +173,17 @@ module Bulkrax
           validate_only: false
         }
       end
-<<<<<<< HEAD
-      
-      it 'sets validate_only to false' do
-        put :continue, params: { importer_id: importer.to_param, }, session: valid_session
-=======
 
       it 'sets validate_only to false' do
         put :continue, params: { importer_id: importer.to_param }, session: valid_session
->>>>>>> 4eacfc4... rudimentary controller spec
         importer.reload
         expect(importer.validate_only).to eq(false)
       end
 
       it 'calls update' do
         expect(controller).to receive(:update)
-<<<<<<< HEAD
-        put :continue, params: { importer_id: importer.to_param, }, session: valid_session
-      end
-
-=======
         put :continue, params: { importer_id: importer.to_param }, session: valid_session
       end
->>>>>>> 4eacfc4... rudimentary controller spec
     end
 
     describe 'DELETE #destroy' do

--- a/spec/models/bulkrax/rdf_entry_spec.rb
+++ b/spec/models/bulkrax/rdf_entry_spec.rb
@@ -56,7 +56,7 @@ module Bulkrax
           subject.raw_metadata = raw_metadata
           subject.identifier = "http://example.org/ns/19158"
           allow_any_instance_of(ObjectFactory).to receive(:run).and_return(instance_of(Work))
-          allow_any_instance_of(User).to receive(:batch_user)
+          allow(User).to receive(:batch_user)
         end
 
         it 'succeeds' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -72,7 +72,7 @@ module Bulkrax
 
       it 'returns the path of the partial import file' do
         expect(subject.write_partial_import_file(file))
-          .to eq('tmp/imports/1/failed_corrected_entries.csv')
+          .to eq("tmp/imports/#{importer.id}/failed_corrected_entries.csv")
       end
 
       it 'moves the partial import file to the correct path' do

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191212155530) do
+ActiveRecord::Schema.define(version: 20200108194557) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20191212155530) do
     t.text "field_mapping"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "validate_only"
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"
   end
 


### PR DESCRIPTION
Add a 'Create and Validate' feature that validates the importer before importing the data. 

This now:
* creates the importer and entries but not the works themselves
* offers discard and continue, discard deletes the importer and entries, discard re-runs it with work creation re-enabled

It is light on specs. I've added basic specs to the controller.