### PR TITLE
Add row param to solr queries for exports

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -116,7 +116,7 @@ module Bulkrax
     end
 
     def create_from_collection
-      work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source}").map(&:id)
+      work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source}", rows: 2_000_000_000).map(&:id)
       work_ids.each_with_index do |wid, index|
         break if limit_reached?(limit, index)
         new_entry = find_or_create_entry(entry_class, wid, 'Bulkrax::Exporter')
@@ -125,7 +125,7 @@ module Bulkrax
     end
 
     def create_from_worktype
-      work_ids = ActiveFedora::SolrService.query("has_model_ssim:#{importerexporter.export_source}").map(&:id)
+      work_ids = ActiveFedora::SolrService.query("has_model_ssim:#{importerexporter.export_source}", rows: 2_000_000_000).map(&:id)
       work_ids.each_with_index do |wid, index|
         break if limit_reached?(limit, index)
         new_entry = find_or_create_entry(entry_class, wid, 'Bulkrax::Exporter')

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -72,7 +72,7 @@ module Bulkrax
 
       it 'returns the path of the partial import file' do
         expect(subject.write_partial_import_file(file))
-          .to eq("tmp/imports/#{importer.id}/failed_corrected_entries.csv")
+            .to eq("tmp/imports/#{importer.id}/failed_corrected_entries.csv")
       end
 
       it 'moves the partial import file to the correct path' do
@@ -131,9 +131,9 @@ module Bulkrax
 
       it 'invokes Bulkrax::ExportWorkJob once per non-Collection Entry' do
         expect(ActiveFedora::SolrService)
-          .to receive(:query)
-          .and_return([{ id: SecureRandom.alphanumeric(9) }])
-          .exactly(2).times
+            .to receive(:query)
+                    .and_return([{ id: SecureRandom.alphanumeric(9) }])
+                    .exactly(2).times
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_importer
       end
@@ -143,9 +143,9 @@ module Bulkrax
 
         it 'invokes Bulkrax::ExportWorkJob once' do
           expect(ActiveFedora::SolrService)
-            .to receive(:query)
-            .and_return([{ id: SecureRandom.alphanumeric(9) }])
-            .exactly(1).times
+              .to receive(:query)
+                      .and_return([{ id: SecureRandom.alphanumeric(9) }])
+                      .exactly(1).times
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_importer
         end
@@ -156,9 +156,9 @@ module Bulkrax
 
         it 'invokes Bulkrax::ExportWorkJob once per non-Collection Entry' do
           expect(ActiveFedora::SolrService)
-            .to receive(:query)
-            .and_return([{ id: SecureRandom.alphanumeric(9) }])
-            .exactly(2).times
+              .to receive(:query)
+                      .and_return([{ id: SecureRandom.alphanumeric(9) }])
+                      .exactly(2).times
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_importer
         end
@@ -172,6 +172,7 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+        expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_collection
@@ -183,6 +184,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_collection
@@ -195,6 +197,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { ' numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_collection
@@ -209,6 +212,7 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+        expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_worktype
@@ -220,6 +224,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_worktype
@@ -232,6 +237,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
+          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_worktype

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -72,7 +72,7 @@ module Bulkrax
 
       it 'returns the path of the partial import file' do
         expect(subject.write_partial_import_file(file))
-            .to eq("tmp/imports/#{importer.id}/failed_corrected_entries.csv")
+          .to eq("tmp/imports/#{importer.id}/failed_corrected_entries.csv")
       end
 
       it 'moves the partial import file to the correct path' do
@@ -131,9 +131,9 @@ module Bulkrax
 
       it 'invokes Bulkrax::ExportWorkJob once per non-Collection Entry' do
         expect(ActiveFedora::SolrService)
-            .to receive(:query)
-                    .and_return([{ id: SecureRandom.alphanumeric(9) }])
-                    .exactly(2).times
+          .to receive(:query)
+          .and_return([{ id: SecureRandom.alphanumeric(9) }])
+          .exactly(2).times
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_importer
       end
@@ -143,9 +143,9 @@ module Bulkrax
 
         it 'invokes Bulkrax::ExportWorkJob once' do
           expect(ActiveFedora::SolrService)
-              .to receive(:query)
-                      .and_return([{ id: SecureRandom.alphanumeric(9) }])
-                      .exactly(1).times
+            .to receive(:query)
+            .and_return([{ id: SecureRandom.alphanumeric(9) }])
+            .exactly(1).times
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_importer
         end
@@ -156,9 +156,9 @@ module Bulkrax
 
         it 'invokes Bulkrax::ExportWorkJob once per non-Collection Entry' do
           expect(ActiveFedora::SolrService)
-              .to receive(:query)
-                      .and_return([{ id: SecureRandom.alphanumeric(9) }])
-                      .exactly(2).times
+            .to receive(:query)
+            .and_return([{ id: SecureRandom.alphanumeric(9) }])
+            .exactly(2).times
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_importer
         end
@@ -172,7 +172,6 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-        expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_collection
@@ -184,7 +183,6 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_collection
@@ -197,7 +195,6 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { ' numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_collection
@@ -212,7 +209,6 @@ module Bulkrax
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
         work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-        expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
         expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_from_worktype
@@ -224,7 +220,6 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_from_worktype
@@ -237,7 +232,6 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
           work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:get).and_return('response' => { 'numFound' => '2' })
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
           parser.create_from_worktype


### PR DESCRIPTION
We have noticed that collection and work type exports seemed to be limited to 10 even with a form limit of 0 or blank. The ActiveFedora::SolrService.query method uses the solr default limit of 10 unless the rows parameter is used, so I added a rows parameter with a value close to the maximum allowed integer value.