### PR TITLE
Fix file paths for Zip CSV imports 

### DIFF
--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -24,9 +24,9 @@ module Bulkrax
     end
 
     def unzip_imported_file(parser)
-      if parser.file? && parser.zip?
-        parser.unzip(parser.parser_fields['import_file_path'])
-      end
+      return unless parser.file? && parser.zip?
+
+      parser.unzip(parser.parser_fields['import_file_path'])
     end
 
     def update_current_run_counters(importer)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -79,11 +79,15 @@ module Bulkrax
       self.parsed_metadata['model'] = hyrax_record.has_model.first
       build_mapping_metadata
 
+      # TODO: fix the "send" parameter in the conditional below
+      # currently it returns: "NoMethodError - undefined method 'bulkrax_identifier' for #<Collection:0x00007fbe6a3b4248>"
       if mapping['collection']&.[]('join')
-        self.parsed_metadata['collection'] = hyrax_record.member_of_collections.map { |c| c.send(work_identifier)&.first }.compact.uniq.join(';')
+        self.parsed_metadata['collection'] = hyrax_record.member_of_collection_ids.join('; ')
+        #   self.parsed_metadata['collection'] = hyrax_record.member_of_collections.map { |c| c.send(work_identifier)&.first }.compact.uniq.join(';')
       else
         hyrax_record.member_of_collections.each_with_index do |collection, i|
-          self.parsed_metadata["collection_#{i + 1}"] = collection.send(work_identifier)&.first
+          self.parsed_metadata["collection_#{i + 1}"] = collection.id
+          #     self.parsed_metadata["collection_#{i + 1}"] = collection.send(work_identifier)&.first
         end
       end
 

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -97,7 +97,11 @@ module Bulkrax
     end
 
     def current_run
-      @current_run ||= self.importer_runs.create!
+      @current_run ||= if file? && zip?
+                         self.importer_runs.create!
+                       else
+                         self.importer_runs.create!(total_work_entries: self.limit || parser.total, total_collection_entries: parser.collections_total)
+                       end
     end
 
     def last_run

--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -38,5 +38,15 @@ module Bulkrax
     def key_without_numbers(key)
       key.gsub(/_\d+/, '').sub(/^\d+_/, '')
     end
+
+    # Is this a file?
+    def file?
+      parser_fields&.[]('import_file_path') && File.file?(parser_fields['import_file_path'])
+    end
+
+    # Is this a zip file?
+    def zip?
+      parser_fields&.[]('import_file_path') && MIME::Types.type_for(parser_fields['import_file_path']).include?('application/zip')
+    end
   end
 end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -289,11 +289,9 @@ module Bulkrax
     private
 
     def real_import_file_path
-      if file? && zip?
-        return importer_unzip_path
-      else
-        parser_fields['import_file_path']
-      end
+      return importer_unzip_path if file? && zip?
+
+      parser_fields['import_file_path']
     end
   end
 end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -274,11 +274,9 @@ module Bulkrax
     # We expect a single CSV at the top level of the zip in the CSVParser
     # but we are willing to go look for it if need be
     def real_import_file_path
-      if file? && zip?
-        return Dir["#{importer_unzip_path}/**/*.csv"].first
-      else
-        parser_fields['import_file_path']
-      end
+      return Dir["#{importer_unzip_path}/**/*.csv"].first if file? && zip?
+
+      parser_fields['import_file_path']
     end
   end
 end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -177,7 +177,7 @@ module Bulkrax
         @total = 0
       end
       return @total
-    rescue StandardErrorr
+    rescue StandardError
       @total = 0
     end
 

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -21,6 +21,14 @@ module Bulkrax
         expect(importer).to receive(:import_works)
         importer_job.perform(1, true)
       end
+
+      it 'updates the current run counters' do
+        expect(importer).to receive(:import_works)
+        importer_job.perform(1)
+
+        expect(importer.current_run.total_work_entries).to eq(10)
+        expect(importer.current_run.total_collection_entries).to eq(421)
+      end
     end
 
     describe 'failed job' do

--- a/spec/models/bulkrax/importer_spec.rb
+++ b/spec/models/bulkrax/importer_spec.rb
@@ -21,14 +21,20 @@ module Bulkrax
     end
 
     describe 'importer run' do
-      before do
-        allow_any_instance_of(Bulkrax::OaiDcParser).to receive(:collections_total).and_return(1)
-      end
-
-      it 'creates an ImporterRun with total_work_entries set to the value of limit' do
+      it 'finds or creates a new ImporterRun' do
         importer.current_run
-        expect(importer.current_run.total_work_entries).to eq(10)
-        expect(importer.current_run.total_collection_entries).to eq(1)
+        expect(importer.current_run).to have_attributes(
+          total_work_entries: 0,
+          enqueued_records: 0,
+          processed_records: 0,
+          deleted_records: 0,
+          failed_records: 0,
+          processed_collections: 0,
+          failed_collections: 0,
+          total_collection_entries: 0,
+          processed_children: 0,
+          failed_children: 0,
+        )
       end
     end
 

--- a/spec/models/bulkrax/importer_spec.rb
+++ b/spec/models/bulkrax/importer_spec.rb
@@ -33,7 +33,7 @@ module Bulkrax
           failed_collections: 0,
           total_collection_entries: 0,
           processed_children: 0,
-          failed_children: 0,
+          failed_children: 0
         )
       end
     end

--- a/spec/models/bulkrax/importer_spec.rb
+++ b/spec/models/bulkrax/importer_spec.rb
@@ -21,20 +21,14 @@ module Bulkrax
     end
 
     describe 'importer run' do
-      it 'finds or creates a new ImporterRun' do
+      before do
+        allow_any_instance_of(Bulkrax::OaiDcParser).to receive(:collections_total).and_return(1)
+      end
+
+      it 'creates an ImporterRun with total_work_entries set to the value of limit' do
         importer.current_run
-        expect(importer.current_run).to have_attributes(
-          total_work_entries: 0,
-          enqueued_records: 0,
-          processed_records: 0,
-          deleted_records: 0,
-          failed_records: 0,
-          processed_collections: 0,
-          failed_collections: 0,
-          total_collection_entries: 0,
-          processed_children: 0,
-          failed_children: 0
-        )
+        expect(importer.current_run.total_work_entries).to eq(10)
+        expect(importer.current_run.total_collection_entries).to eq(1)
       end
     end
 


### PR DESCRIPTION
Only extract zip files once, instead of attempting to extract them for every Entry created