### PR TITLE
clean up object factory to use named args

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -9,7 +9,7 @@ module Bulkrax
     attr_reader :attributes, :object, :source_identifier_value, :klass, :replace_files, :update_files, :work_identifier
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(attributes, source_identifier_value, work_identifier, replace_files = false, user = nil, klass = nil, update_files = false)
+    def initialize(attributes:, source_identifier_value:, work_identifier:, replace_files: false, user: nil, klass: nil, update_files: false)
       @attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes)
       @replace_files = replace_files
       @update_files = update_files

--- a/app/jobs/bulkrax/child_relationships_job.rb
+++ b/app/jobs/bulkrax/child_relationships_job.rb
@@ -74,7 +74,12 @@ module Bulkrax
       # This is adding the reverse relatinship, from the child to the parent
       def work_child_collection_parent(work_id)
         attrs = { id: work_id, collections: [{ id: entry&.factory&.find&.id }] }
-        Bulkrax::ObjectFactory.new(attrs, child_works_hash[work_id][entry.parser.source_identifier], entry.parser.work_identifier, false, user, child_works_hash[work_id][:class_name].constantize).run
+        Bulkrax::ObjectFactory.new(attributes: attrs,
+                                   source_identifier_value: child_works_hash[work_id][entry.parser.source_identifier],
+                                   work_identifier: entry.parser.work_identifier,
+                                   replace_files: false,
+                                   user: user,
+                                   klass: child_works_hash[work_id][:class_name].constantize).run
         ImporterRun.find(importer_run_id).increment!(:processed_children)
       rescue StandardError => e
         entry.status_info(e)
@@ -84,7 +89,12 @@ module Bulkrax
       # Collection-Collection membership is added to the as member_ids
       def collection_parent_collection_child(member_ids)
         attrs = { id: entry&.factory&.find&.id, children: member_ids }
-        Bulkrax::ObjectFactory.new(attrs, entry.identifier, entry.parser.work_identifier, false, user, entry.factory_class).run
+        Bulkrax::ObjectFactory.new(attributes: attrs,
+                                   source_identifier_value: entry.identifier,
+                                   work_identifier: entry.parser.work_identifier,
+                                   replace_files: false,
+                                   user: user,
+                                   klass: entry.factory_class).run
         ImporterRun.find(importer_run_id).increment!(:processed_children)
       rescue StandardError => e
         entry.status_info(e)
@@ -98,7 +108,12 @@ module Bulkrax
                   work_members_attributes: member_ids.each.with_index.each_with_object({}) do |(member, index), ids|
                     ids[index] = { id: member }
                   end }
-        Bulkrax::ObjectFactory.new(attrs, entry.identifier, entry.parser.work_identifier, false, user, entry.factory_class).run
+        Bulkrax::ObjectFactory.new(attributes: attrs,
+                                   source_identifier_value: entry.identifier,
+                                   work_identifier: entry.parser.work_identifier,
+                                   replace_files: false,
+                                   user: user,
+                                   klass: entry.factory_class).run
         ImporterRun.find(importer_run_id).increment!(:processed_children)
       rescue StandardError => e
         entry.status_info(e)

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -63,7 +63,13 @@ module Bulkrax
     end
 
     def factory
-      @factory ||= Bulkrax::ObjectFactory.new(self.parsed_metadata, identifier, parser.work_identifier, replace_files, user, factory_class, update_files)
+      @factory ||= Bulkrax::ObjectFactory.new(attributes: self.parsed_metadata,
+                                              source_identifier_value: identifier,
+                                              work_identifier: parser.work_identifier,
+                                              replace_files: replace_files,
+                                              user: user,
+                                              klass: factory_class,
+                                              update_files: update_files)
     end
 
     def factory_class

--- a/spec/jobs/bulkrax/child_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/child_relationships_job_spec.rb
@@ -39,12 +39,12 @@ module Bulkrax
 
       it 'creates the object factory' do
         expect(Bulkrax::ObjectFactory).to receive(:new).with(
-          { id: "work_id", work_members_attributes: { 0 => { id: "another_work_id" } } },
-          'entry_work',
-          :source,
-          false,
-          importer.user,
-          Work
+          attributes: { id: "work_id", work_members_attributes: { 0 => { id: "another_work_id" } } },
+          source_identifier_value: 'entry_work',
+          work_identifier: :source,
+          replace_files: false,
+          user: importer.user,
+          klass: Work
         )
         child_relationship_job.perform(1, [2], 3)
       end
@@ -92,12 +92,12 @@ module Bulkrax
 
       it 'creates the object factory' do
         expect(Bulkrax::ObjectFactory).to receive(:new).with(
-          { collections: [{ id: "collection_id" }], id: "another_work_id" },
-          'csv_entry',
-          :source,
-          false,
-          importer.user,
-          Work
+          attributes: { collections: [{ id: "collection_id" }], id: "another_work_id" },
+          source_identifier_value: 'csv_entry',
+          work_identifier: :source,
+          replace_files: false,
+          user: importer.user,
+          klass: Work
         )
         child_relationship_job.perform(1, [2], 3)
       end
@@ -129,12 +129,12 @@ module Bulkrax
 
       it 'creates the object factory' do
         expect(Bulkrax::ObjectFactory).to receive(:new).with(
-          { children: ["collection_id"], id: "collection_id" },
-          'entry_collection',
-          :source,
-          false,
-          importer.user,
-          Collection
+          attributes: { children: ["collection_id"], id: "collection_id" },
+          source_identifier_value: 'entry_collection',
+          work_identifier: :source,
+          replace_files: false,
+          user: importer.user,
+          klass: Collection
         )
         child_relationship_job.perform(1, [2], 3)
       end


### PR DESCRIPTION
found a couple instances in OD where these were subtly misaligned after recent work. seems like something that's likely to break a lot