### PR TITLE
Remove jquery and boostrap sprockets from javascript

### DIFF
--- a/app/assets/javascripts/bulkrax/application.js
+++ b/app/assets/javascripts/bulkrax/application.js
@@ -11,6 +11,4 @@
 // about supported directives.
 //
 
-//= require jquery
-//= require bootstrap-sprockets
 //= require_tree .

--- a/app/assets/javascripts/bulkrax/application.js
+++ b/app/assets/javascripts/bulkrax/application.js
@@ -11,4 +11,6 @@
 // about supported directives.
 //
 
+//= require jquery
+//= require bootstrap-sprockets
 //= require_tree .


### PR DESCRIPTION
Removed the jQuery and Boostrap sprockets includes from application.js file. It was causing javascript errors in my application