### PR TITLE
Add last_error to importer

### DIFF
--- a/app/assets/javascripts/bulkrax/entries.js
+++ b/app/assets/javascripts/bulkrax/entries.js
@@ -1,5 +1,5 @@
 $( document ).on('turbolinks:load ready', function() {
-  $( "button" ).click(function() {
+  $( "button#entry_error" ).click(function() {
     $( "#error_trace" ).toggle();
   });
 })

--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -2,6 +2,15 @@
 // All this logic will automatically be available in application.js.
 
 function prepBulkrax(event) {
+
+  $( "button#err_toggle" ).click(function() {
+    $( "#error_trace" ).toggle();
+  });
+
+  $( "button#fm_toggle" ).click(function() {
+    $( "#field_mapping" ).toggle();
+  });
+
   var refresh_button = $('.refresh-set-source')
   var base_url = $('#importer_parser_fields_base_url')
   var initial_base_url = base_url.val()
@@ -81,6 +90,7 @@ function handleFileToggle(file_path) {
     $('#cloud').hide()
     $('#file_path input').attr('required', 'required')
     $('#file_upload input').attr('required', null)
+    $('#importer_parser_fields_file_style_specify_a_path_on_the_server').attr('checked', true)
   }
 
   $('#importer_parser_fields_file_style_upload_a_file').click(function(e){

--- a/app/jobs/bulkrax/download_cloud_file_job.rb
+++ b/app/jobs/bulkrax/download_cloud_file_job.rb
@@ -5,7 +5,7 @@ module Bulkrax
     queue_as :import
 
     # Retrieve cloud file and write to the imports directory
-    # Note: if using the file system, the mounted directory in 
+    # Note: if using the file system, the mounted directory in
     #   browse_everything MUST be shared by web and worker servers
     def perform(file, target_file)
       retriever = BrowseEverything::Retriever.new

--- a/app/jobs/bulkrax/export_work_job.rb
+++ b/app/jobs/bulkrax/export_work_job.rb
@@ -15,10 +15,10 @@ module Bulkrax
         ExporterRun.find(args[1]).decrement!(:enqueued_records)
         raise e
       else
-        if entry.last_exception
+        if entry.last_error
           ExporterRun.find(args[1]).increment!(:failed_records)
           ExporterRun.find(args[1]).decrement!(:enqueued_records)
-          raise entry.last_exception
+          raise entry.last_error['error_class'].constantize
         else
           ExporterRun.find(args[1]).increment!(:processed_records)
           ExporterRun.find(args[1]).decrement!(:enqueued_records)

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -8,6 +8,7 @@ module Bulkrax
     include Bulkrax::HasMatchers
     include Bulkrax::ImportBehavior
     include Bulkrax::ExportBehavior
+    include Bulkrax::Status
     include Bulkrax::HasLocalProcessing
 
     belongs_to :importerexporter, polymorphic: true
@@ -16,7 +17,7 @@ module Bulkrax
     serialize :collection_ids, Array
     serialize :last_error, JSON
 
-    attr_accessor :all_attrs, :last_exception
+    attr_accessor :all_attrs
 
     delegate :parser, :mapping, :replace_files, to: :importerexporter
 
@@ -59,38 +60,6 @@ module Bulkrax
 
     def exporter?
       self.importerexporter_type == 'Bulkrax::Exporter'
-    end
-
-    def status
-      if self.last_error_at.present?
-        'failed'
-      elsif self.last_succeeded_at.present?
-        'succeeded'
-      else
-        'waiting'
-      end
-    end
-
-    def status_at
-      case status
-      when 'succeeded'
-        self.last_succeeded_at
-      when 'failed'
-        self.last_error_at
-      end
-    end
-
-    def status_info(e = nil)
-      if e.nil?
-        self.last_error = nil
-        self.last_error_at = nil
-        self.last_exception = nil
-        self.last_succeeded_at = Time.current
-      else
-        self.last_error =  { error_class: e.class.to_s, error_message: e.message, error_trace: e.backtrace }
-        self.last_error_at = Time.current
-        self.last_exception = e
-      end
     end
 
     def valid_system_id(model_class)

--- a/app/models/concerns/bulkrax/status.rb
+++ b/app/models/concerns/bulkrax/status.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Bulkrax
+  module Status
+    extend ActiveSupport::Concern
+    def status
+      if self.last_error_at.present?
+        'failed'
+      elsif self.last_succeeded_at.present?
+        'succeeded'
+      else
+        'waiting'
+      end
+    end
+
+    def status_at
+      case status
+      when 'succeeded'
+        self.last_succeeded_at
+      when 'failed'
+        self.last_error_at
+      end
+    end
+
+    def status_info(e = nil)
+      if e.nil?
+        self.last_error = nil
+        self.last_error_at = nil
+        self.last_succeeded_at = Time.current
+      else
+        self.last_error =  { error_class: e.class.to_s, error_message: e.message, error_trace: e.backtrace }
+        self.last_error_at = Time.current
+      end
+      self.save!
+    end
+  end
+end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -6,6 +6,7 @@ module Bulkrax
     delegate :only_updates, :limit, :current_exporter_run, :current_importer_run, :errors,
              :seen, :increment_counters, :parser_fields, :user,
              :exporter_export_path, :exporter_export_zip_path, :importer_unzip_path, :validate_only,
+             :status, :status_info, :status_at,
              to: :importerexporter
 
     def self.parser_fields
@@ -109,6 +110,9 @@ module Bulkrax
         child_entry_ids = children.map(&:id)
         ChildRelationshipsJob.perform_later(parent_id, child_entry_ids, current_importer_run.id)
       end
+      status_info
+    rescue StandardError => e
+      status_info(e)
     end
 
     def parents

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -10,6 +10,7 @@ module Bulkrax
       return true if import_fields.present?
     rescue => e
       status_info(e)
+      false
     end
 
     def entry_class

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -7,7 +7,9 @@ module Bulkrax
     end
 
     def valid_import?
-      import_fields.present?
+      return true if import_fields.present?
+    rescue => e
+      status_info(e)
     end
 
     def entry_class
@@ -65,8 +67,9 @@ module Bulkrax
         ImportWorkJob.send(perform_method, new_entry.id, current_importer_run.id)
         increment_counters(index)
       end
+      status_info
     rescue StandardError => e
-      errors.add(:base, e.class.to_s.to_sym, message: e.message)
+      status_info(e)
     end
 
     def collections

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -46,6 +46,7 @@ module Bulkrax
       required_elements?(import_fields) && file_paths.is_a?(Array)
     rescue StandardError => e
       status_info(e)
+      false
     end
 
     def create_collections

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -25,7 +25,7 @@ module Bulkrax
 
     def records(_opts = {})
       file_for_import = only_updates ? parser_fields['partial_import_file_path'] : parser_fields['import_file_path']
-      entry_class.read_data(file_for_import).map { |record_data| entry_class.data_for_entry(record_data) }
+      @records ||= entry_class.read_data(file_for_import).map { |record_data| entry_class.data_for_entry(record_data) }
     end
 
     # We could use CsvEntry#fields_from_data(data) but that would mean re-reading the data
@@ -45,8 +45,7 @@ module Bulkrax
     def valid_import?
       required_elements?(import_fields) && file_paths.is_a?(Array)
     rescue StandardError => e
-      errors.add(:base, e.class.to_s.to_sym, message: e.message)
-      return false
+      status_info(e)
     end
 
     def create_collections
@@ -74,8 +73,9 @@ module Bulkrax
         ImportWorkJob.send(perform_method, new_entry.id, current_importer_run.id)
         increment_counters(index)
       end
+      status_info
     rescue StandardError => e
-      errors.add(:base, e.class.to_s.to_sym, message: e.message)
+      status_info(e)
     end
 
     def write_partial_import_file(file)
@@ -175,6 +175,7 @@ module Bulkrax
     end
 
     def file_paths
+      raise 'No records were found' if records.blank?
       @file_paths ||= records.map do |r|
         next unless r[:file].present?
         r[:file].split(/\s*[:;|]\s*/).map do |f|

--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -40,7 +40,7 @@
       <% if @entry.last_error.present? %>
         <strong>Errored at:</strong> <%= @entry.last_error_at %><br />
         <strong>Error:</strong> <%= @entry.last_error['error_class'] %> - <%= @entry.last_error['error_message'] %><br />
-        <strong>Error Trace: </strong> <button>Toggle</button>
+        <strong>Error Trace: </strong> <button id="entry_error">Toggle</button>
         <p id="error_trace" style="display: none"><%= @entry.last_error['error_trace'] %></p>
       <% else %>
         <strong>Succeeded At:</strong> <%= @entry.last_succeeded_at %>

--- a/app/views/bulkrax/importers/_bagit_fields.html.erb
+++ b/app/views/bulkrax/importers/_bagit_fields.html.erb
@@ -20,16 +20,16 @@
         selected: importer.parser_fields['rights_statement'],
         include_blank: true,
         item_helper: rights_statements.method(:include_current_value),
-        input_html: { class: 'form-control' } %>
+        input_html: { class: 'form-control' } ,
+        required: false
+        %>
   <%= fi.input :override_rights_statement, as: :boolean, hint: 'If checked, always use the selected rights statment. If unchecked, use rights or rights_statement from the record and only use the provided value if dc:rights is blank.', input_html: { checked: (importer.parser_fields['override_rights_statement'] == "1") } %>
 
   <h4>Bag or Bags to Import:</h4>
   <p>File upload and Cloud File upload must be a Zip file containing a single BagIt Bag, or a folder containing multiple BagIt Bags.</p>
   <p>The Server Path can point to a BagIt Bag, a folder containing BagIt Bags, or a zip file containing either.</p>
 
-  <% selected = 'Specify a Path on the Server' if importer.parser_fields['import_file_path'].present? %>
-
-  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server', 'Add Cloud File'], checked: selected, as: :radio_buttons, label: false %>
+  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server', 'Add Cloud File'], as: :radio_buttons, label: false %>
   <div id='file_upload'>
     <%= fi.input 'file', as: :file, input_html: {accept: 'application/zip'} %><br />
   </div>

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -5,15 +5,15 @@
         selected: importer.parser_fields['rights_statement'],
         include_blank: true,
         item_helper: rights_statements.method(:include_current_value),
-        input_html: { class: 'form-control' } %>
+        input_html: { class: 'form-control' },
+        required: false
+        %>
   <%= fi.input :override_rights_statement, as: :boolean, hint: 'If checked, always use the selected rights statment. If unchecked, use rights or rights_statement from the record and only use the provided value if dc:rights is blank.', input_html: { checked: (importer.parser_fields['override_rights_statement'] == "1") } %>
 
   <h4>Add CSV File to Import:</h4>
   <%# accept a single file upload; data files and bags will need to be added another way %>
 
-  <% selected = 'Specify a Path on the Server' if importer.parser_fields['import_file_path'].present? %>
-
-  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server'], checked: selected, as: :radio_buttons, label: false %>
+  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server'], as: :radio_buttons, label: false %>
   <div id='file_upload'>
     <%= fi.input 'file', as: :file, input_html: {accept: 'text/csv'} %><br />
   </div>

--- a/app/views/bulkrax/importers/_oai_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_fields.html.erb
@@ -12,7 +12,9 @@
         selected: importer.parser_fields['rights_statement'],
         include_blank: true,
         item_helper: rights_statements.method(:include_current_value),
-        input_html: { class: 'form-control' } %>
+        input_html: { class: 'form-control' },
+        required: false
+        %>
   <%= fi.input :override_rights_statement, as: :boolean, hint: 'If checked, always use the selected rights statment. If unchecked, use dc:rights from the record and only use the provided value if dc:rights is blank.', input_html: { checked: (importer.parser_fields['override_rights_statement'] == "1") } %>
   <%= fi.input :thumbnail_url, required: false, as: :string, input_html: { value: importer.parser_fields['thumbnail_url'] } %>
   <div class="help-block well well-sm">

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -30,7 +30,13 @@
             <% @importers.each do |importer| %>
             <tr>
               <th scope="row"><%= link_to importer.name, importer_path(importer) %></th>
-              <td><%= importer.importer_runs.last&.importer_status %></td>
+              <td>
+              <% if importer.last_error.present? %>
+                Failed
+              <% else %>
+                <%= importer.importer_runs.last&.importer_status %>
+              <% end %>
+              </td>
               <td><%= importer.last_imported_at.strftime("%b %d, %Y") if importer.last_imported_at %></td>
               <td><%= importer.next_import_at.strftime("%b %d, %Y") if importer.next_import_at %></td>
               <td><%= importer.importer_runs.last&.enqueued_records %></td>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -42,6 +42,17 @@
     </p>
 
     <p>
+      <% if @importer.last_error.present? %>
+        <strong>Errored at:</strong> <%= @importer.last_error_at %><br />
+        <strong>Error:</strong> <%= @importer.last_error['error_class'] %> - <%= @importer.last_error['error_message'] %><br />
+        <strong>Error Trace: </strong> <button id="err_toggle">Toggle</button>
+        <p id="error_trace" style="display: none"><%= @importer.last_error['error_trace'] %></p>
+      <% elsif @importer.last_succeeded_at.present?  %>
+        <strong>Succeeded At:</strong> <%= @importer.last_succeeded_at %>
+      <% end %>
+    </p>
+
+    <p>
       <strong>Parser fields:</strong><br />
       <% @importer.parser_fields.each do |key,value| %>
         <%= key %>: <%= value %> <br />
@@ -49,10 +60,12 @@
     </p>
 
     <p>
-      <strong>Field mapping:</strong><br />
-      <% @importer.mapping.each do |key,value| %>
-        <%= key %>: <%= value %> <br />
-      <% end %>
+      <strong>Field mapping:</strong> <button id="fm_toggle">Toggle</button>
+      <div id="field_mapping" style="display: none">
+        <% @importer.mapping.each do |key,value| %>
+          <%= key %>: <%= value %> <br />
+        <% end %>
+      </div>
     </p>
 
     <p>

--- a/db/migrate/20200301232856_add_status_to_importers.rb
+++ b/db/migrate/20200301232856_add_status_to_importers.rb
@@ -1,0 +1,7 @@
+class AddStatusToImporters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bulkrax_importers, :last_error, :text
+    add_column :bulkrax_importers, :last_error_at, :datetime
+    add_column :bulkrax_importers, :last_succeeded_at, :datetime
+  end
+end

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -44,7 +44,7 @@ module Bulkrax
 
         it 'Raises an error' do
           subject.create_works
-          expect(importer.errors.details[:base].first[:error]).to eq('RuntimeError'.to_sym)
+          expect(importer.last_error['error_class']).to eq('RuntimeError')
         end
       end
 
@@ -55,7 +55,7 @@ module Bulkrax
 
         it 'Raises an error' do
           subject.create_works
-          expect(importer.errors.details[:base].first[:error]).to eq('RuntimeError'.to_sym)
+          expect(importer.last_error['error_class']).to eq('RuntimeError')
         end
       end
 
@@ -111,7 +111,7 @@ module Bulkrax
 
         it 'Raises an error' do
           subject.create_works
-          expect(importer.errors.details[:base].first[:error]).to eq('RuntimeError'.to_sym)
+          expect(importer.last_error['error_class']).to eq('RuntimeError')
         end
       end
     end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -22,7 +22,7 @@ module Bulkrax
 
         it 'returns an empty array, and records the error on the importer' do
           subject.create_works
-          expect(importer.errors.details[:base].first[:error]).to eq('CSV::MalformedCSVError'.to_sym)
+          expect(importer.last_error['error_class']).to eq('CSV::MalformedCSVError')
         end
       end
 

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200108194557) do
+ActiveRecord::Schema.define(version: 20200301232856) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -94,6 +94,9 @@ ActiveRecord::Schema.define(version: 20200108194557) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "validate_only"
+    t.text "last_error"
+    t.datetime "last_error_at"
+    t.datetime "last_succeeded_at"
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"
   end
 


### PR DESCRIPTION
This PR:

* adds last_error, last_error_at, last_succeeded_at to the importers table
* captures and stores errors in the same way as entries
* displays errors in the importer show
* displays failed on the importer index if the importer itself has failed

Also
* checks the 'file on server' box on edit (as this will always be true for edit)
* removes requirement for rights_statement

<img width="964" alt="Screenshot 2020-03-02 at 09 06 24" src="https://user-images.githubusercontent.com/722117/75662443-06947180-5c67-11ea-9327-7f422924798c.png">

<img width="1150" alt="Screenshot 2020-03-02 at 09 21 22" src="https://user-images.githubusercontent.com/722117/75662566-380d3d00-5c67-11ea-93bf-05d300c280c4.png">


<img width="510" alt="Screenshot 2020-03-02 at 09 06 58" src="https://user-images.githubusercontent.com/722117/75662469-114f0680-5c67-11ea-81bd-24816210f09f.png">
