### PR TITLE
351-total-works-count

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -27,7 +27,10 @@ module Bulkrax
     def records(_opts = {})
       file_for_import = only_updates ? parser_fields['partial_import_file_path'] : import_file_path
       # data for entry does not need source_identifier for csv, because csvs are read sequentially and mapped after raw data is read.
-      @records ||= entry_class.read_data(file_for_import).map { |record_data| entry_class.data_for_entry(record_data, nil) }
+      csv_data = entry_class.read_data(file_for_import)
+      importer.parser_fields['total'] = csv_data.count
+      importer.save
+      @records ||= csv_data.map { |record_data| entry_class.data_for_entry(record_data, nil) }
     end
 
     # We could use CsvEntry#fields_from_data(data) but that would mean re-reading the data
@@ -166,11 +169,7 @@ module Bulkrax
     #   Changed to grep as wc -l counts blank lines, and ignores the final unescaped line (which may or may not contain data)
     def total
       if importer?
-        return @total if @total&.positive?
-        # windows enocded
-        @total = `grep -c ^M #{real_import_file_path}`.to_i - 1
-        # unix encoded
-        @total = `grep -vc ^$ #{real_import_file_path}`.to_i - 1 if @total < 1
+        @total = importer.parser_fields['total'] || 0
       elsif exporter?
         @total = importerexporter.entries.count
       else

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -168,14 +168,10 @@ module Bulkrax
     # See https://stackoverflow.com/questions/2650517/count-the-number-of-lines-in-a-file-without-reading-entire-file-into-memory
     #   Changed to grep as wc -l counts blank lines, and ignores the final unescaped line (which may or may not contain data)
     def total
-      if importer?
-        @total = importer.parser_fields['total'] || 0
-      elsif exporter?
-        @total = importerexporter.entries.count
-      else
-        @total = 0
-      end
-      return @total
+      @total = importer.parser_fields['total'] || 0 if importer?
+      @total = importerexporter.entries.count if exporter?
+
+      return @total || 0
     rescue StandardError
       @total = 0
     end

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -31,23 +31,21 @@
           </thead>
           <tbody>
             <% @importers.each do |importer| %>
-            <tr>
-              <th scope="row"><%= link_to importer.name, importer_path(importer) %></th>
-              <td>
-                <%= importer.status %>
-              </td>
-              <td><%= importer.last_imported_at.strftime("%b %d, %Y") if importer.last_imported_at %></td>
-              <td><%= importer.next_import_at.strftime("%b %d, %Y") if importer.next_import_at %></td>
-              <td><%= importer.importer_runs.last&.enqueued_records %></td>
-              <td><%= (importer.importer_runs.last&.processed_collections || 0) + (importer.importer_runs.last&.processed_records || 0)  %></td>
-              <td><%= (importer.importer_runs.last&.failed_collections || 0) + (importer.importer_runs.last&.failed_records || 0)  %></td>
-              <td><%= importer.importer_runs.last&.deleted_records %></td>
-              <td><%= importer.importer_runs.last&.total_collection_entries %></td>
-              <td><%= importer.importer_runs.last&.total_work_entries %></td>
-              <td><%= link_to raw('<span class="glyphicon glyphicon-info-sign"></span>'), importer_path(importer) %></td>
-              <td><%= link_to raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_importer_path(importer) %></td>
-              <td><%= link_to raw('<span class="glyphicon glyphicon-remove"></span>'), importer, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-            </tr>
+              <tr>
+                <th scope="row"><%= link_to importer.name, importer_path(importer) %></th>
+                <td><%= importer.status %></td>
+                <td><%= importer.last_imported_at.strftime("%b %d, %Y") if importer.last_imported_at %></td>
+                <td><%= importer.next_import_at.strftime("%b %d, %Y") if importer.next_import_at %></td>
+                <td><%= importer.importer_runs.last&.enqueued_records %></td>
+                <td><%= (importer.importer_runs.last&.processed_collections || 0) + (importer.importer_runs.last&.processed_records || 0) %></td>
+                <td><%= (importer.importer_runs.last&.failed_collections || 0) + (importer.importer_runs.last&.failed_records || 0) %></td>
+                <td><%= importer.importer_runs.last&.deleted_records %></td>
+                <td><%= importer.importer_runs.last&.total_collection_entries %></td>
+                <td><%= importer.importer_runs.last&.total_work_entries %></td>
+                <td><%= link_to raw('<span class="glyphicon glyphicon-info-sign"></span>'), importer_path(importer) %></td>
+                <td><%= link_to raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_importer_path(importer) %></td>
+                <td><%= link_to raw('<span class="glyphicon glyphicon-remove"></span>'), importer, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+              </tr>
             <% end %>
           </tbody>
         </table>

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -83,6 +83,7 @@ module Bulkrax
         end
 
         it 'counts the correct number of works and collections' do
+          subject.records
           expect(subject.total).to eq(2)
           expect(subject.collections_total).to eq(2)
         end


### PR DESCRIPTION
Ref https://github.com/samvera-labs/bulkrax/issues/351

# Expected behavior
- the amount of works in a csv comes back correct, despite line breaks, etc. in the data

# Demo
check the "total works" label
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/133532553-f8816907-5439-480f-ae52-4381c7470d05.png) | ![image](https://user-images.githubusercontent.com/29032869/133531103-52122b01-aebc-4266-b436-16b287de3a80.png)|

