### PR TITLE
Resolve crash on blanks in CSV files, issue with importer show

### DIFF
--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -20,7 +20,7 @@ module Bulkrax
         return unless content.send(self.if[0], Regexp.new(self.if[1]))
       end
 
-      @result = content.gsub(/\s/, ' ') # remove any line feeds and tabs
+      @result = content.to_s.gsub(/\s/, ' ') # remove any line feeds and tabs
       @result.strip!
 
       if self.split.is_a?(TrueClass)

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -50,7 +50,7 @@
 
     <p>
       <strong>Field mapping:</strong><br />
-      <% @importer.field_mapping.each do |key,value| %>
+      <% @importer.mapping.each do |key,value| %>
         <%= key %>: <%= value %> <br />
       <% end %>
     </p>


### PR DESCRIPTION
Sorry about the daily double

1) If a csv entry is empty (no quotes) it was failing on the split. This just to_s the nil

2) importer mapping method now wraps the field_mapping variable. this updates the show view to reflect that.