### PR TITLE
Fix corrected entries functionality

### DIFF
--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -12,9 +12,10 @@ module Bulkrax
     end
 
     def import(importer, only_updates_since_last_import)
+      importer.only_updates = only_updates_since_last_import || false
       return unless importer.valid_import?
       importer.import_collections
-      importer.import_works(only_updates_since_last_import)
+      importer.import_works
       importer.create_parent_child_relationships unless importer.validate_only
     end
 

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -92,6 +92,7 @@ module Bulkrax
 
     def import_works
       self.save if self.new_record? # Object needs to be saved for statuses
+      self.only_updates ||= false
       parser.create_works
     rescue StandardError => e
       status_info(e)

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -90,9 +90,8 @@ module Bulkrax
       self.parser_fields['replace_files']
     end
 
-    def import_works(only_updates = false)
+    def import_works
       self.save if self.new_record? # Object needs to be saved for statuses
-      self.only_updates = only_updates
       parser.create_works
     rescue StandardError => e
       status_info(e)

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -13,12 +13,12 @@ module Bulkrax
 
     describe 'successful job' do
       it 'calls import_works with false' do
-        expect(importer).to receive(:import_works).with(false)
+        expect(importer).to receive(:import_works)
         importer_job.perform(1)
       end
 
       it 'calls import_works with true if only_updates_since_last_import=true' do
-        expect(importer).to receive(:import_works).with(true)
+        expect(importer).to receive(:import_works)
         importer_job.perform(1, true)
       end
     end
@@ -39,7 +39,7 @@ module Bulkrax
       end
 
       it 'schedules import_works when schedulable?' do
-        expect(importer).to receive(:import_works).with(false)
+        expect(importer).to receive(:import_works)
         expect(ImporterJob).to receive(:set).with(wait_until: 1).and_return(ImporterJob)
         importer_job.perform(1)
       end


### PR DESCRIPTION
Possibly related to #234 ?
When we were testing the csv importer locally, we noticed that the corrected entries function did not seem to be working.  After downloading the failed records, updating the records, and reuploading the csv, the records still failed with the original error messages.  After looking a little more closely, it appears that the records are being parsed during the validation step in the importer job (https://github.com/samvera-labs/bulkrax/blob/master/app/jobs/bulkrax/importer_job.rb#L15) without first setting the only_updates importer attribute.  Since the records are only parsed once (https://github.com/samvera-labs/bulkrax/blob/master/app/parsers/bulkrax/csv_parser.rb#L27), the corrected entries are never used.  I added a line in the importer job to set the only_updates attribute before the validation step and removed the only_updates option from the import_works method.  This seems to have fixed the problem for us.