### PR TITLE
Loosen up oai dependecy as blacklight-oai conflicts

### DIFF
--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rack", ">= 2.0.6" # security issue, remove on rails upgrade
   s.add_dependency "simple_form"
   s.add_dependency 'iso8601', '~> 0.9.0'
-  s.add_dependency 'oai', '~> 1'
+  s.add_dependency 'oai', '>= 0.4', '< 2.x'
   s.add_dependency 'libxml-ruby', '~> 3.1.0'
   s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'
   s.add_dependency 'rdf', '>= 2.0.2', '< 4.0'


### PR DESCRIPTION
OAI 1.0 and OAI 0.4 are functionally equivalent in our use of them, though there is a warning that gets cleared. However blacklight-oai-provider 6.x depends on OAI 0.4. The updated blacklight-oai-provider requires updated blacklight, which doesn't work for Hyrax yet. Therefor, lets be permissive here on OAI versions until things can all be brought forward.