### PR TITLE
ignore Collection entries in errored_entries flow

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -182,7 +182,7 @@ module Bulkrax
     # errored entries methods
 
     def write_errored_entries_file
-      @errored_entries ||= importerexporter.entries.where.not(last_error: [nil, {}, ''])
+      @errored_entries ||= importerexporter.entries.where.not(last_error: [nil, {}, ''], type: 'Bulkrax::CsvCollectionEntry')
       return unless @errored_entries.present?
 
       file = setup_errored_entries_file

--- a/spec/factories/bulkrax_entries.rb
+++ b/spec/factories/bulkrax_entries.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
 
   factory :bulkrax_csv_entry_collection, class: 'Bulkrax::CsvEntry' do
     identifier { "entry_collection" }
-    type { 'Bulkrax::CsvEntry' }
+    type { 'Bulkrax::CsvCollectionEntry' }
     importerexporter { FactoryBot.build(:bulkrax_importer) }
     raw_metadata { {} }
     parsed_metadata { {} }


### PR DESCRIPTION
Ignore entries with type `Bulkrax::CsvCollectionEntry` in `Bulkrax::CsvParser#write_errored_entries_file` 

Addendum to #125 