### PR TITLE
Refactor csv export to use from values instead of to values.

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -108,7 +108,7 @@ module Bulkrax
 
     def build_object(object_key, value)
       data = hyrax_record.send(value['object'])
-      next if data.empty?
+      return if data.empty?
 
       data = data.to_a if data.is_a?(ActiveTriples::Relation)
       object_metadata(Array.wrap(data), object_key)
@@ -148,7 +148,11 @@ module Bulkrax
 
     def object_metadata(data, object_key)
       data = data.map { |d| eval(d) }.flatten # rubocop:disable Security/Eval
+
       data.each_with_index do |obj, index|
+        # allow the object_key to be valid whether it's a string or symbol
+        obj = obj.with_indifferent_access
+
         next unless obj[object_key]
         if obj[object_key].is_a?(Array)
           obj[object_key].each_with_index do |_nested_item, nested_index|

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -14,9 +14,9 @@ module Bulkrax
     def self.read_data(path)
       raise StandardError, 'CSV path empty' if path.blank?
       CSV.read(path,
-               headers: true,
-               header_converters: :symbol,
-               encoding: 'utf-8')
+        headers: true,
+        header_converters: :symbol,
+        encoding: 'utf-8')
     end
 
     def self.data_for_entry(data, _source_id)
@@ -38,14 +38,6 @@ module Bulkrax
 
     def self.children_field
       Bulkrax.parent_child_field_mapping[self.to_s] || 'children'
-    end
-
-    def keys_without_numbers(keys)
-      keys.map { |key| key_without_numbers(key) }
-    end
-
-    def key_without_numbers(key)
-      key.gsub(/_\d+/, '').sub(/^\d+_/, '')
     end
 
     def build_metadata
@@ -86,10 +78,14 @@ module Bulkrax
       self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
       self.parsed_metadata['model'] = hyrax_record.has_model.first
       build_mapping_metadata
-      self.parsed_metadata['collections'] = hyrax_record.member_of_collection_ids.join('; ')
-      unless hyrax_record.is_a?(Collection)
-        self.parsed_metadata['file'] = hyrax_record.file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact.join('; ')
+      if mapping['collections']&.[]('join')
+        self.parsed_metadata['collections'] = hyrax_record.member_of_collection_ids.join('; ')
+      else
+        hyrax_record.member_of_collection_ids.each_with_index do |collection_id, i|
+          self.parsed_metadata["collections_#{i + 1}"] = collection_id
+        end
       end
+      build_files unless hyrax_record.is_a?(Collection)
       self.parsed_metadata
     end
 
@@ -97,22 +93,49 @@ module Bulkrax
       mapping.each do |key, value|
         next if Bulkrax.reserved_properties.include?(key) && !field_supported?(key)
         next if key == "model"
+        next if value['excluded']
 
         object_key = key if value.key?('object')
         next unless hyrax_record.respond_to?(key.to_s) || object_key.present?
 
-        data = object_key.present? ? hyrax_record.send(value['object']) : hyrax_record.send(key.to_s)
         if object_key.present?
-          next if data.empty?
-          data = data.first if data.is_a?(ActiveTriples::Relation)
-
-          object_metadata(data, object_key)
-        elsif data.is_a?(ActiveTriples::Relation)
-          self.parsed_metadata[key] = data.map { |d| prepare_export_data(d) }.join('; ').to_s unless value[:excluded]
+          build_object(object_key, value)
         else
-          self.parsed_metadata[key] = prepare_export_data(data)
+          build_value(key, value)
         end
       end
+    end
+
+    def build_object(object_key, value)
+      data = hyrax_record.send(value['object'])
+      next if data.empty?
+
+      data = data.to_a if data.is_a?(ActiveTriples::Relation)
+      object_metadata(Array.wrap(data), object_key)
+    end
+
+    def build_value(key, value)
+      data = hyrax_record.send(key.to_s)
+      if data.is_a?(ActiveTriples::Relation)
+        if value['join']
+          self.parsed_metadata[key_for_export(key)] = data.map { |d| prepare_export_data(d) }.join('; ').to_s
+        else
+          data.each_with_index do |d, i|
+            self.parsed_metadata["#{key_for_export(key)}_#{i + i}"] = prepare_export_data(d)
+          end
+        end
+      else
+        self.parsed_metadata[key_for_export(key)] = prepare_export_data(data)
+      end
+    end
+
+    # On export the key becomes the from and the from becomes the destination. It is the opposite of the import because we are moving data the opposite direction
+    # metadata that does not have a specific Bulkrax entry is mapped to the key name, as matching keys coming in are mapped by the csv parser automatically
+    def key_for_export(key)
+      clean_key = key_without_numbers(key)
+      unnumbered_key = mapping[clean_key] ? mapping[clean_key]['from'].first : clean_key
+      # Bring the number back if there is one
+      "#{unnumbered_key}#{key.sub(clean_key, '')}"
     end
 
     def prepare_export_data(datum)
@@ -124,29 +147,27 @@ module Bulkrax
     end
 
     def object_metadata(data, object_key)
-      data = convert_to_hash(data)
-
+      data = data.map { |d| eval(d) }.flatten # rubocop:disable Security/Eval
       data.each_with_index do |obj, index|
         next unless obj[object_key]
-
-        next self.parsed_metadata["#{object_key}_#{index + 1}"] = prepare_export_data(obj[object_key]) unless obj[object_key].is_a?(Array)
-
-        obj[object_key].each_with_index do |_nested_item, nested_index|
-          self.parsed_metadata["#{object_key}_#{index + 1}_#{nested_index + 1}"] = prepare_export_data(obj[object_key][nested_index])
+        if obj[object_key].is_a?(Array)
+          obj[object_key].each_with_index do |_nested_item, nested_index|
+            self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}_#{nested_index + 1}"] = prepare_export_data(obj[object_key][nested_index])
+          end
+        else
+          self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}"] = prepare_export_data(obj[object_key])
         end
       end
     end
 
-    def convert_to_hash(data)
-      # converts data from `'[{}]'` to `[{}]`
-      gsub_data = data.gsub(/\[{/, '{')
-                      .gsub(/}\]/, '}')
-                      .gsub('=>', ':')
-                      .gsub(/},\s?{/, "}},{{")
-                      .split("},{")
-      gsub_data = [gsub_data] if gsub_data.is_a?(String)
-
-      return gsub_data.map { |d| JSON.parse(d) }
+    def build_files
+      if mapping['file']&.[]('join')
+        self.parsed_metadata['file'] = hyrax_record.file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact.join('; ')
+      else
+        hyrax_record.file_sets.each_with_index do |fs, i|
+          self.parsed_metadata["file_#{i + 1}"] = filename(fs).to_s if filename(fs).present?
+        end
+      end
     end
 
     # In order for the existing exported hyrax_record, to be updated by a re-import

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -23,7 +23,13 @@ module Bulkrax
 
     attr_accessor :all_attrs
 
-    delegate :parser, :mapping, :replace_files, :update_files, to: :importerexporter
+    delegate :parser,
+      :mapping,
+      :replace_files,
+      :update_files,
+      :keys_without_numbers,
+      :key_without_numbers,
+      to: :importerexporter
 
     delegate :client,
              :collection_name,

--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -30,5 +30,13 @@ module Bulkrax
       current_run.enqueued_records = index + 1
       current_run.save!
     end
+
+    def keys_without_numbers(keys)
+      keys.map { |key| key_without_numbers(key) }
+    end
+
+    def key_without_numbers(key)
+      key.gsub(/_\d+/, '').sub(/^\d+_/, '')
+    end
   end
 end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -5,11 +5,11 @@ module Bulkrax
     attr_accessor :importerexporter, :headers
     alias importer importerexporter
     alias exporter importerexporter
-    delegate :only_updates, :limit, :current_run, :errors,
-             :seen, :increment_counters, :parser_fields, :user,
-             :exporter_export_path, :exporter_export_zip_path, :importer_unzip_path, :validate_only,
-             :status, :status_info, :status_at,
-             to: :importerexporter
+    delegate :only_updates, :limit, :current_run, :errors, :mapping,
+      :seen, :increment_counters, :parser_fields, :user, :keys_without_numbers,
+      :key_without_numbers, :status, :status_info, :status_at,
+      :exporter_export_path, :exporter_export_zip_path, :importer_unzip_path, :validate_only,
+      to: :importerexporter
 
     def self.parser_fields
       {}
@@ -25,6 +25,7 @@ module Bulkrax
 
     def initialize(importerexporter)
       @importerexporter = importerexporter
+      @headers = []
     end
 
     # @api

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -211,16 +211,13 @@ module Bulkrax
       # we don't want access_control_id exported and we want file at the end
       # also sort the headers so they're grouped and easier to find
       headers.delete('access_control_id') if headers.include?('access_control_id')
-      headers.delete('file') if headers.include?('file')
       headers.sort!
 
       # add the headers below at the beginning or end to maintain the preexisting export behavior
-      headers.prepend('collections')
       headers.prepend('model')
       headers.prepend(source_identifier.to_s)
       headers.prepend('id')
 
-      headers << 'file'
       headers.uniq
     end
 

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -364,10 +364,10 @@ module Bulkrax
 
         it 'succeeds' do
           metadata = subject.build_export_metadata
-          expect(metadata['first_name_1']).to eq('Fake')
-          expect(metadata['last_name_1']).to eq('Fakerson')
-          expect(metadata['position_1']).to include('Leader', 'Jester', 'Queen')
-          expect(metadata['language_1']).to eq('english')
+          expect(metadata['single_object_first_name_1']).to eq('Fake')
+          expect(metadata['single_object_last_name_1']).to eq('Fakerson')
+          expect(metadata['single_object_position_1']).to include('Leader', 'Jester', 'Queen')
+          expect(metadata['single_object_language_1']).to eq('english')
         end
       end
 
@@ -461,13 +461,13 @@ module Bulkrax
 
         it 'succeeds' do
           metadata = subject.build_export_metadata
-          expect(metadata['first_name_1']).to eq('Fake')
-          expect(metadata['last_name_1']).to eq('Fakerson')
-          expect(metadata['position_1']).to include('Leader, Jester, Queen')
-          expect(metadata['language_1']).to eq('english')
-          expect(metadata['first_name_2']).to eq('Judge')
-          expect(metadata['last_name_2']).to eq('Hines')
-          expect(metadata['position_2']).to include('King, Lord, Duke')
+          expect(metadata['multiple_objects_first_name_1']).to eq('Fake')
+          expect(metadata['multiple_objects_last_name_1']).to eq('Fakerson')
+          expect(metadata['multiple_objects_position_1']).to include('Leader, Jester, Queen')
+          expect(metadata['multiple_objects_language_1']).to eq('english')
+          expect(metadata['multiple_objects_first_name_2']).to eq('Judge')
+          expect(metadata['multiple_objects_last_name_2']).to eq('Hines')
+          expect(metadata['multiple_objects_position_2']).to include('King, Lord, Duke')
         end
       end
 
@@ -555,13 +555,13 @@ module Bulkrax
 
         it 'succeeds' do
           metadata = subject.build_export_metadata
-          expect(metadata['first_name_1']).to eq('Fake')
-          expect(metadata['last_name_1']).to eq('Fakerson')
-          expect(metadata['first_name_2']).to eq('Judge')
-          expect(metadata['last_name_2']).to eq('Hines')
-          expect(metadata['position_2_1']).to eq('King')
-          expect(metadata['position_2_2']).to eq('Lord')
-          expect(metadata['position_2_3']).to eq('Duke')
+          expect(metadata['multiple_objects_first_name_1']).to eq('Fake')
+          expect(metadata['multiple_objects_last_name_1']).to eq('Fakerson')
+          expect(metadata['multiple_objects_first_name_2']).to eq('Judge')
+          expect(metadata['multiple_objects_last_name_2']).to eq('Hines')
+          expect(metadata['multiple_objects_position_2_1']).to eq('King')
+          expect(metadata['multiple_objects_position_2_2']).to eq('Lord')
+          expect(metadata['multiple_objects_position_2_3']).to eq('Duke')
         end
       end
       # rubocop:enable RSpec/ExampleLength

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -259,14 +259,12 @@ module Bulkrax
         headers = parser.export_headers
         expect(headers).to include('id')
         expect(headers).to include('model')
-        expect(headers).to include('collections')
         expect(headers).to include('display_title')
         expect(headers).to include('multiple_objects_first_name_1')
         expect(headers).to include('multiple_objects_last_name_1')
         expect(headers).to include('multiple_objects_position_1_1')
         expect(headers).to include('multiple_objects_position_1_2')
         expect(headers).to include('multiple_objects_first_name_2')
-        expect(headers).to include('file')
       end
     end
   end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -230,6 +230,7 @@ module Bulkrax
       let(:exporter) do
         FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
                             'id' => { from: ['id'], source_identifier: true },
+                            'title' => { from: ['display_title'] },
                             'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
                             'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
                             'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
@@ -239,11 +240,12 @@ module Bulkrax
       let(:entry) do
         FactoryBot.create(:bulkrax_csv_entry, importerexporter: exporter, parsed_metadata: {
                             'id' => work_id,
-                            'first_name_1' => 'Judge',
-                            'last_name_1' => 'Hines',
-                            'position_1_1' => 'King',
-                            'position_1_2' => 'Lord',
-                            'first_name_2' => 'Aaliyah'
+                            'display_title' => 'First',
+                            'multiple_objects_first_name_1' => 'Judge',
+                            'multiple_objects_last_name_1' => 'Hines',
+                            'multiple_objects_position_1_1' => 'King',
+                            'multiple_objects_position_1_2' => 'Lord',
+                            'multiple_objects_first_name_2' => 'Aaliyah'
                           })
       end
 
@@ -258,11 +260,12 @@ module Bulkrax
         expect(headers).to include('id')
         expect(headers).to include('model')
         expect(headers).to include('collections')
-        expect(headers).to include('first_name_1')
-        expect(headers).to include('last_name_1')
-        expect(headers).to include('position_1_1')
-        expect(headers).to include('position_1_2')
-        expect(headers).to include('first_name_2')
+        expect(headers).to include('display_title')
+        expect(headers).to include('multiple_objects_first_name_1')
+        expect(headers).to include('multiple_objects_last_name_1')
+        expect(headers).to include('multiple_objects_position_1_1')
+        expect(headers).to include('multiple_objects_position_1_2')
+        expect(headers).to include('multiple_objects_first_name_2')
         expect(headers).to include('file')
       end
     end


### PR DESCRIPTION
CSV export was using the wrong headers. If you specify `"title" => {from: ['display_title']}` in the mapper,
then you would expect the export to say `display_title` and not `title`. This was not the case.

This commit also adds a new option for the field mapping - join. The default behavior on export has been to
join fields together, but field_1,field_2 easier for users to edit. This will be the new default and join allows
you to specify the old behavior.

Also cleaned up object code on exporter and reduced cyclomatic complexity on some methods in csv entry.