### PR TITLE
Add visiblity to all standard views

### DIFF
--- a/app/views/bulkrax/importers/_bagit_fields.html.erb
+++ b/app/views/bulkrax/importers/_bagit_fields.html.erb
@@ -14,6 +14,16 @@
     include_blank: true,
     input_html: { class: 'form-control' }
     %>
+
+  <%= fi.input :visibility, 
+		collection: [
+      ['Public', 'open'],
+      ['Private', 'restricted']
+		], 
+    selected: importer.parser_fields['visibility'] || 'open',
+    input_html: { class: 'form-control' }
+    %>
+
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,
         collection: rights_statements.select_active_options,

--- a/app/views/bulkrax/importers/_bagit_fields.html.erb
+++ b/app/views/bulkrax/importers/_bagit_fields.html.erb
@@ -15,14 +15,14 @@
     input_html: { class: 'form-control' }
     %>
 
-  <%= fi.input :visibility, 
-		collection: [
+  <%= fi.input :visibility,
+    collection: [
       ['Public', 'open'],
       ['Private', 'restricted']
-		], 
+    ],
     selected: importer.parser_fields['visibility'] || 'open',
     input_html: { class: 'form-control' }
-    %>
+  %>
 
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -1,4 +1,14 @@
 <div class='csv_fields'>
+
+  <%= fi.input :visibility, 
+		collection: [
+      ['Public', 'open'],
+      ['Private', 'restricted']
+		], 
+    selected: importer.parser_fields['visibility'] || 'open',
+    input_html: { class: 'form-control' }
+    %>
+
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,
         collection: rights_statements.select_active_options,

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -1,13 +1,13 @@
 <div class='csv_fields'>
 
-  <%= fi.input :visibility, 
-		collection: [
+  <%= fi.input :visibility,
+    collection: [
       ['Public', 'open'],
       ['Private', 'restricted']
-		], 
+    ],
     selected: importer.parser_fields['visibility'] || 'open',
     input_html: { class: 'form-control' }
-    %>
+  %>
 
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,

--- a/app/views/bulkrax/importers/_oai_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_fields.html.erb
@@ -5,6 +5,15 @@
   
   <%= fi.input :set, collection: [importer.parser_fields['set']], label: 'Set (source)', selected: importer.parser_fields['set'] %>
   <button type="button" class="btn btn-default refresh-set-source">Refresh Sets</button>
+
+  <%= fi.input :visibility, 
+		collection: [
+      ['Public', 'open'],
+      ['Private', 'restricted']
+		], 
+    selected: importer.parser_fields['visibility'] || 'open',
+    input_html: { class: 'form-control' }
+    %>
   
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement, required: false,

--- a/app/views/bulkrax/importers/_oai_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_fields.html.erb
@@ -6,15 +6,15 @@
   <%= fi.input :set, collection: [importer.parser_fields['set']], label: 'Set (source)', selected: importer.parser_fields['set'] %>
   <button type="button" class="btn btn-default refresh-set-source">Refresh Sets</button>
 
-  <%= fi.input :visibility, 
-		collection: [
+  <%= fi.input :visibility,
+    collection: [
       ['Public', 'open'],
       ['Private', 'restricted']
-		], 
+    ],
     selected: importer.parser_fields['visibility'] || 'open',
     input_html: { class: 'form-control' }
-    %>
-  
+  %>
+
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement, required: false,
         collection: rights_statements.select_active_options,

--- a/app/views/bulkrax/importers/_xml_fields.html.erb
+++ b/app/views/bulkrax/importers/_xml_fields.html.erb
@@ -22,14 +22,14 @@
   
   <h4>Visiblity</h4>
 
-  <%= fi.input :visibility, 
-		collection: [
+  <%= fi.input :visibility,
+    collection: [
       ['Public', 'open'],
       ['Private', 'restricted']
-		], 
+    ],
     selected: importer.parser_fields['visibility'] || 'open',
     input_html: { class: 'form-control' }
-    %>
+  %>
 
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,


### PR DESCRIPTION
This PR adds a visiblity option to all parser views, set to open/public by default to mirror existing default behaviour.

The base work for this was done for the xml importer, this PR rolls the behaviour to the other views.