### PR TITLE
Add guards to new migrations

### DIFF
--- a/app/parsers/bulkrax/xml_parser.rb
+++ b/app/parsers/bulkrax/xml_parser.rb
@@ -67,14 +67,14 @@ module Bulkrax
     # Otherwise return all xml files in the given folder
     def metadata_paths
       @metadata_paths ||=
-          if file? && MIME::Types.type_for(import_file_path).include?('application/xml')
-            [import_file_path]
-          else
-            file_paths.select do |f|
-              MIME::Types.type_for(f).include?('application/xml') &&
-                  f.include?("import_#{importerexporter.id}")
-            end
+        if file? && MIME::Types.type_for(import_file_path).include?('application/xml')
+          [import_file_path]
+        else
+          file_paths.select do |f|
+            MIME::Types.type_for(f).include?('application/xml') &&
+              f.include?("import_#{importerexporter.id}")
           end
+        end
     end
 
     def create_works

--- a/db/migrate/20201106014204_add_date_filter_and_status_to_bulkrax_exporters.rb
+++ b/db/migrate/20201106014204_add_date_filter_and_status_to_bulkrax_exporters.rb
@@ -1,7 +1,7 @@
 class AddDateFilterAndStatusToBulkraxExporters < ActiveRecord::Migration[5.1]
   def change
-    add_column :bulkrax_exporters, :start_date, :date
-    add_column :bulkrax_exporters, :finish_date, :date
-    add_column :bulkrax_exporters, :work_visibility, :string
+    add_column :bulkrax_exporters, :start_date, :date unless column_exists?(:bulkrax_exporters, :start_date)
+    add_column :bulkrax_exporters, :finish_date, :date unless column_exists?(:bulkrax_exporters, :finish_date)
+    add_column :bulkrax_exporters, :work_visibility, :string unless column_exists?(:bulkrax_exporters, :work_visibility)
   end
 end

--- a/db/migrate/20201117220007_add_workflow_status_to_bulkrax_exporter.rb
+++ b/db/migrate/20201117220007_add_workflow_status_to_bulkrax_exporter.rb
@@ -1,5 +1,5 @@
 class AddWorkflowStatusToBulkraxExporter < ActiveRecord::Migration[5.1]
   def change
-    add_column :bulkrax_exporters, :workflow_status, :string
+    add_column :bulkrax_exporters, :workflow_status, :string unless column_exists?(:bulkrax_exporters, :workflow_status)
   end
 end


### PR DESCRIPTION
Running migrations are throwing errors: 

```sh
PG::DuplicateColumn: ERROR:  column "start_date" of relation "bulkrax_exporters" already exists
: ALTER TABLE "bulkrax_exporters" ADD "start_date" date excluded from capture: DSN not set
```

Guard to prevent these errors. 