### PR TITLE
321 export nested object fields

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -103,8 +103,10 @@ module Bulkrax
         if data.is_a?(ActiveTriples::Relation)
           self.parsed_metadata[key] = data.map { |d| prepare_export_data(d) }.join('; ').to_s unless value[:excluded]
         elsif object_key.present?
-          data = JSON.parse(data.gsub(/[\[\]]/,'').gsub('=>', ':'))
-          self.parsed_metadata[key] = prepare_export_data(data[object_key])
+          gsub_data = data.gsub(/[\[\]]/,'').gsub('=>', ':').gsub("},{","}},{{").split("},{")
+          gsub_data = [gsub_data] if gsub_data.is_a?(String)
+          data = gsub_data.map{ |m| JSON.parse(m) }
+          self.parsed_metadata[key] = prepare_export_data(data.map { |d| d[object_key]}.join('; '))
         else
           self.parsed_metadata[key] = prepare_export_data(data)
         end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -101,7 +101,9 @@ module Bulkrax
         next unless hyrax_record.respond_to?(key.to_s) || object_key.present?
         data = object_key.present? ? hyrax_record.send(value['object']) : hyrax_record.send(key.to_s)
         if object_key.present?
-          data = data.first if data.is_a?(Array) || data.is_a?(ActiveTriples::Relation)
+          data = data.first if data.first && (data.is_a?(Array) || data.is_a?(ActiveTriples::Relation))
+          next self.parsed_metadata[key] = '' if data.empty?
+
           gsub_data = data.gsub(/[\[\]]/,'').gsub('=>', ':').gsub(/},\s?{/,"}},{{").split("},{")
           gsub_data = [gsub_data] if gsub_data.is_a?(String)
           data = gsub_data.map{ |m| JSON.parse(m) }

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -370,6 +370,62 @@ module Bulkrax
           expect(metadata['language']).to eq('english')
         end
       end
+
+      context 'with multiple objects and fields prefixed' do
+        let(:exporter) do
+          FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'id' => { from: ['id'], source_identifier: true },
+                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+                              'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+                            })
+        end
+
+        let(:work_obj) do
+          Work.new(
+            title: ['test'],
+            multiple_objects: [
+              [{
+                'multiple_objects_first_name' => 'Fake',
+                'multiple_objects_last_name' => 'Fakerson',
+                'multiple_objects_position' => 'Leader, Jester, Queen',
+                'multiple_objects_language' => 'english'
+              },
+              {
+                'multiple_objects_first_name' => 'Judge',
+                'multiple_objects_last_name' => 'Hines',
+                'multiple_objects_position' => 'King, Lord, Duke',
+              }].to_s
+            ]
+          )
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return('test123')
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_export_metadata
+          expect(metadata['multiple_objects_first_name']).to eq('Fake; Judge')
+          expect(metadata['multiple_objects_last_name']).to eq('Fakerson; Hines')
+          expect(metadata['multiple_objects_position']).to include('Leader, Jester, Queen; King, Lord, Duke')
+          expect(metadata['multiple_objects_language']).to eq('english; ')
+        end
+      end
+
+      context 'with multiple objects and no fields prefixed' do
+        let(:exporter) do
+          FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'id' => { from: ['id'], source_identifier: true },
+                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+                              'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+                            })
+        end
     end
   end
 end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -460,6 +460,51 @@ module Bulkrax
           expect(metadata['language']).to eq('english; ')
         end
       end
+
+
+      context 'with object fields prefixed and properties with multiple values' do
+        let(:exporter) do
+          FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'id' => { from: ['id'], source_identifier: true },
+                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' },
+                            })
+        end
+
+        let(:work_obj) do
+          Work.new(
+            title: ['test'],
+            multiple_objects: [
+              [{
+                'multiple_objects_first_name' => 'Fake',
+                'multiple_objects_last_name' => 'Fakerson',
+                'multiple_objects_position' => 'Leader, Jester, Queen',
+                'multiple_objects_language' => 'english'
+              },
+              {
+                'multiple_objects_first_name' => 'Judge',
+                'multiple_objects_last_name' => 'Hines',
+                'multiple_objects_position' => 'King, Lord, Duke',
+              }].to_s
+            ]
+          )
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return('test123')
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_export_metadata
+          # expect(metadata['first_name']).to eq('Fake; Judge')
+          # expect(metadata['last_name']).to eq('Fakerson; Hines')
+          # expect(metadata['position']).to include('Leader, Jester, Queen; King, Lord, Duke')
+          # expect(metadata['language']).to eq('english; ')
+        end
+      end
     end
   end
 end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -298,19 +298,20 @@ module Bulkrax
       context 'with object fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'id' => { from: ['id'], source_identifier: true }
                               'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
                               'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
                               'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
                               'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true },
-                              'id' => { from: ['id'], source_identifier: true }
-                            })
+          })
         end
 
         let(:work_obj) do
           Work.new(
             title: ["test"],
             single_object: [{
-              'single_object_first_name' => 'Fake','single_object_last_name' => 'Fakerson',
+              'single_object_first_name' => 'Fake',
+              'single_object_last_name' => 'Fakerson',
               'single_object_position' => 'Leader, Jester, Queen',
               'single_object_language' => 'english'
             }].to_s

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -291,5 +291,46 @@ module Bulkrax
       end
       # rubocop:enable RSpec/ExampleLength
     end
+
+    describe 'reads entry' do
+      subject { described_class.new(importerexporter: exporter) }
+
+      context 'with object fields prefixed' do
+        let(:exporter) do
+          FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+                              'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+                              'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
+                              'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true },
+                              'id' => { from: ['id'], source_identifier: true }
+                            })
+        end
+
+        let(:work_obj) do
+          Work.new(
+            title: ["test"],
+            single_object: [{
+              'single_object_first_name' => 'Fake','single_object_last_name' => 'Fakerson',
+              'single_object_position' => 'Leader, Jester, Queen',
+              'single_object_language' => 'english'
+            }].to_s
+          )
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return("test123")
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_export_metadata
+          expect(metadata['single_object_first_name']).to eq('Fake')
+          expect(metadata['single_object_last_name']).to eq('Fakerson')
+          expect(metadata['single_object_position']).to include('Leader', 'Jester', 'Queen')
+          expect(metadata['single_object_language']).to eq('english')
+        end
+      end
+    end
   end
 end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -426,6 +426,40 @@ module Bulkrax
                               'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
                             })
         end
+
+        let(:work_obj) do
+          Work.new(
+            title: ['test'],
+            multiple_objects: [
+              [{
+                'first_name' => 'Fake',
+                'last_name' => 'Fakerson',
+                'position' => 'Leader, Jester, Queen',
+                'language' => 'english'
+              },
+              {
+                'first_name' => 'Judge',
+                'last_name' => 'Hines',
+                'position' => 'King, Lord, Duke',
+              }].to_s
+            ]
+          )
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return('test123')
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_export_metadata
+          expect(metadata['first_name']).to eq('Fake; Judge')
+          expect(metadata['last_name']).to eq('Fakerson; Hines')
+          expect(metadata['position']).to include('Leader, Jester, Queen; King, Lord, Duke')
+          expect(metadata['language']).to eq('english; ')
+        end
+      end
     end
   end
 end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -298,7 +298,7 @@ module Bulkrax
       context 'with object fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-                              'id' => { from: ['id'], source_identifier: true }
+                              'id' => { from: ['id'], source_identifier: true },
                               'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
                               'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
                               'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
@@ -308,7 +308,7 @@ module Bulkrax
 
         let(:work_obj) do
           Work.new(
-            title: ["test"],
+            title: ['test'],
             single_object: [{
               'single_object_first_name' => 'Fake',
               'single_object_last_name' => 'Fakerson',
@@ -321,7 +321,7 @@ module Bulkrax
         before do
           allow_any_instance_of(ObjectFactory).to receive(:run!)
           allow(subject).to receive(:hyrax_record).and_return(work_obj)
-          allow(work_obj).to receive(:id).and_return("test123")
+          allow(work_obj).to receive(:id).and_return('test123')
         end
 
         it 'succeeds' do
@@ -330,6 +330,44 @@ module Bulkrax
           expect(metadata['single_object_last_name']).to eq('Fakerson')
           expect(metadata['single_object_position']).to include('Leader', 'Jester', 'Queen')
           expect(metadata['single_object_language']).to eq('english')
+        end
+      end
+
+      context 'with object fields and no prefix' do
+        let(:exporter) do
+          FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'id' => { from: ['id'], source_identifier: true },
+                              'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+                              'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+                              'position' => { from: ['single_object_position'], object: 'single_object' },
+                              'language' => { from: ['single_object_language'], object: 'single_object', parsed: true },
+                            })
+        end
+
+        let(:work_obj) do
+          Work.new(
+            title: ['test'],
+            single_object: [{
+              'first_name' => 'Fake',
+              'last_name' => 'Fakerson',
+              'position' => 'Leader, Jester, Queen',
+              'language' => 'english'
+            }].to_s
+          )
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return('test123')
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_export_metadata
+          expect(metadata['first_name']).to eq('Fake')
+          expect(metadata['last_name']).to eq('Fakerson')
+          expect(metadata['position']).to include('Leader', 'Jester', 'Queen')
+          expect(metadata['language']).to eq('english')
         end
       end
     end


### PR DESCRIPTION
Ref https://github.com/samvera-labs/bulkrax/issues/321

# Expected behavior
- bulkrax can export nested properties from an object to a csv where the header has the object name prefixed
- bulkrax can export nested properties from an object to a csv where the header does not have the object name prefixed