### PR TITLE
Deal with blank raw_metadata on entry

### DIFF
--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -20,8 +20,10 @@
 
     <p>
       <strong>Raw Metadata:</strong><br />
-      <% @entry.raw_metadata.each do |key,value| %>
-        <%= key %>: <%= value %> <br />
+      <% if @entry.raw_metadata.present? %>
+        <% @entry.raw_metadata.each do |key,value| %>
+          <%= key %>: <%= value %> <br />
+        <% end %>
       <% end %>
     </p>
 


### PR DESCRIPTION
Affects OAI entries particularly as we don't store raw_metadata on those.