### PR TITLE
Support csv headers with #_value or value_#

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -44,16 +44,24 @@ module Bulkrax
       Bulkrax.parent_child_field_mapping[self.to_s] || 'children'
     end
 
+    def keys_without_numbers(keys)
+      keys.map { |key| key_without_numbers(key) }
+    end
+
+    def key_without_numbers(key)
+      key.sub(/_\d+/, '').sub(/^\d+_/, '')
+    end
+
     def build_metadata
       raise StandardError, 'Record not found' if record.nil?
 
-      raise StandardError, "Missing required elements, required elements are: #{importerexporter.parser.required_elements.join(', ')}" unless importerexporter.parser.required_elements?(record.keys)
+      raise StandardError, "Missing required elements, required elements are: #{importerexporter.parser.required_elements.join(', ')}" unless importerexporter.parser.required_elements?(keys_without_numbers(record.keys))
 
       self.parsed_metadata = {}
       self.parsed_metadata[Bulkrax.system_identifier_field] = [record['source_identifier']]
       record.each do |key, value|
         next if key == 'collection'
-        add_metadata(key, value)
+        add_metadata(key_without_numbers(key), value)
       end
 
       add_file

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -61,7 +61,6 @@ module Bulkrax
         end
       end
 
-
       context 'with files containing spaces' do
         before do
           allow_any_instance_of(ObjectFactory).to receive(:run!)

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -35,6 +35,33 @@ module Bulkrax
         end
       end
 
+      context 'with enumerated columns appended' do
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:record).and_return('source_identifier' => '2', 'title_1' => 'some title', 'title_2' => 'another title')
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_metadata
+          expect(metadata['title']).to include('some title')
+          expect(metadata['title']).to include('another title')
+        end
+      end
+
+      context 'with enumerated columns prepended' do
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:record).and_return('source_identifier' => '2', '1_title' => 'some title', '2_title' => 'another title')
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_metadata
+          expect(metadata['title']).to include('some title')
+          expect(metadata['title']).to include('another title')
+        end
+      end
+
+
       context 'with files containing spaces' do
         before do
           allow_any_instance_of(ObjectFactory).to receive(:run!)


### PR DESCRIPTION
for example title_1, title_2, title_3 all get parsed as title. The same is true with 1_title, 2_title (but not red_title, blue_title)

coauthor: <alisha@notch8.com>,<sara@notch8.com>