### PR TITLE
return-total-works

### DIFF
--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -9,8 +9,8 @@ module Bulkrax
 
       importer.current_run
       unzip_imported_file(importer.parser)
-      update_current_run_counters(importer)
       import(importer, only_updates_since_last_import)
+      update_current_run_counters(importer)
       schedule(importer) if importer.schedulable?
     end
 


### PR DESCRIPTION
# summary
for some reason, the "total works" count started returning 0 consistently for import and export

# Expected behavior
- total works should once again return the correct amount of works in that import or export run

# Demo
| | importer | exporter |
| --- | --- | --- |
| after | ![Screen Shot 2021-09-22 at 11 22 49 PM](https://user-images.githubusercontent.com/29032869/134464567-447c0cef-572c-4b24-8940-0c46798bf971.png) | ![Screen Shot 2021-09-22 at 11 33 04 PM](https://user-images.githubusercontent.com/29032869/134464643-4e2b3876-eefe-45fa-92b0-deb366280716.png)| 
| before | ![Screen Shot 2021-09-22 at 11 03 20 PM](https://user-images.githubusercontent.com/29032869/134464540-29f69c84-cc14-4ef8-91a4-8ca3f04cc14f.png) | ![Screen Shot 2021-09-22 at 11 31 51 PM](https://user-images.githubusercontent.com/29032869/134464624-cc5008da-c18b-4206-a18a-77c085c0e22d.png) |