### PR TITLE
ability to fill in missing identifiers during import

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -190,6 +190,19 @@ module Bulkrax
       true
     end
 
+    def record_has_source_identifier(record, _index)
+      if record[source_identifier].blank?
+        if Bulkrax.fill_in_blank_source_identifiers.present?
+          record[source_identifier] = Bulkrax.fill_in_blank_source_identifiers.call
+        else
+          invalid_record("Missing #{source_identifier} for #{record.to_h}\n")
+          false
+        end
+      else
+        true
+      end
+    end
+
     # rubocop:disable Rails/SkipsModelValidations
     def invalid_record(message)
       current_run.invalid_records ||= ""

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -65,10 +65,7 @@ module Bulkrax
 
     def create_works
       records.each_with_index do |record, index|
-        if record[source_identifier].blank?
-          invalid_record("Missing #{source_identifier} for #{record.to_h}\n")
-          next
-        end
+        next unless record_has_source_identifier(record, index)
         break if limit_reached?(limit, index)
 
         seen[record[source_identifier]] = true

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -73,10 +73,7 @@ module Bulkrax
 
     def create_works
       records.each_with_index do |record, index|
-        if record[source_identifier].blank?
-          current_run.invalid_records += "Missing #{source_identifier} for #{record.to_h}\n"
-          next
-        end
+        next unless record_has_source_identifier(record, index)
         break if limit_reached?(limit, index)
 
         seen[record[source_identifier]] = true

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -86,8 +86,12 @@ module Bulkrax
       results.full.each_with_index do |record, index|
         identifier = record.send(source_identifier)
         if identifier.blank?
-          invalid_record("Missing #{source_identifier} for #{record.to_h}\n")
-          next
+          if Bulkrax.fill_in_blank_source_identifiers.present?
+            identifier = Bulkrax.fill_in_blank_source_identifiers.call
+          else
+            invalid_record("Missing #{source_identifier} for #{record.to_h}\n")
+            next
+          end
         end
 
         break if limit_reached?(limit, index)

--- a/app/parsers/bulkrax/xml_parser.rb
+++ b/app/parsers/bulkrax/xml_parser.rb
@@ -79,10 +79,7 @@ module Bulkrax
 
     def create_works
       records.each_with_index do |record, index|
-        if record[source_identifier].blank?
-          invalid_record("Missing #{source_identifier} for #{record.to_h}\n")
-          next
-        end
+        next unless record_has_source_identifier(record, index)
         break if !limit.nil? && index >= limit
 
         seen[record[source_identifier]] = true

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -9,6 +9,7 @@ module Bulkrax
                    :default_work_type,
                    :default_field_mapping,
                    :collection_field_mapping,
+                   :fill_in_blank_source_identifiers,
                    :parent_child_field_mapping,
                    :reserved_properties,
                    :field_mappings,

--- a/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
+++ b/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
@@ -57,7 +57,7 @@ Bulkrax.setup do |config|
   #   config.field_mappings["Bulkrax::OaiDcParser"].each {|key,value| config.field_mappings["Bulkrax::OaiOmekaParser"][key] = value }
 
   # Should Bulkrax make up source identifiers for you? This allow round tripping and download errored entries to still work, but does
-  # mean if you upload the same source record in two differnet files you WILL get duplicates.
+  # mean if you upload the same source record in two different files you WILL get duplicates.
   # for the importer id and the row in the file
   #    config.fill_in_blank_source_identifiers.call = -> { "b-#{importer.id}-#{_index}"}
   # or use a uuid

--- a/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
+++ b/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
@@ -50,10 +50,18 @@ Bulkrax.setup do |config|
   #
   # #   e.g. to add the required source_identifier field
   #   #   config.field_mappings["Bulkrax::CsvParser"]["source_id"] = { from: ["old_source_id"], source_identifier: true  }
+  # If you want Bulkrax to fill in source_identifiers for you, see below
 
   # To duplicate a set of mappings from one parser to another
   #   config.field_mappings["Bulkrax::OaiOmekaParser"] = {}
   #   config.field_mappings["Bulkrax::OaiDcParser"].each {|key,value| config.field_mappings["Bulkrax::OaiOmekaParser"][key] = value }
+
+  # Should Bulkrax make up source identifiers for you? This allow round tripping and download errored entries to still work, but does
+  # mean if you upload the same source record in two differnet files you WILL get duplicates.
+  # for the importer id and the row in the file
+  #    config.fill_in_blank_source_identifiers.call = -> { "b-#{importer.id}-#{_index}"}
+  # or use a uuid
+  #    config.fill_in_blank_source_identifiers.call = -> { SecureRandom.uuid }
 
   # Properties that should not be used in imports/exports. They are reserved for use by Hyrax.
   # config.reserved_properties += ['my_field']

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -46,6 +46,16 @@ module Bulkrax
           expect(subject).to receive(:increment_counters).once
           subject.create_works
         end
+
+        context 'with fill_in_source_identifier set' do
+          it 'fills in the source_identifier if fill_in_source_identifier is set' do
+            expect(subject).to receive(:increment_counters).twice
+            # once for presetn? and once to execture
+            expect(Bulkrax).to receive(:fill_in_blank_source_identifiers).twice.and_return(-> { "4649ee79-7d7a-4df0-86d6-d6865e2925ca" })
+            subject.create_works
+            expect(subject.seen).to include("2", "4649ee79-7d7a-4df0-86d6-d6865e2925ca")
+          end
+        end
       end
 
       context 'with good data' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -50,7 +50,7 @@ module Bulkrax
         context 'with fill_in_source_identifier set' do
           it 'fills in the source_identifier if fill_in_source_identifier is set' do
             expect(subject).to receive(:increment_counters).twice
-            # once for presetn? and once to execture
+            # once for present? and once to execute
             expect(Bulkrax).to receive(:fill_in_blank_source_identifiers).twice.and_return(-> { "4649ee79-7d7a-4df0-86d6-d6865e2925ca" })
             subject.create_works
             expect(subject.seen).to include("2", "4649ee79-7d7a-4df0-86d6-d6865e2925ca")


### PR DESCRIPTION
Adds a new setting to fill in missing source identifiers. The config option takes. a proc, which it will then call in context. Added examples of usage and a warning about duplicates.