### PR TITLE
make sure different versions of an importer with the same id do not cross-contaminate

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -123,15 +123,17 @@ module Bulkrax
 
     # If the import data is zipped, unzip it to this path
     def importer_unzip_path
-      @importer_unzip_path ||= File.join(ENV.fetch('RAILS_TMP', Dir.tmpdir).to_s, "import_#{self.id}_#{self.importer_runs.last.id}")
-    rescue
-      @importer_unzip_path ||= File.join(ENV.fetch('RAILS_TMP', Dir.tmpdir).to_s, "import_#{self.id}_0")
+      @importer_unzip_path ||= File.join(Bulkrax.import_path, "import_#{path_string}")
     end
 
     def errored_entries_csv_path
-      @errored_entries_csv_path ||= File.join(ENV.fetch('RAILS_TMP', Dir.tmpdir).to_s, "import_#{self.id}_#{self.importer_runs.last.id}_errored_entries.csv")
+      @errored_entries_csv_path ||= File.join(Bulkrax.import_path, "import_#{path_string}_errored_entries.csv")
+    end
+
+    def path_string
+      "#{self.id}_#{self.created_at.strftime('%Y%m%d%H%M%S')}_#{self.importer_runs.last.id}"
     rescue
-      @errored_entries_csv_path ||= File.join(ENV.fetch('RAILS_TMP', Dir.tmpdir).to_s, "import_#{self.id}_0_errored_entries.csv")
+      "#{self.id}_#{self.created_at.strftime('%Y%m%d%H%M%S')}"
     end
   end
 end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -75,9 +75,9 @@ module Bulkrax
     # Path where we'll store the import metadata and files
     #  this is used for uploaded and cloud files
     def path_for_import
-      path = File.join(Bulkrax.import_path, importerexporter.id.to_s)
-      FileUtils.mkdir_p(path) unless File.exist?(path)
-      path
+      @path_for_import = File.join(Bulkrax.import_path, importerexporter.path_string)
+      FileUtils.mkdir_p(@path_for_import) unless File.exist?(@path_for_import)
+      @path_for_import
     end
 
     # Optional, only used by certain parsers

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -265,6 +265,7 @@ module Bulkrax
     end
 
     def setup_errored_entries_file
+      FileUtils.mkdir_p(File.dirname(importerexporter.errored_entries_csv_path))
       File.open(importerexporter.errored_entries_csv_path, 'w')
     end
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -72,7 +72,7 @@ module Bulkrax
 
       it 'returns the path of the partial import file' do
         expect(subject.write_partial_import_file(file))
-          .to eq("tmp/imports/#{importer.id}/failed_corrected_entries.csv")
+          .to eq("tmp/imports/#{importer.id}_#{importer.created_at.strftime('%Y%m%d%H%M%S')}/failed_corrected_entries.csv")
       end
 
       it 'moves the partial import file to the correct path' do
@@ -175,6 +175,8 @@ module Bulkrax
       end
 
       it 'writes a CSV file to the correct location' do
+        # ensure path is clean before we start
+        FileUtils.rm_rf(import_file_path)
         expect(File.exist?(import_file_path)).to eq(false)
 
         subject.write_errored_entries_file


### PR DESCRIPTION
Especially important in multi-tenant, but also relevant if db is reset