### PR TITLE
i43 upload corrected entries - processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ spec/test_app/db/*.sqlite3-journal
 spec/test_app/log/*.log
 spec/test_app/tmp/
 coverage/**
+.byebug_history

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -109,12 +109,13 @@ module Bulkrax
     def upload_corrected_entries_file
       file = params[:importer][:parser_fields].delete(:file)
       @importer = Importer.find(params[:importer_id])
-      if @importer.save && file.present?
-        @importer[:parser_fields]['partial_import_file_path'] = @importer.parser.write_import_file(file) if file.present?
+      if file.present?
+        @importer[:parser_fields]['partial_import_file_path'] = @importer.parser.write_partial_import_file(file)
         @importer.save
-        redirect_to importer_path(@importer), notice: 'Corrected entries uploaded successfully'
+        Bulkrax::ImporterJob.perform_later(@importer.id, true)
+        redirect_to importer_path(@importer), notice: 'Corrected entries uploaded successfully.'
       else
-        redirect_to importer_upload_corrected_entries_path(@importer), alert: 'Importer failed to update with new file'
+        redirect_to importer_upload_corrected_entries_path(@importer), alert: 'Importer failed to update with new file.'
       end
     end
 

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -163,13 +163,14 @@ module Bulkrax
     end
 
     def find_or_create_entry(entryclass, identifier, type, raw_metadata = nil)
-      entryclass.where(
+      entry = entryclass.where(
         importerexporter_id: importerexporter.id,
         importerexporter_type: type,
         identifier: identifier
-      ).first_or_create! do |e|
-        e.raw_metadata = raw_metadata
-      end
+      ).first_or_create!
+      entry.raw_metadata = raw_metadata
+      entry.save!
+      entry
     end
 
     # @todo - review this method

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -63,6 +63,18 @@ module Bulkrax
       path
     end
 
+    def write_partial_import_file(file)
+      path = File.join(path_for_import, file.original_filename)
+      initial_filename = path.split('/').last
+      filename = "#{File.basename(path, '.csv')}_corrected_entries.csv"
+      mv_path = File.join(path_for_import, filename)
+      FileUtils.mv(
+        file.path,
+        mv_path
+      )
+      mv_path
+    end
+
     def path_for_import
       path = File.join(Bulkrax.import_path, importerexporter.id.to_s)
       FileUtils.mkdir_p(path) unless File.exist?(path)

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -64,15 +64,15 @@ module Bulkrax
     end
 
     def write_partial_import_file(file)
-      path = File.join(path_for_import, file.original_filename)
-      initial_filename = path.split('/').last
-      filename = "#{File.basename(path, '.csv')}_corrected_entries.csv"
-      mv_path = File.join(path_for_import, filename)
+      import_filename = import_file_path.split('/').last
+      partial_import_filename = "#{File.basename(import_filename, '.csv')}_corrected_entries.csv"
+
+      path = File.join(path_for_import, partial_import_filename)
       FileUtils.mv(
         file.path,
-        mv_path
+        path
       )
-      mv_path
+      path
     end
 
     def path_for_import

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -63,18 +63,6 @@ module Bulkrax
       path
     end
 
-    def write_partial_import_file(file)
-      import_filename = import_file_path.split('/').last
-      partial_import_filename = "#{File.basename(import_filename, '.csv')}_corrected_entries.csv"
-
-      path = File.join(path_for_import, partial_import_filename)
-      FileUtils.mv(
-        file.path,
-        path
-      )
-      path
-    end
-
     def path_for_import
       path = File.join(Bulkrax.import_path, importerexporter.id.to_s)
       FileUtils.mkdir_p(path) unless File.exist?(path)

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -25,7 +25,7 @@ module Bulkrax
 
     def records(_opts = {})
       file_for_import = only_updates ? parser_fields['partial_import_file_path'] : parser_fields['import_file_path']
-      @records ||= entry_class.read_data(file_for_import).map { |record_data| entry_class.data_for_entry(record_data) }
+      entry_class.read_data(file_for_import).map { |record_data| entry_class.data_for_entry(record_data) }
     end
 
     # We could use CsvEntry#fields_from_data(data) but that would mean re-reading the data
@@ -70,8 +70,7 @@ module Bulkrax
         break if !limit.nil? && index >= limit
 
         seen[record[:source_identifier]] = true
-        # new_entry = find_or_create_entry(entry_class, record[:source_identifier], 'Bulkrax::Importer', record.to_h.compact)
-        new_entry = entry_class.where(importerexporter: self.importerexporter, importerexporter_type: 'Bulkrax::Importer', identifier: record[:source_identifier]).first_or_create!
+        new_entry = find_or_create_entry(entry_class, record[:source_identifier], 'Bulkrax::Importer', record.to_h.compact)
         ImportWorkJob.perform_later(new_entry.id, current_importer_run.id)
         increment_counters(index)
       end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -78,6 +78,18 @@ module Bulkrax
       errors.add(:base, e.class.to_s.to_sym, message: e.message)
     end
 
+    def write_partial_import_file(file)
+      import_filename = import_file_path.split('/').last
+      partial_import_filename = "#{File.basename(import_filename, '.csv')}_corrected_entries.csv"
+
+      path = File.join(path_for_import, partial_import_filename)
+      FileUtils.mv(
+        file.path,
+        path
+      )
+      path
+    end
+
     def create_parent_child_relationships
       super
     end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -24,7 +24,8 @@ module Bulkrax
     end
 
     def records(_opts = {})
-      @records ||= entry_class.read_data(parser_fields['import_file_path']).map { |record_data| entry_class.data_for_entry(record_data) }
+      file_for_import = only_updates ? parser_fields['partial_import_file_path'] : parser_fields['import_file_path']
+      @records ||= entry_class.read_data(file_for_import).map { |record_data| entry_class.data_for_entry(record_data) }
     end
 
     # We could use CsvEntry#fields_from_data(data) but that would mean re-reading the data
@@ -69,7 +70,8 @@ module Bulkrax
         break if !limit.nil? && index >= limit
 
         seen[record[:source_identifier]] = true
-        new_entry = find_or_create_entry(entry_class, record[:source_identifier], 'Bulkrax::Importer', record.to_h.compact)
+        # new_entry = find_or_create_entry(entry_class, record[:source_identifier], 'Bulkrax::Importer', record.to_h.compact)
+        new_entry = entry_class.where(importerexporter: self.importerexporter, importerexporter_type: 'Bulkrax::Importer', identifier: record[:source_identifier]).first_or_create!
         ImportWorkJob.perform_later(new_entry.id, current_importer_run.id)
         increment_counters(index)
       end

--- a/app/views/bulkrax/importers/upload_corrected_entries.html.erb
+++ b/app/views/bulkrax/importers/upload_corrected_entries.html.erb
@@ -5,7 +5,11 @@
 <div class="panel panel-default">
   <div class="panel-body">
 
-    <p>Upload only the corrected works for the <b><%= @importer.name %></b> importer. Only CSV files are allowed.</p>
+    <p>
+    Upload <b>only</b> the corrected entries for the <b><%= @importer.name %></b> importer. To export failed entries for correction,
+    <%= link_to "click here <span class='glyphicon glyphicon-download-alt'></span>".html_safe, importer_export_errors_path(@importer.id) %>
+    </p>
+    <p>Only CSV files are allowed.</p>
 
     <%= simple_form_for @importer, url: importer_upload_corrected_entries_file_path, method: :post, html: { multipart: true } do |f| %>
       <%= f.fields_for :parser_fields do |fi| %>

--- a/app/views/bulkrax/importers/upload_corrected_entries.html.erb
+++ b/app/views/bulkrax/importers/upload_corrected_entries.html.erb
@@ -1,23 +1,24 @@
-<div class="col-xs-12 main-header">
-  <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Upload Corrected Entries: <%= @importer.name %></h1>
+<div class='col-xs-12 main-header'>
+  <h1><span class='fa fa-cloud-upload' aria-hidden='true'></span> Upload Corrected Entries: <%= @importer.name %></h1>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-body">
-
+<div class='panel panel-default'>
+  <div class='panel-body'>
     <p>
     Upload <b>only</b> the corrected entries for the <b><%= @importer.name %></b> importer. To export failed entries for correction,
-    <%= link_to "click here <span class='glyphicon glyphicon-download-alt'></span>".html_safe, importer_export_errors_path(@importer.id) %>
+    <%= link_to importer_export_errors_path(@importer.id) do %>
+      click here <span class='glyphicon glyphicon-download-alt'></span>
+    <% end %>
     </p>
     <p>Only CSV files are allowed.</p>
 
     <%= simple_form_for @importer, url: importer_upload_corrected_entries_file_path, method: :post, html: { multipart: true } do |f| %>
       <%= f.fields_for :parser_fields do |fi| %>
         <div class='parser_fields'>
-          <div class="fileupload-buttonbar hide-required-tag">
+          <div class='fileupload-buttonbar hide-required-tag'>
             <%= fi.input 'file',
               as: :file,
-              label: raw("<span class='glyphicon glyphicon-plus'></span><span> Add file...</span>"),
+              label: "<span class='glyphicon glyphicon-plus'></span><span> Add file...</span>".html_safe,
               label_html: {
                 class: 'btn btn-success'
               },
@@ -28,7 +29,7 @@
           </div>
         </div>
       <% end %>
-      <div class="pull-right">
+      <div class='pull-right'>
         <%= f.button :submit, 'Import Corrected Works', class: 'btn btn-primary' %>
       </div>
     <% end %>

--- a/spec/jobs/bulkrax/exporter_job_spec.rb
+++ b/spec/jobs/bulkrax/exporter_job_spec.rb
@@ -14,7 +14,7 @@ module Bulkrax
       allow(exporter).to receive(:mapping).and_return("title" => {})
     end
 
-    describe 'successful job' do
+    describe 'successful job', clean_downloads: true do
       it 'calls export' do
         expect(exporter).to receive(:export)
         exporter_job.perform(1)

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -65,6 +65,37 @@ module Bulkrax
       end
     end
 
+    describe '#write_partial_import_file', clean_downloads: true do
+      let(:importer) { FactoryBot.create(:bulkrax_importer_csv_failed) }
+      let(:file)     { fixture_file_upload('./spec/fixtures/csv/ok.csv') }
+      subject        { described_class.new(importer) }
+
+      it 'returns the path of the partial import file' do
+        expect(subject.write_partial_import_file(file))
+          .to eq('tmp/imports/1/failed_corrected_entries.csv')
+      end
+
+      it 'moves the partial import file to the correct path' do
+        expect(File.exist?(file.path)).to eq(true)
+
+        new_path = subject.write_partial_import_file(file)
+
+        expect(File.exist?(file.path)).to eq(false)
+        expect(File.exist?(new_path)).to eq(true)
+      end
+
+      it 'renames the uploaded file to the original import filename + _corrected_entries' do
+        import_filename = importer.parser_fields['import_file_path'].split('/').last
+        uploaded_filename = file.original_filename
+        partial_import_filename = subject.write_partial_import_file(file).split('/').last
+
+        expect(import_filename).to eq('failed.csv')
+        expect(uploaded_filename).to eq('ok.csv')
+        expect(partial_import_filename).to_not eq(uploaded_filename)
+        expect(partial_import_filename).to eq('failed_corrected_entries.csv')
+      end
+    end
+
     describe '#create_parent_child_relationships' do
       subject { described_class.new(importer) }
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv_complex) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,7 +46,9 @@ RSpec.configure do |config|
   end
 
   config.after(:each, clean_downloads: true) do
-    FileUtils.rm_rf(Dir.glob("#{ENV.fetch('RAILS_TMP', Dir.tmpdir)}/*_errored_entries.csv"))
+    FileUtils.rm_rf(Dir.glob("#{ENV.fetch('RAILS_TMP', Dir.tmpdir)}/*_entries.csv"))
+    FileUtils.rm_rf(Dir.glob("#{File.join(Bulkrax.import_path, '1', '/*_entries.csv')}"))
+    FileUtils.rm_rf(Dir.glob("#{File.join(Bulkrax.export_path, '1', '1', '/*.csv')}"))
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
# Summary 
Implements the logic behind processing uploaded corrected CSV entries.

# Related Issue
https://github.com/samvera-labs/bulkrax/pull/133

# Expected Behavior

- The entries will be matched with those in the original importer (ie. a new importer will not be created) and updated. 

- The user will be taken to the original importer page, where, if successful, no errors will now be listed. If there are still errors, they can export-correct-upload again.

- When a successful job works, it will wipe out the `last_error` field. 

# Screenshots / Video
<img width="586" alt="Image 2020-02-19 at 10 37 57 AM" src="https://user-images.githubusercontent.com/32469930/74865390-e9c27a80-5305-11ea-9de2-e0e77c98be5a.png">

<img width="1579" alt="Image 2020-02-19 at 10 41 28 AM" src="https://user-images.githubusercontent.com/32469930/74865979-e4b1fb00-5306-11ea-94a3-d0cf724a0cee.png">

_In second image, highlighted Entry was successfully corrected and thus had its status updated and its errors cleared._ 

# Special Attention / Side Effects

Uploading corrected entries breaks Entry counters on Importer show and index pages. This side effect is captured here: https://github.com/samvera-labs/bulkrax/issues/144 
