### PR TITLE
Exporter show page

### DIFF
--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -10,7 +10,6 @@ module Bulkrax
     before_action :authenticate_user!
     with_themed_layout 'dashboard'
 
-    # GET /importers/1/entries/1
     def show
       if params[:importer_id].present?
         show_importer
@@ -19,9 +18,11 @@ module Bulkrax
       end
     end
 
+    # GET /importers/1/entries/1
     def show_importer
       @importer = Importer.find(params[:importer_id])
       @entry = Entry.find(params[:id])
+
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb 'Importers', bulkrax.importers_path
@@ -29,9 +30,11 @@ module Bulkrax
       add_breadcrumb @entry.id
     end
 
+    # GET /exporters/1/entries/1
     def show_exporter
       @exporter = Exporter.find(params[:exporter_id])
       @entry = Entry.find(params[:id])
+
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb 'Exporters', bulkrax.exporters_path

--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -12,12 +12,30 @@ module Bulkrax
 
     # GET /importers/1/entries/1
     def show
+      if params[:importer_id].present?
+        show_importer
+      elsif params[:exporter_id].present?
+        show_exporter
+      end
+    end
+
+    def show_importer
       @importer = Importer.find(params[:importer_id])
       @entry = Entry.find(params[:id])
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb 'Importers', bulkrax.importers_path
       add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+      add_breadcrumb @entry.id
+    end
+
+    def show_exporter
+      @exporter = Exporter.find(params[:exporter_id])
+      @entry = Entry.find(params[:id])
+      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb 'Exporters', bulkrax.exporters_path
+      add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
       add_breadcrumb @entry.id
     end
   end

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -21,6 +21,8 @@ module Bulkrax
     def show
       add_exporter_breadcrumbs
       add_breadcrumb @exporter.name
+
+      @work_entries = @exporter.entries.where(type: @exporter.parser.entry_class.to_s).page(params[:work_entries_page])
     end
 
     # GET /exporters/new

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -12,28 +12,30 @@ module Bulkrax
 
     # GET /exporters
     def index
-      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Exporters', bulkrax.exporters_path
       @exporters = Exporter.all
+
+      add_exporter_breadcrumbs
     end
 
     # GET /exporters/1
-    def show; end
+    def show
+      add_exporter_breadcrumbs
+      add_breadcrumb @exporter.name
+    end
 
     # GET /exporters/new
     def new
-      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Exporters', bulkrax.exporters_path
       @exporter = Exporter.new
+
+      add_exporter_breadcrumbs
+      add_breadcrumb 'New'
     end
 
     # GET /exporters/1/edit
     def edit
-      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Exporters', bulkrax.exporters_path
+      add_exporter_breadcrumbs
+      add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
+      add_breadcrumb 'Edit'
 
       # Correctly populate export_source_collection input
       @collection = Collection.find(@exporter.export_source) if @exporter.export_source.present? && @exporter.export_from == 'collection'
@@ -95,6 +97,12 @@ module Bulkrax
         # @todo replace/append once mapping GUI is in place
         fields = Bulkrax.parsers.map { |m| m[:partial] if m[:class_name] == params[:exporter][:parser_klass] }.compact.first
         @exporter.field_mapping = Bulkrax.field_mappings[fields.to_sym] if fields
+      end
+
+      def add_exporter_breadcrumbs
+        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb 'Exporters', bulkrax.exporters_path
       end
 
       # Download methods

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -23,9 +23,7 @@ module Bulkrax
       if api_request?
         json_response('index')
       else
-        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb 'Importers', bulkrax.importers_path
+        add_importer_breadcrumbs
       end
     end
 
@@ -34,9 +32,7 @@ module Bulkrax
       if api_request?
         json_response('show')
       else
-        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb 'Importers', bulkrax.importers_path
+        add_importer_breadcrumbs
         add_breadcrumb @importer.name
         @work_entries = @importer.entries.where(type: @importer.parser.entry_class.to_s).page(params[:work_entries_page])
         @collection_entries = @importer.entries.where(type: @importer.parser.collection_entry_class.to_s).page(params[:collections_entries_page])
@@ -49,9 +45,8 @@ module Bulkrax
       if api_request?
         json_response('new')
       else
-        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb 'Importers', bulkrax.importers_path
+        add_importer_breadcrumbs
+        add_breadcrumb 'New'
       end
     end
 
@@ -60,9 +55,9 @@ module Bulkrax
       if api_request?
         json_response('edit')
       else
-        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb 'Importers', bulkrax.importers_path
+        add_importer_breadcrumbs
+        add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+        add_breadcrumb 'Edit'
       end
     end
 
@@ -257,6 +252,12 @@ module Bulkrax
         # @todo replace/append once mapping GUI is in place
         field_mapping_key = Bulkrax.parsers.map { |m| m[:class_name] if m[:class_name] == params[:importer][:parser_klass] }.compact.first
         @importer.field_mapping = Bulkrax.field_mappings[field_mapping_key] if field_mapping_key
+      end
+
+      def add_importer_breadcrumbs
+        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb 'Importers', bulkrax.importers_path
       end
 
       def setup_client(url)

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -34,6 +34,7 @@ module Bulkrax
       else
         add_importer_breadcrumbs
         add_breadcrumb @importer.name
+
         @work_entries = @importer.entries.where(type: @importer.parser.entry_class.to_s).page(params[:work_entries_page])
         @collection_entries = @importer.entries.where(type: @importer.parser.collection_entry_class.to_s).page(params[:collections_entries_page])
       end

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -78,6 +78,8 @@ module Bulkrax
         Bulkrax::ImporterJob.send(@importer.parser.perform_method, @importer.id)
         if api_request?
           json_response('create', :created, 'Importer was successfully created.')
+        elsif @importer.validate_only
+          redirect_to importer_path(@importer.id), notice: 'Importer validation completed. Please review and choose to either Continue with or Discard the import.'
         else
           redirect_to importers_path, notice: 'Importer was successfully created.'
         end

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -5,8 +5,10 @@ require 'fileutils'
 module Bulkrax
   class Exporter < ApplicationRecord
     include Bulkrax::ImporterExporterBehavior
+    include Bulkrax::Status
 
     serialize :field_mapping, JSON
+    serialize :last_error, JSON
 
     belongs_to :user
     has_many :exporter_runs, dependent: :destroy, foreign_key: 'exporter_id'
@@ -27,6 +29,9 @@ module Bulkrax
       when 'worktype'
         create_from_worktype
       end
+      status_info
+    rescue StandardError => e
+      status_info(e)
     end
 
     # #export_source accessors

--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -47,30 +47,38 @@
       <% end %>
     </p>
 
+    <%# TODO: i18n %>
     <p>
-      <% if @entry.last_succeeded_at != nil %>
-        <% if @importer.class == Bulkrax::Importer %>
+      <% if @importer.present? %>
+        <% if @entry.last_succeeded_at != nil %>
           <strong>Importer:</strong>
           <%= link_to @importer.name, importer_path(@importer) %>
         <% else %>
-        <%# TODO: Create Exporter showpage table for individual items in order to link to the item %>
-          <strong>Exporter Link: Showpage has not been setup yet.</strong>
+          <strong>Importer Link: Item has not been imported successfully</strong>
         <% end %>
-      <% else %>
-        <strong>Importer Link: Item has not been imported successfully</strong>
+      <% elsif @exporter.present? %>
+        <% if @entry.last_succeeded_at != nil %>
+          <strong>Exporter:</strong>
+          <%= link_to @exporter.name, exporter_path(@exporter) %>
+        <% else %>
+          <strong>Exporter Link: Item has not been exported successfully</strong>
+        <% end %>
       <% end %>
     </p>
 
-    <p>
-      <% factory_record = @entry.factory.find %>
-      <% if @entry.last_succeeded_at != nil && factory_record.present? %>
-        <strong><%= @entry.factory_class.to_s %> Link:</strong>
-        <% if @entry.factory_class.to_s == "Collection" %>
-          <%= link_to @entry.factory_class.to_s, hyrax.polymorphic_path(@entry.factory.find) %>
+    <%# TODO: Exporter equivalent? %>
+    <% if @importer.present? %>
+      <p>
+        <% factory_record = @entry.factory.find %>
+        <% if @entry.last_succeeded_at != nil && factory_record.present? %>
+          <strong><%= @entry.factory_class.to_s %> Link:</strong>
+          <% if @entry.factory_class.to_s == "Collection" %>
+            <%= link_to @entry.factory_class.to_s, hyrax.polymorphic_path(@entry.factory.find) %>
+          <% else %>
+            <%= link_to @entry.factory_class.to_s, main_app.polymorphic_path(@entry.factory.find) %>
+          <% end %>
         <% else %>
-          <%= link_to @entry.factory_class.to_s, main_app.polymorphic_path(@entry.factory.find) %>
+          <strong> Item Link: Item has not been imported successfully</strong>
         <% end %>
-      <% else %>
-        <strong> Item Link: Item has not been imported successfully</strong>
-      <% end %>
-    </p>
+      </p>
+    <% end %>

--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -62,21 +62,26 @@
       <% end %>
     </p>
 
-    <%# TODO: Currently no Exporter equivalent, is one necessary? %>
-    <% if @importer.present? %>
-      <p>
+    <p>
+      <% if @importer.present? %>
         <% factory_record = @entry.factory.find %>
         <% if @entry.last_succeeded_at != nil && factory_record.present? %>
           <strong><%= @entry.factory_class.to_s %> Link:</strong>
           <% if @entry.factory_class.to_s == "Collection" %>
-            <%= link_to @entry.factory_class.to_s, hyrax.polymorphic_path(@entry.factory.find) %>
+            <%= link_to @entry.factory_class.to_s, hyrax.polymorphic_path(factory_record) %>
           <% else %>
-            <%= link_to @entry.factory_class.to_s, main_app.polymorphic_path(@entry.factory.find) %>
+            <%= link_to @entry.factory_class.to_s, main_app.polymorphic_path(factory_record) %>
           <% end %>
         <% else %>
           <strong>Item Link:</strong> Item has not been imported successfully
         <% end %>
-      </p>
-    <% end %>
+      <% else %>
+        <% record = @entry&.work %>
+        <% if record.present? %>
+          <strong><%= record.class.to_s %> Link:</strong>
+          <%= link_to record.class.to_s, main_app.polymorphic_path(record) %>
+        <% end %>
+      <% end %>
+    </p>
   </div>
 </div>

--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -1,8 +1,9 @@
+<p id="notice"><%= notice %></p>
+
 <div class="panel panel-default">
   <div class="panel-body">
 
-    <p id="notice"><%= notice %></p>
-
+    <%# TODO: i18n %>
     <p>
       <strong>Identifier:</strong>
       <%= @entry.identifier %>
@@ -36,37 +37,32 @@
       <% end %>
     </p>
 
+    <%# Consider spliting dynamic fields into two partials %>
+
     <p>
       <% if @entry.last_error.present? %>
         <strong>Errored at:</strong> <%= @entry.last_error_at %><br />
         <strong>Error:</strong> <%= @entry.last_error['error_class'] %> - <%= @entry.last_error['error_message'] %><br />
         <strong>Error Trace: </strong> <button id="entry_error">Toggle</button>
         <p id="error_trace" style="display: none"><%= @entry.last_error['error_trace'] %></p>
-      <% else %>
+      <% elsif @entry.last_succeeded_at != nil %>
         <strong>Succeeded At:</strong> <%= @entry.last_succeeded_at %>
+      <% else %>
+        <strong>Succeeded At:</strong> Item has not been <%= @importer.present? ? 'imported' : 'exported' %> successfully
       <% end %>
     </p>
 
-    <%# TODO: i18n %>
     <p>
       <% if @importer.present? %>
-        <% if @entry.last_succeeded_at != nil %>
-          <strong>Importer:</strong>
-          <%= link_to @importer.name, importer_path(@importer) %>
-        <% else %>
-          <strong>Importer Link: Item has not been imported successfully</strong>
-        <% end %>
+        <strong>Importer:</strong>
+        <%= link_to @importer.name, importer_path(@importer) %>
       <% elsif @exporter.present? %>
-        <% if @entry.last_succeeded_at != nil %>
-          <strong>Exporter:</strong>
-          <%= link_to @exporter.name, exporter_path(@exporter) %>
-        <% else %>
-          <strong>Exporter Link: Item has not been exported successfully</strong>
-        <% end %>
+        <strong>Exporter:</strong>
+        <%= link_to @exporter.name, exporter_path(@exporter) %>
       <% end %>
     </p>
 
-    <%# TODO: Exporter equivalent? %>
+    <%# TODO: Currently no Exporter equivalent, is one necessary? %>
     <% if @importer.present? %>
       <p>
         <% factory_record = @entry.factory.find %>
@@ -78,7 +74,9 @@
             <%= link_to @entry.factory_class.to_s, main_app.polymorphic_path(@entry.factory.find) %>
           <% end %>
         <% else %>
-          <strong> Item Link: Item has not been imported successfully</strong>
+          <strong>Item Link:</strong> Item has not been imported successfully
         <% end %>
       </p>
     <% end %>
+  </div>
+</div>

--- a/app/views/bulkrax/exporters/edit.html.erb
+++ b/app/views/bulkrax/exporters/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span> New Exporter</h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span> Edit Exporter</h1>
 <% end %>
 
 <div class="row">
@@ -9,10 +9,12 @@
         <%= render 'form', exporter: @exporter, form: form %>
         <div class="panel-footer">
           <div class='pull-right'>
-             <%= form.button :submit, value: 'Update Exporter', class: 'btn btn-primary' %>
-           | <%= form.button :submit, value: 'Update and Re-Export All Items', class: 'btn btn-primary' %>
-           <% cancel_path = form.object.persisted? ? exporter_path(form.object) : exporters_path %>
-            | <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>
+            <%= form.button :submit, value: 'Update Exporter', class: 'btn btn-primary' %>
+            |
+            <%= form.button :submit, value: 'Update and Re-Export All Items', class: 'btn btn-primary' %>
+            |
+            <% cancel_path = form.object.persisted? ? exporter_path(form.object) : exporters_path %>
+            <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>
           </div>
         </div>
       <% end %>

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -27,7 +27,13 @@
             <% @exporters.each do |exporter| %>
               <tr>
                 <th scope="row"><%= link_to exporter.name, exporter_path(exporter) %></th>
-                <td><%= exporter.exporter_runs.last&.exporter_status %></td>
+                <td>
+                  <% if exporter.last_error.present? %>
+                    Failed
+                  <% else %>
+                    <%= exporter.exporter_runs.last&.exporter_status %>
+                  <% end %>
+                </td>
                 <td><%= exporter.created_at %></td>
                 <td>
                   <% if File.exist?(exporter.exporter_export_zip_path) %>

--- a/app/views/bulkrax/exporters/new.html.erb
+++ b/app/views/bulkrax/exporters/new.html.erb
@@ -9,10 +9,12 @@
         <%= render 'form', exporter: @exporter, form: form %>
         <div class="panel-footer">
           <div class='pull-right'>
-           <%= form.button :submit, value: 'Create and Export', class: 'btn btn-primary' %>
-            | <%= form.button :submit, value: 'Create', class: 'btn btn-primary' %>
+            <%= form.button :submit, value: 'Create and Export', class: 'btn btn-primary' %>
+            |
+            <%= form.button :submit, value: 'Create', class: 'btn btn-primary' %>
+            |
             <% cancel_path = form.object.persisted? ? exporter_path(form.object) : exporters_path %>
-            | <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>
+            <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>
           </div>
         </div>
       <% end %>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -1,39 +1,84 @@
 <p id="notice"><%= notice %></p>
 
-<p>
-  <strong><% t('bulkrax.exporter.labels.name') %></strong>
-  <%= @exporter.name %>
-</p>
+<div class="col-xs-12 main-header">
+  <h1><span class="fa fa-cloud-download" aria-hidden="true"></span> Exporter: <%= @exporter.name %></h1>
+</div>
 
-<p>
-  <strong><% t('bulkrax.exporter.labels.export_type') %></strong>
-  <%= @exporter.export_type %>
-</p>
+<div class="panel panel-default">
+  <div class="panel-body">
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.name') %>:</strong>
+      <%= @exporter.name %>
+    </p>
 
-<p>
-  <strong><% t('bulkrax.exporter.labels.export_from') %></strong>
-  <%= @exporter.export_from %>
-</p>
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.user') %>:</strong>
+      <%= @exporter.user %>
+    </p>
 
-<p>
-  <strong><% t('bulkrax.exporter.labels.export_source') %></strong>
-  <%= @exporter.export_source %>
-</p>
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.export_type') %>:</strong>
+      <%= @exporter.export_type %>
+    </p>
 
-<p>
-  <strong><% t('bulkrax.exporter.labels.parser_klass') %></strong>
-  <%= @exporter.parser_klass %>
-</p>
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.export_from') %>:</strong>
+      <%= @exporter.export_from %>
+    </p>
 
-<p>
-  <strong><% t('bulkrax.exporter.labels.limit') %></strong>
-  <%= @exporter.limit %>
-</p>
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.export_source') %>:</strong>
+      <% case @exporter.export_from %>
+      <% when 'collection' %>
+        <% collection = Collection.find(@exporter.export_source) %>
+        <%= link_to collection&.title&.first, hyrax.dashboard_collection_path(collection.id) %>
+      <% when 'importer' %>
+        <% importer = Bulkrax::Importer.find(@exporter.export_source) %>
+        <%= link_to importer.name, bulkrax.importer_path(importer.id) %>
+      <% when 'worktype' %>
+        <%= @exporter.export_source %>
+      <% end %>
+    </p>
 
-<p>
-  <strong><% t('bulkrax.exporter.labels.field_mapping') %></strong>
-  <%= @exporter.field_mapping %>
-</p>
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.parser_klass') %>:</strong>
+      <%= @exporter.parser_klass %>
+    </p>
 
-<%= link_to 'Edit', edit_exporter_path(@exporter) %> |
-<%= link_to 'Back', exporters_path %>
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.limit') %>:</strong>
+      <%= @exporter.limit %>
+    </p>
+
+    <%# TODO: last_error %>
+
+    <%# Currently, no parser-specific fields exist on Exporter,
+        thus there's no real reason to always show this field %>
+    <% if @exporter.parser_fields.present? %>
+      <p>
+        <strong><%= t('bulkrax.exporter.labels.parser_fields') %>:</strong><br>
+        <% @exporter.parser_fields.each do |k, v| %>
+          <%= k %>: <%= v %><br>
+        <% end %>
+      </p>
+    <% end %>
+
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.field_mapping') %>:</strong> <button id="fm_toggle">Toggle</button>
+      <div id="field_mapping" style="display: none">
+        <% @exporter.mapping.each do |k, v| %>
+          <%= k %>: <%= v %><br>
+        <% end %>
+      </div>
+    </p>
+
+    <p>
+      <strong><%= t('bulkrax.exporter.labels.total_work_entries') %>:</strong>
+      <%= @exporter.exporter_runs.last&.total_work_entries %>
+    </p>
+
+    <%= link_to 'Edit', edit_exporter_path(@exporter) %>
+    |
+    <%= link_to 'Back', exporters_path %>
+  </div>
+</div>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -50,7 +50,16 @@
       <%= @exporter.limit %>
     </p>
 
-    <%# TODO: last_error %>
+    <p>
+      <% if @exporter.last_error.present? %>
+        <strong>Errored at:</strong> <%= @exporter.last_error_at %><br />
+        <strong>Error:</strong> <%= @exporter.last_error['error_class'] %> - <%= @exporter.last_error['error_message'] %><br />
+        <strong>Error Trace: </strong> <button id="err_toggle">Toggle</button>
+        <p id="error_trace" style="display: none"><%= @exporter.last_error['error_trace'] %></p>
+      <% elsif @exporter.last_succeeded_at.present?  %>
+        <strong>Succeeded At:</strong> <%= @exporter.last_succeeded_at %>
+      <% end %>
+    </p>
 
     <%# Currently, no parser-specific fields exist on Exporter,
         thus there's no real reason to always show this field %>
@@ -66,7 +75,7 @@
     <p>
       <strong><%= t('bulkrax.exporter.labels.field_mapping') %>:</strong> <button id='fm_toggle'>Toggle</button>
       <div id='field_mapping' style='display: none'>
-        <% @exporter.field_mapping.each do |k, v| %>
+        <% @exporter.field_mapping&.each do |k, v| %>
           <%= k %>: <%= v %><br>
         <% end %>
       </div>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -1,11 +1,11 @@
-<p id="notice"><%= notice %></p>
+<p id='notice'><%= notice %></p>
 
-<div class="col-xs-12 main-header">
-  <h1><span class="fa fa-cloud-download" aria-hidden="true"></span> Exporter: <%= @exporter.name %></h1>
+<div class='col-xs-12 main-header'>
+  <h1><span class='fa fa-cloud-download' aria-hidden='true'></span> Exporter: <%= @exporter.name %></h1>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-body">
+<div class='panel panel-default'>
+  <div class='panel-body'>
     <p>
       <strong><%= t('bulkrax.exporter.labels.name') %>:</strong>
       <%= @exporter.name %>
@@ -64,8 +64,8 @@
     <% end %>
 
     <p>
-      <strong><%= t('bulkrax.exporter.labels.field_mapping') %>:</strong> <button id="fm_toggle">Toggle</button>
-      <div id="field_mapping" style="display: none">
+      <strong><%= t('bulkrax.exporter.labels.field_mapping') %>:</strong> <button id='fm_toggle'>Toggle</button>
+      <div id='field_mapping' style='display: none'>
         <% @exporter.mapping.each do |k, v| %>
           <%= k %>: <%= v %><br>
         <% end %>
@@ -76,6 +76,55 @@
       <strong><%= t('bulkrax.exporter.labels.total_work_entries') %>:</strong>
       <%= @exporter.exporter_runs.last&.total_work_entries %>
     </p>
+
+    <br>
+
+    <h2>Work Entries</h2>
+    <table class='table table-striped'>
+      <thead>
+        <tr>
+          <th>Identifier</th>
+          <th>Collection</th>
+          <th>Entry ID</th>
+          <th>Status</th>
+          <th>Errors</th>
+          <th>Status Set At</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @work_entries.each do |e| %>
+          <tr>
+            <td><%= link_to e.identifier, bulkrax.exporter_entry_path(@exporter.id, e.id) %></td>
+            <% if e.parsed_metadata.present? && e.parsed_metadata.dig('collections').present? %>
+              <td><%= e.parsed_metadata.dig('collections').map {|c| c['id'] }.join('; ') %></td>
+            <% elsif e.raw_metadata.present? %>
+              <td><%= Array.wrap(e.raw_metadata.dig('collection')).join(';') %></td>
+            <% else %>
+            <td></td>
+            <% end %>
+            <td><%= e.id %></td>
+            <% if e.status == 'succeeded' %>
+              <td><span class='glyphicon glyphicon-ok' style='color: green;'></span> <%= e.status %></td>
+              <% else %>
+              <td><span class='glyphicon glyphicon-remove' style='color: red;'></span> <%= e.status %></td>
+            <% end %>
+            <% if e.last_error.present? %>
+              <td><%= link_to e.last_error.dig('error_class'), bulkrax.exporter_entry_path(@exporter.id, e.id) %></td>
+            <% else %>
+              <td></td>
+            <% end %>
+            <td><%= e.status_at %></td>
+            <td><%= link_to raw("<span class='glyphicon glyphicon-info-sign'></span>"), bulkrax.exporter_entry_path(@exporter.id, e.id) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= page_entries_info(@work_entries) %><br>
+    <%= paginate(@work_entries, param_name: :work_entries_page) %>
+
+    <br>
 
     <%= link_to 'Edit', edit_exporter_path(@exporter) %>
     |

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -66,7 +66,7 @@
     <p>
       <strong><%= t('bulkrax.exporter.labels.field_mapping') %>:</strong> <button id='fm_toggle'>Toggle</button>
       <div id='field_mapping' style='display: none'>
-        <% @exporter.mapping.each do |k, v| %>
+        <% @exporter.field_mapping.each do |k, v| %>
           <%= k %>: <%= v %><br>
         <% end %>
       </div>

--- a/app/views/bulkrax/importers/edit.html.erb
+++ b/app/views/bulkrax/importers/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span> New Importer</h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span> Edit Importer</h1>
 <% end %>
 
 <div class="row">

--- a/app/views/bulkrax/importers/new.html.erb
+++ b/app/views/bulkrax/importers/new.html.erb
@@ -10,10 +10,13 @@
         <div class="panel-footer">
           <div class='pull-right'>
             <%= form.button :submit, value: 'Create and Validate', class: 'btn btn-primary' %>
-           <%= form.button :submit, value: 'Create and Import', class: 'btn btn-primary' %>
-            | <%= form.button :submit, value: 'Create', class: 'btn btn-primary' %>
+            |
+            <%= form.button :submit, value: 'Create and Import', class: 'btn btn-primary' %>
+            |
+            <%= form.button :submit, value: 'Create', class: 'btn btn-primary' %>
+            |
             <% cancel_path = form.object.persisted? ? importer_path(form.object) : importers_path %>
-            | <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>
+            <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>
           </div>
         </div>
       <% end %>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -77,9 +77,10 @@
       <strong>Total Collections:</strong>
       <%= @importer.importer_runs.last&.total_collection_entries %>
     </p>
+
     <br />
+
     <h2>Collection Entries</h2>
-    <%# TODO add entry info and paginate it here %>
     <table class='table table-striped'>
       <thead>
         <tr>
@@ -91,6 +92,7 @@
           <th>Actions</th>
         </tr>
       </thead>
+
       <tbody>
         <% @collection_entries.each do |e| %>
           <tr>
@@ -116,6 +118,7 @@
     <%= paginate(@collection_entries, param_name: :collections_entries_page) %>
 
     <br />
+
     <h2>Work Entries</h2>
     <table class='table table-striped'>
       <thead>
@@ -129,6 +132,7 @@
           <th>Actions</th>
         </tr>
       </thead>
+
       <tbody>
         <% @work_entries.each do |e| %>
           <tr>
@@ -159,18 +163,20 @@
     </table>
     <%= page_entries_info(@work_entries, param_name: :collections_entries_page) %><br />
     <%= paginate(@work_entries, param_name: :work_entries_page) %>
+
     <br />
-    <%= link_to 'Edit', edit_importer_path(@importer) %> |
+
+    <%= link_to 'Edit', edit_importer_path(@importer) %>
+    |
     <%= link_to 'Back', importers_path %><br /><br />
 
     <% if @importer.validate_only == true %>
-        <div class='pull-left'>
-          <%= button_to 'Continue', importer_continue_path(@importer), method: :put, class: 'btn btn-primary' %>
-        </div>
-        <div class='pull-right'>
-          <%= button_to 'Discard', @importer, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-primary' %>
-        </div>
+      <div class='pull-left'>
+        <%= button_to 'Continue', importer_continue_path(@importer), method: :put, class: 'btn btn-primary' %>
+      </div>
+      <div class='pull-right'>
+        <%= button_to 'Discard', @importer, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-primary' %>
+      </div>
     <% end %>
-
   </div>
 </div>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -114,7 +114,7 @@
         <% end %>
       </tbody>
     </table>
-    <%= page_entries_info(@collection_entries, param_name: :collections_entries_page) %><br />
+    <%= page_entries_info(@collection_entries) %><br />
     <%= paginate(@collection_entries, param_name: :collections_entries_page) %>
 
     <br />
@@ -161,7 +161,7 @@
         <% end %>
       </tbody>
     </table>
-    <%= page_entries_info(@work_entries, param_name: :collections_entries_page) %><br />
+    <%= page_entries_info(@work_entries) %><br />
     <%= paginate(@work_entries, param_name: :work_entries_page) %>
 
     <br />

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -1,5 +1,9 @@
 en:
   bulkrax:
+    admin:
+      sidebar:
+        exporters: Exporters
+        importers: Importers
     exporter:
       labels:
         export_type: Type of Export

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -6,15 +6,19 @@ en:
         importers: Importers
     exporter:
       labels:
-        export_type: Type of Export
-        export_from: Export From
-        limit: Limit
-        export_format: Export Format
-        name: Name
         collection: Collection
-        importer: Importer
-        worktype: Work Type
-        metadata: Metadata Only
-        full: Metadata and Files
-        parser_klass: Parser
+        export_format: Export Format
+        export_from: Export From
+        export_source: Export Source
+        export_type: Type of Export
         field_mapping: Field Mapping
+        full: Metadata and Files
+        importer: Importer
+        limit: Limit
+        metadata: Metadata Only
+        name: Name
+        parser_fields: Parser Fields
+        parser_klass: Parser
+        total_work_entries: Total Works
+        user: User
+        worktype: Work Type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Bulkrax::Engine.routes.draw do
   resources :exporters do
     get :download
+    resources :entries, only: %i[show]
   end
   resources :importers do
     put :continue

--- a/db/migrate/20200326235838_add_status_to_exporters.rb
+++ b/db/migrate/20200326235838_add_status_to_exporters.rb
@@ -1,0 +1,7 @@
+class AddStatusToExporters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bulkrax_exporters, :last_error, :text
+    add_column :bulkrax_exporters, :last_error_at, :datetime
+    add_column :bulkrax_exporters, :last_succeeded_at, :datetime
+  end
+end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200312190638) do
+ActiveRecord::Schema.define(version: 20200326235838) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -62,6 +62,9 @@ ActiveRecord::Schema.define(version: 20200312190638) do
     t.string "export_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "last_error"
+    t.datetime "last_error_at"
+    t.datetime "last_succeeded_at"
     t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 


### PR DESCRIPTION
Update the exporter show page in line with the importer show page (but without the Collections section). 

![Screen Shot 2020-03-26 at 6 13 36 PM](https://user-images.githubusercontent.com/32469930/77711196-8c1cf000-6f8d-11ea-83dd-0285ef3e764b.png)


- [x]  The Exporter show page looks like Importer show page; at the top of the page, all metadata from the Exporter should be shown. At the bottom, there will not be any collections.

- [x]  The Exporter index links through to the Exporter show page from the Exporter name and an `i` icon

- [x] There is a route for `exporter/x/entries/x` 

- [x]  The Entries on the Exporter show page link through to the Entry's show page via `identifier` and `i`con 

- [x]  The Entry show page has a link back to the Exporter (in the same way as the importer entries do)