### PR TITLE
Correctly calculate totals for zipped csv imports

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -152,7 +152,7 @@ module Bulkrax
     def total
       if importer?
         # @total ||= `wc -l #{parser_fields['import_file_path']}`.to_i - 1
-        @total ||= `grep -vc ^$ #{parser_fields['import_file_path']}`.to_i - 1
+        @total ||= `grep -vc ^$ #{real_import_file_path}`.to_i - 1
       elsif exporter?
         @total ||= importerexporter.entries.count
       else


### PR DESCRIPTION
In the case where a zip file is being imported, total was counting the lines in the zip file, not the contained .csv file.