### PR TITLE
objects-in-csv-revision

### DIFF
--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -46,6 +46,13 @@ module Bulkrax
           multiple_metadata?(name, node_name, node_content, object)
         else
           Rails.logger.info("Bulkrax Column automatically matched #{node_name}, #{node_content}")
+          # if object
+          #   puts "node_content >> #{node_content}"
+          #   puts "object >> #{object}"
+          #   puts "parsed_metadata >> #{parsed_metadata}"
+          #   puts "name >> #{name}"
+            # debugger
+          # end
 
           node_content = node_content.content if node_content.is_a?(Nokogiri::XML::NodeSet)
           next parsed_metadata[object][name] = Array.wrap(node_content.to_s.strip).join('; ') if object && node_content
@@ -93,6 +100,14 @@ module Bulkrax
     def multiple_metadata?(name, node_name, node_content, object = false)
       Rails.logger.info("Bulkrax Column automatically matched #{node_name}, #{node_content}")
       node_content = node_content.content if node_content.is_a?(Nokogiri::XML::NodeSet)
+      # if object
+      #   puts "name >> #{name}"
+      #   puts "node_name >> #{node_name}"
+      #   puts "node_content >> #{node_content}"
+      #   puts "object >> #{object}"
+      #   puts "parsed_metadata >> #{parsed_metadata}"
+        # debugger
+      # end
 
       if object
         parsed_metadata[object][name] ||= []
@@ -106,6 +121,16 @@ module Bulkrax
     def matched_metadata?(matcher, multiple, name, node_content, object = false)
       result = matcher.result(self, node_content)
       return unless result
+      # if object
+      #   puts "result >> #{result}"
+      #   puts "matcher >> #{matcher.inspect}"
+      #   puts "multiple >> #{multiple}"
+      #   puts "name >> #{name}"
+      #   puts "node_content >> #{node_content}"
+      #   puts "object >> #{object}"
+      #   puts "parsed_metadata >> #{parsed_metadata}"
+        # debugger
+      # end
 
       if object
         if multiple

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -99,6 +99,22 @@ module Bulkrax
 
         it 'succeeds' do
           metadata = subject.build_metadata
+          # puts "METADATA>> #{metadata}"
+          # metadata = {
+          #   "source"=>["2"],
+          #   "title"=>["some title"],
+          #   "creator"=>{
+          #     "creator_first_name"=>"Fake",
+          #     "creator_last_name"=>"Fakerson",
+          #     "creator_position"=>"Leader, Jester, Queen",
+          #     "creator_language"=>"English"
+          #   },
+          #   "file"=>[],
+          #   "visibility"=>"open",
+          #   "rights_statement"=>[nil],
+          #   "admin_set_id"=>"MyString"
+          # }
+
           expect(metadata['creator']['creator_first_name']).to eq('Fake')
           expect(metadata['creator']['creator_last_name']).to eq('Fakerson')
           expect(metadata['creator']['creator_position']).to include('Leader', 'Jester', 'Queen')


### PR DESCRIPTION
# Summary
currently the object metadata is coming back as only an object. when I compared that against the data that's returned from the british library ui when multiple creators are added, it's not a simple object though.

#### current implementation per the spec
```
{
  "source"=>["2"],
  "title"=>["some title"],
  "creator"=>{
    "creator_first_name"=>"Fake",
    "creator_last_name"=>"Fakerson",
    "creator_position"=>"Leader, Jester, Queen",
    "creator_language"=>"English"
  },
  "file"=>[],
  "visibility"=>"open",
  "rights_statement"=>[nil],
  "admin_set_id"=>"MyString"
}
```

#### intended implementation per the UI
"creator" is an object (or series of objects), wrapped in an array, wrapped in a string, wrapped in another array
```
{
  "source"=>["2"],
  "title"=>["some title"],
  "creator"=> ["[
    {
      "creator_given_name":"Creator given name 1",
      "creator_family_name":"Creator family name 1",
      "creator_name_type":"Personal",
      "creator_orcid":"reator1",
      "creator_isni":"reator1",
      "creator_position":"1",
      "creator_institutional_relationship":["Staff member"]
    }
  ]"],
  "file"=>[],
  "visibility"=>"open",
  "rights_statement"=>[nil],
  "admin_set_id"=>"MyString"
}
```