### PR TITLE
Fix exporter solr limits

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -116,7 +116,8 @@ module Bulkrax
     end
 
     def create_from_collection
-      work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source}").map(&:id)
+      collection_works_count = ActiveFedora::SolrService.get("member_of_collection_ids_ssim:#{importerexporter.export_source}", rows: 0)['response']['numFound']
+      work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source}", rows: collection_works_count).map(&:id)
       work_ids.each_with_index do |wid, index|
         break if limit_reached?(limit, index)
         new_entry = find_or_create_entry(entry_class, wid, 'Bulkrax::Exporter')
@@ -125,7 +126,8 @@ module Bulkrax
     end
 
     def create_from_worktype
-      work_ids = ActiveFedora::SolrService.query("has_model_ssim:#{importerexporter.export_source}").map(&:id)
+      work_type_count = ActiveFedora::SolrService.get("has_model_ssim:#{importerexporter.export_source}", rows: 0)['response']['numFound']
+      work_ids = ActiveFedora::SolrService.query("has_model_ssim:#{importerexporter.export_source}", rows: work_type_count).map(&:id)
       work_ids.each_with_index do |wid, index|
         break if limit_reached?(limit, index)
         new_entry = find_or_create_entry(entry_class, wid, 'Bulkrax::Exporter')

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -172,7 +172,7 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-        expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
+        expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_collection
@@ -184,7 +184,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_collection
@@ -197,7 +197,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { ' numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_collection
@@ -212,7 +212,7 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-        expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
+        expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_worktype
@@ -224,7 +224,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_worktype
@@ -237,7 +237,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_worktype

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -172,6 +172,7 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+        expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_collection
@@ -183,6 +184,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_collection
@@ -195,6 +197,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_collection
@@ -209,6 +212,7 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+        expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_worktype
@@ -220,6 +224,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_worktype
@@ -232,6 +237,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return({'response'=>{'numFound'=>'2'}})
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_worktype


### PR DESCRIPTION
We have noticed that collection and work type exports seemed to be limited to 10 even with a form limit of 0 or blank.  The `ActiveFedora::SolrService.query` method uses the solr default limit of 10 unless the `rows` parameter is used, so I added a `ActiveFedora::SolrService.get` query to find the expected number of items and used that value with the `rows` parameter.