### PR TITLE
include object headers again

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -108,6 +108,7 @@ module Bulkrax
 
     def build_object(object_key, value)
       data = hyrax_record.send(value['object'])
+      # byebug
       return if data.empty?
 
       data = data.to_a if data.is_a?(ActiveTriples::Relation)
@@ -147,17 +148,19 @@ module Bulkrax
     end
 
     def object_metadata(data, object_key)
-      # eval turns all of the keys into symbols
       data = data.map { |d| eval(d) }.flatten # rubocop:disable Security/Eval
+
       data.each_with_index do |obj, index|
-        object_symbol = object_key.to_sym
-        next unless obj[object_symbol]
-        if obj[object_symbol].is_a?(Array)
-          obj[object_symbol].each_with_index do |_nested_item, nested_index|
-            self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}_#{nested_index + 1}"] = prepare_export_data(obj[object_symbol][nested_index])
+        # allow the object_key to be valid whether it's a string or symbol
+        obj = obj.with_indifferent_access
+
+        next unless obj[object_key]
+        if obj[object_key].is_a?(Array)
+          obj[object_key].each_with_index do |_nested_item, nested_index|
+            self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}_#{nested_index + 1}"] = prepare_export_data(obj[object_key][nested_index])
           end
         else
-          self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}"] = prepare_export_data(obj[object_symbol])
+          self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}"] = prepare_export_data(obj[object_key])
         end
       end
     end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -108,10 +108,11 @@ module Bulkrax
 
     def build_object(object_key, value)
       data = hyrax_record.send(value['object'])
-      next if data.empty?
 
-      data = data.to_a if data.is_a?(ActiveTriples::Relation)
-      object_metadata(Array.wrap(data), object_key)
+      unless data.empty?
+        data = data.to_a if data.is_a?(ActiveTriples::Relation)
+        object_metadata(Array.wrap(data), object_key)
+      end
     end
 
     def build_value(key, value)
@@ -147,15 +148,17 @@ module Bulkrax
     end
 
     def object_metadata(data, object_key)
+      # eval turns all of the keys into symbols
       data = data.map { |d| eval(d) }.flatten # rubocop:disable Security/Eval
       data.each_with_index do |obj, index|
-        next unless obj[object_key]
-        if obj[object_key].is_a?(Array)
-          obj[object_key].each_with_index do |_nested_item, nested_index|
-            self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}_#{nested_index + 1}"] = prepare_export_data(obj[object_key][nested_index])
+        object_symbol = object_key.to_sym
+        next unless obj[object_symbol]
+        if obj[object_symbol].is_a?(Array)
+          obj[object_symbol].each_with_index do |_nested_item, nested_index|
+            self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}_#{nested_index + 1}"] = prepare_export_data(obj[object_symbol][nested_index])
           end
         else
-          self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}"] = prepare_export_data(obj[object_key])
+          self.parsed_metadata["#{key_for_export(object_key)}_#{index + 1}"] = prepare_export_data(obj[object_symbol])
         end
       end
     end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -108,7 +108,6 @@ module Bulkrax
 
     def build_object(object_key, value)
       data = hyrax_record.send(value['object'])
-      # byebug
       return if data.empty?
 
       data = data.to_a if data.is_a?(ActiveTriples::Relation)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -108,11 +108,10 @@ module Bulkrax
 
     def build_object(object_key, value)
       data = hyrax_record.send(value['object'])
+      return if data.empty?
 
-      unless data.empty?
-        data = data.to_a if data.is_a?(ActiveTriples::Relation)
-        object_metadata(Array.wrap(data), object_key)
-      end
+      data = data.to_a if data.is_a?(ActiveTriples::Relation)
+      object_metadata(Array.wrap(data), object_key)
     end
 
     def build_value(key, value)

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -214,10 +214,12 @@ module Bulkrax
       headers.sort!
 
       # add the headers below at the beginning or end to maintain the preexisting export behavior
+      headers.prepend('collection') unless headers.detect {|header| header.match(/^collection/)}
       headers.prepend('model')
       headers.prepend(source_identifier.to_s)
       headers.prepend('id')
 
+      headers << 'file' unless headers.detect {|header| header.match(/^file/)}
       headers.uniq
     end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -214,12 +214,10 @@ module Bulkrax
       headers.sort!
 
       # add the headers below at the beginning or end to maintain the preexisting export behavior
-      headers.prepend('collection') unless headers.detect {|header| header.match(/^collection/)}
       headers.prepend('model')
       headers.prepend(source_identifier.to_s)
       headers.prepend('id')
 
-      headers << 'file' unless headers.detect {|header| header.match(/^file/)}
       headers.uniq
     end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -211,16 +211,13 @@ module Bulkrax
       # we don't want access_control_id exported and we want file at the end
       # also sort the headers so they're grouped and easier to find
       headers.delete('access_control_id') if headers.include?('access_control_id')
-      headers.delete('file') if headers.include?('file')
       headers.sort!
 
       # add the headers below at the beginning or end to maintain the preexisting export behavior
-      headers.prepend('collections')
       headers.prepend('model')
       headers.prepend(source_identifier.to_s)
       headers.prepend('id')
 
-      headers << 'file'
       headers.uniq
     end
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -259,14 +259,12 @@ module Bulkrax
         headers = parser.export_headers
         expect(headers).to include('id')
         expect(headers).to include('model')
-        expect(headers).to include('collections')
         expect(headers).to include('display_title')
         expect(headers).to include('multiple_objects_first_name_1')
         expect(headers).to include('multiple_objects_last_name_1')
         expect(headers).to include('multiple_objects_position_1_1')
         expect(headers).to include('multiple_objects_position_1_2')
         expect(headers).to include('multiple_objects_first_name_2')
-        expect(headers).to include('file')
       end
     end
   end


### PR DESCRIPTION
# Related to
https://github.com/samvera-labs/bulkrax/pull/334
https://github.com/samvera-labs/bulkrax/pull/339

# Summary
- the object headers were not being exported in https://github.com/samvera-labs/bulkrax/pull/339

# Expected behavior
- object headers are exported again

# Example export
[export.csv](https://github.com/samvera-labs/bulkrax/files/7123162/export.csv)