### PR TITLE
Various browse everything fixes

### DIFF
--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -73,8 +73,8 @@ module Bulkrax
       if api_request?
         return return_json_response unless valid_create_params?
       end
-      file = params[:importer][:parser_fields].delete(:file)
-      cloud_files = params[:importer].delete(:selected_files)
+      file = params.to_unsafe_h[:importer][:parser_fields].delete(:file)
+      cloud_files = params.to_unsafe_h[:importer].delete(:selected_files)
       @importer = Importer.new(importer_params)
       field_mapping_params
       @importer.validate_only = true if params[:commit] == 'Create and Validate'
@@ -105,8 +105,8 @@ module Bulkrax
       end
       # skipped for calls from continue
       if params[:importer][:parser_fields].present?
-        file = params[:importer][:parser_fields].delete(:file)
-        cloud_files = params[:importer].delete(:selected_files)
+        file = params.to_unsafe_h[:importer][:parser_fields].delete(:file)
+        cloud_files = params.to_unsafe_h[:importer].delete(:selected_files)
         field_mapping_params
       end
 

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -74,7 +74,7 @@ module Bulkrax
         return return_json_response unless valid_create_params?
       end
       file = params.to_unsafe_h[:importer][:parser_fields].delete(:file)
-      cloud_files = params.to_unsafe_h[:importer].delete(:selected_files)
+      cloud_files = params.to_unsafe_h.delete(:selected_files)
       @importer = Importer.new(importer_params)
       field_mapping_params
       @importer.validate_only = true if params[:commit] == 'Create and Validate'
@@ -106,7 +106,7 @@ module Bulkrax
       # skipped for calls from continue
       if params[:importer][:parser_fields].present?
         file = params.to_unsafe_h[:importer][:parser_fields].delete(:file)
-        cloud_files = params.to_unsafe_h[:importer].delete(:selected_files)
+        cloud_files = params.to_unsafe_h.delete(:selected_files)
         field_mapping_params
       end
 

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -60,7 +60,10 @@ module Bulkrax
       end
 
       # construct full file path
-      self.parsed_metadata['file'] = record['file'].split(/\s*[:;|]\s*/).map { |f| path_to_file(f.tr(' ', '_')) } if record['file'].present?
+      self.parsed_metadata['file'] ||= []
+      self.parsed_metadata['file'] += record['file'].split(/\s*[:;|]\s*/) if record['file'].present?
+      self.parsed_metadata['file'] = self.parsed_metadata['file'].select { |f| f.present? }
+      self.parsed_metadata['file'] = self.parsed_metadata['file'].map { |f| path_to_file(f.tr(' ', '_')) }
 
       add_visibility
       add_rights_statement

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -62,7 +62,7 @@ module Bulkrax
       # construct full file path
       self.parsed_metadata['file'] ||= []
       self.parsed_metadata['file'] += record['file'].split(/\s*[:;|]\s*/) if record['file'].present?
-      self.parsed_metadata['file'] = self.parsed_metadata['file'].select { |f| f.present? }
+      self.parsed_metadata['file'] = self.parsed_metadata['file'].select { |f| f.present? && f != '[]' }
       self.parsed_metadata['file'] = self.parsed_metadata['file'].map { |f| path_to_file(f.tr(' ', '_')) }
 
       add_visibility

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -142,6 +142,11 @@ module Bulkrax
       files_path = File.join(path_for_import, 'files')
       FileUtils.mkdir_p(files_path) unless File.exist?(files_path)
       files.each_pair do |_key, file|
+        # fixes bug where auth headers do not get attached properly
+        if file['auth_header'].present?
+          file['headers'] ||= {}
+          file['headers'].merge!(file['auth_header'])
+        end
         # this only works for uniquely named files
         target_file = File.join(files_path, file['file_name'].tr(' ', '_'))
         # Now because we want the files in place before the importer runs


### PR DESCRIPTION
- Move params to correct location and allow values to be plucked out safely
- Map auth_header to headers, which is where the BrowseEverything retriever expects to find it
- Try to deal with CSV entry when someone maps something to file besides the column header "file"