### PR TITLE
custom-model-header-name-on-export

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -76,7 +76,7 @@ module Bulkrax
       self.parsed_metadata = {}
       self.parsed_metadata['id'] = hyrax_record.id
       self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
-      self.parsed_metadata['model'] = hyrax_record.has_model.first
+      self.parsed_metadata[mapping['model']['from'].first || 'model'] = hyrax_record.has_model.first
       build_mapping_metadata
 
       # TODO: fix the "send" parameter in the conditional below

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -219,10 +219,10 @@ module Bulkrax
       # we don't want access_control_id exported and we want file at the end
       # also sort the headers so they're grouped and easier to find
       headers.delete('access_control_id') if headers.include?('access_control_id')
-      headers.sort!
+      headers.delete('model')
 
-      # add the headers below at the beginning or end to maintain the preexisting export behavior
-      headers.prepend('model')
+      # add the headers below at the beginning to maintain the preexisting export behavior
+      headers.prepend(mapping['model']['from'].first || 'model')
       headers.prepend(source_identifier.to_s)
       headers.prepend('id')
 


### PR DESCRIPTION
# Expected behavior
- the header that refers to the Model on the csv will be "model" unless there is a field mapping for "model"
- if there's a field mapping for "model", the header will use that field mapping

# Demo
field mapping: `'model' => { from: ['work_type'] }`

csv:
[export 3.csv](https://github.com/samvera-labs/bulkrax/files/7200251/export.3.csv)
![image](https://user-images.githubusercontent.com/29032869/134112069-8aabd741-66b6-4e6b-b909-aa8f65c1a78b.png)
