### PR TITLE
object-metadata-nil-check

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -156,6 +156,7 @@ module Bulkrax
       data = data.map { |d| eval(d) }.flatten # rubocop:disable Security/Eval
 
       data.each_with_index do |obj, index|
+        next if obj.nil?
         # allow the object_key to be valid whether it's a string or symbol
         obj = obj.with_indifferent_access
 


### PR DESCRIPTION
Ref https://gitlab.com/notch8/britishlibrary/-/issues/148

# Expected behavior
- although I have no idea why the object would be nil and could not duplicate this error locally, we're now checking to make sure the object exists before calling a method on it

# Bug
- `NoMethodError - undefined method 'with_indifferent_access' for nil:NilClass` error was received on BL prod

![image](https://user-images.githubusercontent.com/29032869/134578221-35a74040-479f-4405-be9a-114199882f0a.png)