### PR TITLE
Refactor and rename csv_parser#files_path

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -60,7 +60,7 @@ module Bulkrax
       end
 
       # construct full file path
-      self.parsed_metadata['file'] = record['file'].split(/\s*[:;|]\s*/).map { |f| file_path(f.tr(' ', '_')) } if record['file'].present?
+      self.parsed_metadata['file'] = record['file'].split(/\s*[:;|]\s*/).map { |f| path_to_file(f.tr(' ', '_')) } if record['file'].present?
 
       add_visibility
       add_rights_statement
@@ -123,10 +123,11 @@ module Bulkrax
       %w[title source_identifier]
     end
 
-    def file_path(file)
+    # If only filename is given, construct the path (/files/my_file)
+    def path_to_file(file)
       # return if we already have the full file path
       return file if File.exist?(file)
-      path = importerexporter.parser.files_path
+      path = importerexporter.parser.path_to_files
       f = File.join(path, file)
       return f if File.exist?(f)
       raise "File #{f} does not exist"

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -33,10 +33,10 @@ module Bulkrax
     # Assume a single metadata record per path
     # Create an Array of all metadata records, one per file
     def records(_opts = {})
-      raise 'No BagIt records were found' if bags.blank?
+      raise StandardError, 'No BagIt records were found' if bags.blank?
       @records ||= bags.map do |bag|
         path = metadata_path(bag)
-        raise 'No metadata files were found' if path.blank?
+        raise StandardError, 'No metadata files were found' if path.blank?
         data = entry_class.read_data(path)
         data = entry_class.data_for_entry(data, path)
         data[:file] = bag.bag_files.join('|')
@@ -121,7 +121,7 @@ module Bulkrax
                   Dir.glob("#{import_file_path}/**/*").map { |d| bag(d) }
                 end
         @bags.delete(nil)
-        raise 'No valid bags found' if @bags.blank?
+        raise StandardError, 'No valid bags found' if @bags.blank?
         return @bags
       end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -175,6 +175,7 @@ module Bulkrax
       File.open(File.join(importerexporter.exporter_export_path, 'export.csv'), 'w')
     end
 
+    # Retrieve file paths for [:file] in records
     def file_paths
       raise StandardError, 'No records were found' if records.blank?
       @file_paths ||= records.map do |r|
@@ -187,11 +188,12 @@ module Bulkrax
       end.flatten.compact.uniq
     end
 
-    def files_path
-      path = self.importerexporter.parser_fields['import_file_path'].split('/')
-      # remove the metadata filename from the end of the import path
-      path.pop
-      File.join(path.join('/'), 'files')
+    # Retrieve the path where we expect to find files
+    def path_to_files
+      @path_to_files ||= File.join(
+        File.file?(real_import_file_path) ? File.dirname(real_import_file_path) : real_import_file_path,
+        'files'
+      )
     end
 
     # errored entries methods

--- a/spec/models/bulkrax/rdf_entry_spec.rb
+++ b/spec/models/bulkrax/rdf_entry_spec.rb
@@ -21,7 +21,6 @@ module Bulkrax
           data: "<http://example.org/ns/19158> <http://purl.org/dc/terms/identifier> \"12345\" .\n<http://example.org/ns/19158> <http://purl.org/dc/terms/title> \"Test Bag\" .\n",
           children: [],
           collection: [],
-          file: [],
           format: :ntriples,
           source_identifier: "http://example.org/ns/19158"
         )
@@ -61,7 +60,7 @@ module Bulkrax
 
         it 'succeeds' do
           subject.build
-          expect(subject.parsed_metadata).to eq("file" => [], "rights_statement" => [nil], "source" => ["http://example.org/ns/19158"], "title" => ["Test Bag"], "visibility" => "open")
+          expect(subject.parsed_metadata).to eq("file" => nil, "rights_statement" => [nil], "source" => ["http://example.org/ns/19158"], "title" => ["Test Bag"], "visibility" => "open")
           expect(subject.status).to eq('succeeded')
         end
       end


### PR DESCRIPTION
This PR:
* renames csv_parser#files_path as the name is too similar to other methods
* renames csv_entry#file_path to match
* adds comments
* refactors the new path_to_files method to use File.dirname
* fixes 2 broken tests