### PR TITLE
Fix find_or_create

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -154,9 +154,10 @@ module Bulkrax
       entryclass.where(
         importerexporter_id: importerexporter.id,
         importerexporter_type: type,
-        identifier: identifier,
-        raw_metadata: raw_metadata
-      ).first_or_create!
+        identifier: identifier
+      ).first_or_create! do |e|
+        e.raw_metadata = raw_metadata
+      end
     end
 
     # @todo - review this method


### PR DESCRIPTION
Refactor `ApplicationParser#find_or_create_entry` to avoid using the raw_metadata in the where clause.