### PR TITLE
fix controller inheritance to make multitenant work in hyku

### DIFF
--- a/app/controllers/bulkrax/application_controller.rb
+++ b/app/controllers/bulkrax/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ::ApplicationController
     helper Rails.application.class.helpers
     protect_from_forgery with: :exception
   end


### PR DESCRIPTION
Currently we do not inherit anything from the main apps ApplicationController. This makes injecting things like auth hard.  By just changing ActiveController::Base to ::ApplicationController (note the double colons) we can include before actions and other helpful items from the parent Rails app.