### PR TITLE
Remove last_error, up database text field size

### DIFF
--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -14,12 +14,10 @@ module Bulkrax
     belongs_to :importerexporter, polymorphic: true
     alias importer importerexporter
     alias exporter importerexporter
-    has_many :statuses, as: :statusable, dependent: :destroy
 
     serialize :parsed_metadata, JSON
     # Do not serialize raw_metadata as so we can support xml or other formats
     serialize :collection_ids, Array
-    serialize :last_error, JSON
 
     paginates_per 5
 

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -6,12 +6,10 @@ module Bulkrax
 
     serialize :parser_fields, JSON
     serialize :field_mapping, JSON
-    serialize :last_error, JSON
 
     belongs_to :user
     has_many :exporter_runs, dependent: :destroy, foreign_key: 'exporter_id'
     has_many :entries, as: :importerexporter, dependent: :destroy
-    has_many :statuses, as: :statusable, dependent: :destroy
 
     validates :name, presence: true
     validates :parser_klass, presence: true

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -9,12 +9,10 @@ module Bulkrax
 
     serialize :parser_fields, JSON
     serialize :field_mapping, JSON
-    serialize :last_error, JSON
 
     belongs_to :user
     has_many :importer_runs, dependent: :destroy, foreign_key: 'importer_id'
     has_many :entries, as: :importerexporter, dependent: :destroy
-    has_many :statuses, as: :statusable, dependent: :destroy
 
     validates :name, presence: true
     validates :admin_set_id, presence: true

--- a/app/models/bulkrax/status.rb
+++ b/app/models/bulkrax/status.rb
@@ -8,5 +8,18 @@ module Bulkrax
 
     scope :for_importers, -> { where(statusable_type: 'Bulkrax::Importer') }
     scope :for_exporters, -> { where(statusable_type: 'Bulkrax::Exporter') }
+
+    scope :latest_by_statusable, -> { joins(latest_by_statusable_subtable.join_sources) }
+
+    def self.latest_by_statusable_subtable
+      status_table = self.arel_table
+      latest_status_query = status_table.project(status_table[:statusable_id],
+                                                 status_table[:statusable_type],
+                                                 status_table[:id].maximum.as("latest_status_id")).group(status_table[:statusable_id], status_table[:statusable_type])
+
+      latest_status_table = Arel::Table.new(latest_status_query).alias(:latest_status)
+      status_table.join(latest_status_query.as(latest_status_table.name.to_s), Arel::Nodes::InnerJoin)
+                  .on(status_table[:id].eq(latest_status_table[:latest_status_id]))
+    end
   end
 end

--- a/app/models/concerns/bulkrax/errored_entries.rb
+++ b/app/models/concerns/bulkrax/errored_entries.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  module ErroredEntries
+    extend ActiveSupport::Concern
+
+    def write_errored_entries_file
+      if @errored_entries.blank?
+        entry_ids = importerexporter.entries.pluck(:id)
+        error_statuses = Bulkrax::Status.latest_by_statusable
+                                        .includes(:statusable)
+                                        .where('bulkrax_statuses.statusable_id IN (?) AND bulkrax_statuses.statusable_type = ? AND status_message = ?', entry_ids, 'Bulkrax::Entry', 'Failed')
+        @errored_entries = error_statuses.map(&:statusable)
+      end
+      return unless @errored_entries.present?
+
+      file = setup_errored_entries_file
+      headers = import_fields
+      file.puts(headers.to_csv)
+      @errored_entries.each do |ee|
+        row = build_errored_entry_row(headers, ee)
+        file.puts(row)
+      end
+      file.close
+      true
+    end
+
+    def build_errored_entry_row(headers, errored_entry)
+      row = {}
+      # Ensure each header has a value, even if it's just an empty string
+      headers.each do |h|
+        row.merge!("#{h}": nil)
+      end
+      # Match each value to its corresponding header
+      row.merge!(errored_entry.raw_metadata.symbolize_keys)
+
+      row.values.to_csv
+    end
+
+    def setup_errored_entries_file
+      FileUtils.mkdir_p(File.dirname(importerexporter.errored_entries_csv_path))
+      File.open(importerexporter.errored_entries_csv_path, 'w')
+    end
+  end
+end

--- a/app/models/concerns/bulkrax/status_info.rb
+++ b/app/models/concerns/bulkrax/status_info.rb
@@ -3,6 +3,15 @@ module Bulkrax
   module StatusInfo
     extend ActiveSupport::Concern
 
+    included do
+      has_many :statuses, as: :statusable, dependent: :destroy
+      has_one :latest_status,
+              -> { merge(Status.latest_by_statusable) },
+              as: :statusable,
+              class_name: "Bulkrax::Status",
+              inverse_of: :statusable
+    end
+
     def current_status
       last_status = self.statuses.last
       last_status if last_status && last_status.runnable == last_run

--- a/db/migrate/20210806044408_remove_unused_last_error.rb
+++ b/db/migrate/20210806044408_remove_unused_last_error.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedLastError < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :bulkrax_entries, :last_error
+    remove_column :bulkrax_exporters, :last_error
+    remove_column :bulkrax_importers, :last_error
+  end
+end

--- a/db/migrate/20210806065737_increase_text_sizes.rb
+++ b/db/migrate/20210806065737_increase_text_sizes.rb
@@ -1,0 +1,12 @@
+class IncreaseTextSizes < ActiveRecord::Migration[5.1]
+  def change
+    change_column :bulkrax_entries, :raw_metadata, :text, limit: 16777215
+    change_column :bulkrax_entries, :parsed_metadata, :text, limit: 16777215
+    change_column :bulkrax_exporters, :parser_fields, :text, limit: 16777215
+    change_column :bulkrax_exporters, :field_mapping, :text, limit: 16777215
+    change_column :bulkrax_importers, :parser_fields, :text, limit: 16777215
+    change_column :bulkrax_importers, :field_mapping, :text, limit: 16777215
+    change_column :bulkrax_importer_runs, :invalid_records, :text, limit: 16777215
+    change_column :bulkrax_statuses, :error_backtrace, :text, limit: 16777215
+  end
+end

--- a/spec/factories/bulkrax/statuses.rb
+++ b/spec/factories/bulkrax/statuses.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :bulkrax_status, class: 'Status' do
+  factory :bulkrax_status, class: 'Bulkrax::Status' do
     status_message { "MyString" }
     error_class { "MyString" }
     error_message { "MyString" }
-    error_backtrace { "MyText" }
-    statusable_id { 1 }
-    statusable_type { "MyString" }
-    runnable_id { 1 }
-    runnable_type { "MyString" }
+    error_backtrace { ["MyText"] }
+    statusable { build(:bulkrax_entry) }
+    runnable { build(:bulkrax_importer_run) }
   end
 end

--- a/spec/factories/bulkrax_entries.rb
+++ b/spec/factories/bulkrax_entries.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     importerexporter { FactoryBot.build(:bulkrax_importer) }
     raw_metadata { { title: 'Title' } }
     parsed_metadata { {} }
-    last_error { 'failed' }
+    statuses { [association(:bulkrax_status, status_message: 'Failed')] }
   end
 
   factory :bulkrax_rdf_entry, class: 'Bulkrax::RdfEntry' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -181,7 +181,7 @@ module Bulkrax
       let(:importer)         { FactoryBot.create(:bulkrax_importer_csv_failed, entries: [entry_failed, entry_succeeded, entry_collection]) }
       let(:entry_failed)     { FactoryBot.create(:bulkrax_csv_entry_failed, raw_metadata: { title: 'Failed' }) }
       let(:entry_succeeded)  { FactoryBot.create(:bulkrax_csv_entry, raw_metadata: { title: 'Succeeded' }) }
-      let(:entry_collection) { FactoryBot.create(:bulkrax_csv_entry_collection, raw_metadata: { title: 'Collection' }, last_error: 'failed') }
+      let(:entry_collection) { FactoryBot.create(:bulkrax_csv_entry_collection, raw_metadata: { title: 'Collection' }) }
       let(:import_file_path) { importer.errored_entries_csv_path }
 
       it 'returns true' do

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201117220007) do
+ActiveRecord::Schema.define(version: 20210806044408) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 20201117220007) do
     t.text "parsed_metadata"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "last_error"
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
     t.string "importerexporter_type", default: "Bulkrax::Importer"
@@ -62,7 +61,6 @@ ActiveRecord::Schema.define(version: 20201117220007) do
     t.string "export_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "last_error"
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
     t.date "start_date"
@@ -102,7 +100,6 @@ ActiveRecord::Schema.define(version: 20201117220007) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "validate_only"
-    t.text "last_error"
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210806044408) do
+ActiveRecord::Schema.define(version: 20210806065737) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -29,8 +29,8 @@ ActiveRecord::Schema.define(version: 20210806044408) do
     t.string "collection_ids"
     t.string "type"
     t.integer "importerexporter_id"
-    t.text "raw_metadata"
-    t.text "parsed_metadata"
+    t.text "raw_metadata", limit: 16777215
+    t.text "parsed_metadata", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_error_at"
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 20210806044408) do
     t.integer "user_id"
     t.string "parser_klass"
     t.integer "limit"
-    t.text "parser_fields"
-    t.text "field_mapping"
+    t.text "parser_fields", limit: 16777215
+    t.text "field_mapping", limit: 16777215
     t.string "export_source"
     t.string "export_from"
     t.string "export_type"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20210806044408) do
     t.integer "total_collection_entries", default: 0
     t.integer "processed_children", default: 0
     t.integer "failed_children", default: 0
-    t.text "invalid_records"
+    t.text "invalid_records", limit: 16777215
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 
@@ -95,8 +95,8 @@ ActiveRecord::Schema.define(version: 20210806044408) do
     t.string "frequency"
     t.string "parser_klass"
     t.integer "limit"
-    t.text "parser_fields"
-    t.text "field_mapping"
+    t.text "parser_fields", limit: 16777215
+    t.text "field_mapping", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "validate_only"
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 20210806044408) do
     t.string "status_message"
     t.string "error_class"
     t.string "error_message"
-    t.text "error_backtrace"
+    t.text "error_backtrace", limit: 16777215
     t.integer "statusable_id"
     t.string "statusable_type"
     t.integer "runnable_id"


### PR DESCRIPTION
- We stopped writing last error in order to use the statuses table. There were still some places in the code that used it (and would never pass). @sephirothkod one of these was the "export the errors" for csv parsers.
- We use serialized text fields for storing error backtraces and field sets. These values were potentially too small for some use cases.

Closes #303 