### PR TITLE
Use mapping for :file in CsvParser#file_paths

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -208,13 +208,15 @@ module Bulkrax
       File.join(importerexporter.exporter_export_path, 'export.csv')
     end
 
-    # Retrieve file paths for [:file] in records
+    # Retrieve file paths for [:file] mapping in records
     #  and check all listed files exist.
     def file_paths
       raise StandardError, 'No records were found' if records.blank?
       @file_paths ||= records.map do |r|
-        next unless r[:file].present?
-        r[:file].split(/\s*[:;|]\s*/).map do |f|
+        file_mapping = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from).first.to_sym
+        next unless r[file_mapping].present?
+
+        r[file_mapping].split(/\s*[:;|]\s*/).map do |f|
           file = File.join(path_to_files, f.tr(' ', '_'))
           if File.exist?(file) # rubocop:disable Style/GuardClause
             file

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -213,7 +213,7 @@ module Bulkrax
     def file_paths
       raise StandardError, 'No records were found' if records.blank?
       @file_paths ||= records.map do |r|
-        file_mapping = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from).first.to_sym
+        file_mapping = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from)&.first&.to_sym || :file
         next unless r[file_mapping].present?
 
         r[file_mapping].split(/\s*[:;|]\s*/).map do |f|


### PR DESCRIPTION
Use the field mapping for `:file` in `CsvParser#file_paths`. If `:file` has been mapped to a different import column name, `#file_paths` always returns an empty array.

There are almost certainly more places where fields are referenced directly instead of using the field mapping.