### PR TITLE
Imported Collections get a PermissionTemplate with a manager

### DIFF
--- a/app/jobs/bulkrax/import_work_collection_job.rb
+++ b/app/jobs/bulkrax/import_work_collection_job.rb
@@ -27,14 +27,13 @@ module Bulkrax
         user                = ::User.find(entry.importerexporter.user_id)
         collection          = entry.factory.find
         permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: collection.id)
-        
+
         Hyrax::PermissionTemplateAccess.create!(
           permission_template_id: permission_template.id,
           agent_id: user.user_key,
           agent_type: 'user',
           access: 'manage'
         )
-        
 
         collection.reset_access_controls!
       end

--- a/app/jobs/bulkrax/import_work_collection_job.rb
+++ b/app/jobs/bulkrax/import_work_collection_job.rb
@@ -21,21 +21,25 @@ module Bulkrax
     end
     # rubocop:enable Rails/SkipsModelValidations
 
-    def add_user_to_permission_template!(entry)
-      user                = ::User.find(entry.importerexporter.user_id)
-      collection          = entry.factory.find
-      permission_template = Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+    private
 
-      if permission_template.present?
-        Hyrax::PermissionTemplateAccess.create!(
-          permission_template_id: permission_template.id,
-          agent_id: user.email,
-          agent_type: 'user',
-          access: 'manage'
-        )
-      else
-        Hyrax::PermissionTemplate.create!(source_id: collection.id, manage_users: [user])
+      def add_user_to_permission_template!(entry)
+        user                = ::User.find(entry.importerexporter.user_id)
+        collection          = entry.factory.find
+        permission_template = Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+
+        if permission_template.present?
+          Hyrax::PermissionTemplateAccess.create!(
+            permission_template_id: permission_template.id,
+            agent_id: user.user_key,
+            agent_type: 'user',
+            access: 'manage'
+          )
+        else
+          Hyrax::PermissionTemplate.create!(source_id: collection.id, manage_users: [user])
+        end
+
+        collection.reset_access_controls!
       end
-    end
   end
 end

--- a/app/jobs/bulkrax/import_work_collection_job.rb
+++ b/app/jobs/bulkrax/import_work_collection_job.rb
@@ -26,18 +26,15 @@ module Bulkrax
       def add_user_to_permission_template!(entry)
         user                = ::User.find(entry.importerexporter.user_id)
         collection          = entry.factory.find
-        permission_template = Hyrax::PermissionTemplate.find_by(source_id: collection.id)
-
-        if permission_template.present?
-          Hyrax::PermissionTemplateAccess.create!(
-            permission_template_id: permission_template.id,
-            agent_id: user.user_key,
-            agent_type: 'user',
-            access: 'manage'
-          )
-        else
-          Hyrax::PermissionTemplate.create!(source_id: collection.id, manage_users: [user])
-        end
+        permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: collection.id)
+        
+        Hyrax::PermissionTemplateAccess.create!(
+          permission_template_id: permission_template.id,
+          agent_id: user.user_key,
+          agent_type: 'user',
+          access: 'manage'
+        )
+        
 
         collection.reset_access_controls!
       end


### PR DESCRIPTION
When creating a Collection through the UI, the creator is automatically assigned to the new Collection as a manager through the Collection's PermissionTemplate.

Currently, it seems like imported Collections don't get a PermissionTemplate.

We should create a PermissionTemplate for the imported Collection if one doesn't already exist and add the User who created the Importer as a manager of that Collection.

Resolves #244 