### PR TITLE
Functional jQuery DataTables on Importer and Exporter index views

### DIFF
--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -17,12 +17,16 @@
               <th scope="col">Name</th>
               <th scope="col">Status</th>
               <th scope="col">Date Exported</th>
+              <th scope="col"></th>
+              <th scope="col"></th>
+              <th scope="col"></th>
+              <th scope="col"></th>
             </tr>
           </thead>
           <tbody>
             <% @exporters.each do |exporter| %>
               <tr>
-                <th scope="row"><%= exporter.name %></th>
+                <th scope="row"><%= link_to exporter.name, exporter_path(exporter) %></th>
                 <td><%= exporter.exporter_runs.last&.exporter_status %></td>
                 <td><%= exporter.created_at %></td>
                 <td>
@@ -30,6 +34,7 @@
                     <%= link_to raw('<span class="glyphicon glyphicon-download"></span>'), exporter_download_path(exporter) %>
                   <% end%>
                 </td>
+                <td><%= link_to raw('<span class="glyphicon glyphicon-info-sign"></span>'), exporter_path(exporter) %></td>
                 <td><%= link_to raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(exporter) %></td>
                 <td><%= link_to raw('<span class="glyphicon glyphicon-remove"></span>'), exporter, method: :delete, data: { confirm: 'Are you sure?' } %></td>
               </tr>
@@ -42,3 +47,21 @@
       <% end %>
   </div>
 </div>
+
+<script>
+  $(function() {
+    $('#DataTables_Table_0').DataTable({
+      destroy: true, /* Reinitialize DataTable with config below */
+      'columnDefs': [
+          { 'orderable': true, 'targets': [0, 1, 2] },
+          { 'orderable': false, 'targets': [3, 4, 5, 6] }
+      ],
+      'language': {
+        'info': 'Showing _START_ to _END_ of _TOTAL_ exporters',
+        'infoEmpty': 'No exporters to show',
+        'infoFiltered': '(filtered from _MAX_ total exporters)',
+        'lengthMenu': 'Show _MENU_ exporters'
+      }
+    })
+  })
+</script>

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -24,6 +24,9 @@
               <th scope="col">Entries Deleted Upstream</th>
               <th scope="col">Total Collection Entries</th>
               <th scope="col">Total Work Entries</th>
+              <th scope="col"></th>
+              <th scope="col"></th>
+              <th scope="col"></th>
             </tr>
           </thead>
           <tbody>
@@ -60,3 +63,21 @@
       <% end %>
   </div>
 </div>
+
+<script>
+  $(function() {
+    $('#DataTables_Table_0').DataTable({
+      destroy: true, /* Reinitialize DataTable with config below */
+      'columnDefs': [
+          { 'orderable': true, 'targets': [...Array(10).keys()] },
+          { 'orderable': false, 'targets': [10, 11, 12] }
+      ],
+      'language': {
+        'info': 'Showing _START_ to _END_ of _TOTAL_ importers',
+        'infoEmpty': 'No importers to show',
+        'infoFiltered': '(filtered from _MAX_ total importers)',
+        'lengthMenu': 'Show _MENU_ importers'
+      }
+    })
+  })
+</script>


### PR DESCRIPTION
Adds the following features to the Importer and Exporter index tables: 

- Limit 

- Search 

- Pagination 

- Sorting (by column) 

As well as customizes the `language` used in the table to avoid confusion (by default, `DataTable` refers to rows as 'entries', which is its own concept in Bulkrax). 

![Image 2020-03-20 at 6 04 22 PM](https://user-images.githubusercontent.com/32469930/77216304-94c97e00-6ad6-11ea-92c9-168285396390.png)
