### PR TITLE
Add admin_set_id to parsed_metadata

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -58,6 +58,7 @@ module Bulkrax
       add_file
       add_visibility
       add_rights_statement
+      add_admin_set_id
       add_collections
       add_local
 

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -38,6 +38,7 @@ module Bulkrax
 
       add_visibility
       add_rights_statement
+      add_admin_set_id
       add_collections
       add_local
 

--- a/app/models/bulkrax/rdf_entry.rb
+++ b/app/models/bulkrax/rdf_entry.rb
@@ -63,6 +63,7 @@ module Bulkrax
       end
       add_visibility
       add_rights_statement
+      add_admin_set_id
       add_collections
       add_local
       self.parsed_metadata['file'] = self.raw_metadata['file']

--- a/app/models/bulkrax/xml_entry.rb
+++ b/app/models/bulkrax/xml_entry.rb
@@ -54,6 +54,7 @@ module Bulkrax
       end
       add_visibility
       add_rights_statement
+      add_admin_set_id
       add_collections
       self.parsed_metadata['file'] = self.raw_metadata['file']
 

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -52,6 +52,10 @@ module Bulkrax
       self.parsed_metadata['visibility'] = importerexporter.visibility if self.parsed_metadata['visibility'].blank?
     end
 
+    def add_admin_set_id
+      self.parsed_metadata['admin_set_id'] = importerexporter.admin_set_id if self.parsed_metadata['admin_set_id'].blank?
+    end
+
     def add_collections
       return unless find_or_create_collection_ids.present?
       self.parsed_metadata['collections'] = []

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -31,6 +31,7 @@ module Bulkrax
         it 'succeeds' do
           subject.build
           expect(subject.status).to eq('Complete')
+          expect(subject.parsed_metadata['admin_set_id']).to eq 'MyString'
         end
       end
 

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -71,5 +71,19 @@ module Bulkrax
         expect(entry.collection_ids.length).to eq(0)
       end
     end
+
+    context 'with specified admin set' do
+      before do
+        importer.parser_fields['thumbnail_url'] = ''
+      end
+
+      it 'adds admin set id to parsed metadata' do
+        allow(entry).to receive_message_chain(:record, :header, :identifier).and_return("some_identifier")
+        allow(entry).to receive_message_chain(:record, :header, :set_spec).and_return([])
+        allow(entry).to receive_message_chain(:record, :metadata, :children).and_return([])
+        entry.build_metadata
+        expect(entry.parsed_metadata['admin_set_id']).to eq 'MyString'
+      end
+    end
   end
 end

--- a/spec/models/bulkrax/rdf_entry_spec.rb
+++ b/spec/models/bulkrax/rdf_entry_spec.rb
@@ -68,7 +68,7 @@ module Bulkrax
 
         it 'succeeds' do
           subject.build
-          expect(subject.parsed_metadata).to eq("file" => nil, "rights_statement" => [nil], "source" => ["http://example.org/ns/19158"], "title" => ["Test Bag"], "visibility" => "open")
+          expect(subject.parsed_metadata).to eq("file" => nil, "rights_statement" => [nil], "source" => ["http://example.org/ns/19158"], "title" => ["Test Bag"], "visibility" => "open", "admin_set_id" => "MyString")
           expect(subject.status).to eq('Complete')
         end
 

--- a/spec/models/bulkrax/xml_entry_spec.rb
+++ b/spec/models/bulkrax/xml_entry_spec.rb
@@ -96,7 +96,7 @@ module Bulkrax
 
         it 'builds entry' do
           xml_entry.build
-          expect(xml_entry.parsed_metadata).to eq("file" => nil, "rights_statement" => [nil], "source" => ["3456012"], "title" => ["Single XML Entry"], "visibility" => "open")
+          expect(xml_entry.parsed_metadata).to eq("file" => nil, "rights_statement" => [nil], "source" => ["3456012"], "title" => ["Single XML Entry"], "visibility" => "open", "admin_set_id" => "MyString")
         end
 
         it 'does not add unsupported fields' do


### PR DESCRIPTION
Currently, it seems that bulkrax defaults to the default admin set for imported works, ignoring the admin set selected in the form.  I added a method to add the admin set id to the parsed metadata for importers and added tests to verify that the admin set id is captured.  I believe this is related to #216 