### PR TITLE
seperate-paths-by-tenant

### DIFF
--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -105,13 +105,13 @@ module Bulkrax
     end
 
     def exporter_export_path
-      @exporter_export_path ||= File.join(Bulkrax.base_path.call('export'), self.id.to_s, self.exporter_runs.last.id.to_s)
+      @exporter_export_path ||= File.join(parser.base_path('export'), self.id.to_s, self.exporter_runs.last.id.to_s)
     end
 
     def exporter_export_zip_path
-      @exporter_export_zip_path ||= File.join(Bulkrax.base_path.call('export'), "export_#{self.id}_#{self.exporter_runs.last.id}.zip")
+      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_#{self.exporter_runs.last.id}.zip")
     rescue
-      @exporter_export_zip_path ||= File.join(Bulkrax.base_path.call('export'), "export_#{self.id}_0.zip")
+      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_0.zip")
     end
 
     def export_properties

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -114,7 +114,6 @@ module Bulkrax
       @exporter_export_zip_path ||= File.join(Bulkrax.base_path.call('export'), "export_#{self.id}_0.zip")
     end
 
-
     def export_properties
       properties = Hyrax.config.registered_curation_concern_types.map { |work| work.constantize.properties.keys }.flatten.uniq.sort
       properties.reject { |prop| Bulkrax.reserved_properties.include?(prop) }

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -105,18 +105,15 @@ module Bulkrax
     end
 
     def exporter_export_path
-      @exporter_export_path ||= File.join(export_base_path, self.id.to_s, self.exporter_runs.last.id.to_s)
+      @exporter_export_path ||= File.join(Bulkrax.base_path.call('export'), self.id.to_s, self.exporter_runs.last.id.to_s)
     end
 
     def exporter_export_zip_path
-      @exporter_export_zip_path ||= File.join(export_base_path, "export_#{self.id}_#{self.exporter_runs.last.id}.zip")
+      @exporter_export_zip_path ||= File.join(Bulkrax.base_path.call('export'), "export_#{self.id}_#{self.exporter_runs.last.id}.zip")
     rescue
-      @exporter_export_zip_path ||= File.join(export_base_path, "export_#{self.id}_0.zip")
+      @exporter_export_zip_path ||= File.join(Bulkrax.base_path.call('export'), "export_#{self.id}_0.zip")
     end
 
-    def export_base_path
-      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.export_path, Site.instance.account.name) : Bulkrax.export_path
-    end
 
     def export_properties
       properties = Hyrax.config.registered_curation_concern_types.map { |work| work.constantize.properties.keys }.flatten.uniq.sort

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -105,13 +105,17 @@ module Bulkrax
     end
 
     def exporter_export_path
-      @exporter_export_path ||= File.join(Bulkrax.export_path, self.id.to_s, self.exporter_runs.last.id.to_s)
+      @exporter_export_path ||= File.join(export_base_path, self.id.to_s, self.exporter_runs.last.id.to_s)
     end
 
     def exporter_export_zip_path
-      @exporter_export_zip_path ||= File.join(Bulkrax.export_path, "export_#{self.id}_#{self.exporter_runs.last.id}.zip")
+      @exporter_export_zip_path ||= File.join(export_base_path, "export_#{self.id}_#{self.exporter_runs.last.id}.zip")
     rescue
-      @exporter_export_zip_path ||= File.join(Bulkrax.export_path, "export_#{self.id}_0.zip")
+      @exporter_export_zip_path ||= File.join(export_base_path, "export_#{self.id}_0.zip")
+    end
+
+    def export_base_path
+      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.export_path, Site.instance.account.name) : Bulkrax.export_path
     end
 
     def export_properties

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -153,11 +153,15 @@ module Bulkrax
 
     # If the import data is zipped, unzip it to this path
     def importer_unzip_path
-      @importer_unzip_path ||= File.join(Bulkrax.import_path, "import_#{path_string}")
+      @importer_unzip_path ||= File.join(import_base_path, "import_#{path_string}")
     end
 
     def errored_entries_csv_path
-      @errored_entries_csv_path ||= File.join(Bulkrax.import_path, "import_#{path_string}_errored_entries.csv")
+      @errored_entries_csv_path ||= File.join(import_base_path, "import_#{path_string}_errored_entries.csv")
+    end
+
+    def import_base_path
+      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.import_path, Site.instance.account.name) : Bulkrax.import_path
     end
 
     def path_string

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -153,15 +153,11 @@ module Bulkrax
 
     # If the import data is zipped, unzip it to this path
     def importer_unzip_path
-      @importer_unzip_path ||= File.join(import_base_path, "import_#{path_string}")
+      @importer_unzip_path ||= File.join(Bulkrax.base_path.call('import'), "import_#{path_string}")
     end
 
     def errored_entries_csv_path
-      @errored_entries_csv_path ||= File.join(import_base_path, "import_#{path_string}_errored_entries.csv")
-    end
-
-    def import_base_path
-      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.import_path, Site.instance.account.name) : Bulkrax.import_path
+      @errored_entries_csv_path ||= File.join(Bulkrax.base_path.call('import'), "import_#{path_string}_errored_entries.csv")
     end
 
     def path_string

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -153,11 +153,11 @@ module Bulkrax
 
     # If the import data is zipped, unzip it to this path
     def importer_unzip_path
-      @importer_unzip_path ||= File.join(Bulkrax.base_path.call('import'), "import_#{path_string}")
+      @importer_unzip_path ||= File.join(parser.base_path, "import_#{path_string}")
     end
 
     def errored_entries_csv_path
-      @errored_entries_csv_path ||= File.join(Bulkrax.base_path.call('import'), "import_#{path_string}_errored_entries.csv")
+      @errored_entries_csv_path ||= File.join(parser.base_path, "import_#{path_string}_errored_entries.csv")
     end
 
     def path_string

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -92,10 +92,15 @@ module Bulkrax
       path
     end
 
+    # Base path for imported and exported files
+    def base_path(type = 'import')
+      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.send("#{type}_path"), Site.instance.account.name) : Bulkrax.send("#{type}_path")
+    end
+
     # Path where we'll store the import metadata and files
     #  this is used for uploaded and cloud files
     def path_for_import
-      @path_for_import = File.join(Bulkrax.base_path.call('import'), importerexporter.path_string)
+      @path_for_import = File.join(base_path, importerexporter.path_string)
       FileUtils.mkdir_p(@path_for_import) unless File.exist?(@path_for_import)
       @path_for_import
     end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -95,9 +95,13 @@ module Bulkrax
     # Path where we'll store the import metadata and files
     #  this is used for uploaded and cloud files
     def path_for_import
-      @path_for_import = File.join(Bulkrax.import_path, importerexporter.path_string)
+      @path_for_import = File.join(import_base_path, importerexporter.path_string)
       FileUtils.mkdir_p(@path_for_import) unless File.exist?(@path_for_import)
       @path_for_import
+    end
+
+    def import_base_path
+      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.import_path, Site.instance.account.name) : Bulkrax.import_path
     end
 
     # Optional, only used by certain parsers

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -95,13 +95,9 @@ module Bulkrax
     # Path where we'll store the import metadata and files
     #  this is used for uploaded and cloud files
     def path_for_import
-      @path_for_import = File.join(import_base_path, importerexporter.path_string)
+      @path_for_import = File.join(Bulkrax.base_path.call('import'), importerexporter.path_string)
       FileUtils.mkdir_p(@path_for_import) unless File.exist?(@path_for_import)
       @path_for_import
-    end
-
-    def import_base_path
-      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.import_path, Site.instance.account.name) : Bulkrax.import_path
     end
 
     # Optional, only used by certain parsers

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -17,7 +17,6 @@ module Bulkrax
                    :export_path,
                    :removed_image_path,
                    :server_name,
-                   :base_path,
                    :api_definition,
                    :removed_image_path
 
@@ -33,10 +32,6 @@ module Bulkrax
     self.export_path = 'tmp/exports'
     self.removed_image_path = Bulkrax::Engine.root.join('spec', 'fixtures', 'removed.png').to_s
     self.server_name = 'bulkrax@example.com'
-
-    self.base_path = lambda do |type|
-      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.send("#{type}_path"), Site.instance.account.name) : Bulkrax.send("#{type}_path")
-    end
 
     # @todo, merge parent_child_field_mapping and collection_field_mapping into field_mappings,
     # or make them settable per import some other way.

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -17,6 +17,7 @@ module Bulkrax
                    :export_path,
                    :removed_image_path,
                    :server_name,
+                   :base_path,
                    :api_definition,
                    :removed_image_path
 
@@ -32,6 +33,10 @@ module Bulkrax
     self.export_path = 'tmp/exports'
     self.removed_image_path = Bulkrax::Engine.root.join('spec', 'fixtures', 'removed.png').to_s
     self.server_name = 'bulkrax@example.com'
+
+    self.base_path = lambda do |type|
+      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.send("#{type}_path"), Site.instance.account.name) : Bulkrax.send("#{type}_path")
+    end
 
     # @todo, merge parent_child_field_mapping and collection_field_mapping into field_mappings,
     # or make them settable per import some other way.

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -126,7 +126,11 @@ module Bulkrax
         # TODO(alishaevn): get this spec to work
         before do
           ENV['HYKU_MULTITENANT'] = 'true'
-          # Site.instance.account.name = 'hyku'
+          # allow(Site).to receive(instance).and_return({})
+          # allow(Site.instance).to receive(account).and_return({})
+          # allow(Site.instance.account).to receive(name).and_return('hyku')
+
+          # allow('base_path').to receive(::Site.instance.account.name).and_return('hyku')
         end
 
         xit 'returns the path of the partial import file' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -95,29 +95,32 @@ module Bulkrax
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv_failed) }
       let(:file)     { fixture_file_upload('./spec/fixtures/csv/ok.csv') }
 
-      it 'returns the path of the partial import file' do
-        expect(subject.write_partial_import_file(file))
-          .to eq("tmp/imports/#{importer.id}_#{importer.created_at.strftime('%Y%m%d%H%M%S')}/failed_corrected_entries.csv")
+      context 'in a single tenant application' do
+        it 'returns the path of the partial import file' do
+          expect(subject.write_partial_import_file(file))
+            .to eq("tmp/imports/#{importer.id}_#{importer.created_at.strftime('%Y%m%d%H%M%S')}/failed_corrected_entries.csv")
+        end
+
+        it 'moves the partial import file to the correct path' do
+          expect(File.exist?(file.path)).to eq(true)
+
+          new_path = subject.write_partial_import_file(file)
+
+          expect(File.exist?(file.path)).to eq(false)
+          expect(File.exist?(new_path)).to eq(true)
+        end
+
+        it 'renames the uploaded file to the original import filename + _corrected_entries' do
+          import_filename = importer.parser_fields['import_file_path'].split('/').last
+          uploaded_filename = file.original_filename
+          partial_import_filename = subject.write_partial_import_file(file).split('/').last
+
+          expect(import_filename).to eq('failed.csv')
+          expect(uploaded_filename).to eq('ok.csv')
+          expect(partial_import_filename).not_to eq(uploaded_filename)
+          expect(partial_import_filename).to eq('failed_corrected_entries.csv')
+        end
       end
-
-      it 'moves the partial import file to the correct path' do
-        expect(File.exist?(file.path)).to eq(true)
-
-        new_path = subject.write_partial_import_file(file)
-
-        expect(File.exist?(file.path)).to eq(false)
-        expect(File.exist?(new_path)).to eq(true)
-      end
-
-      it 'renames the uploaded file to the original import filename + _corrected_entries' do
-        import_filename = importer.parser_fields['import_file_path'].split('/').last
-        uploaded_filename = file.original_filename
-        partial_import_filename = subject.write_partial_import_file(file).split('/').last
-
-        expect(import_filename).to eq('failed.csv')
-        expect(uploaded_filename).to eq('ok.csv')
-        expect(partial_import_filename).not_to eq(uploaded_filename)
-        expect(partial_import_filename).to eq('failed_corrected_entries.csv')
       end
     end
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -121,6 +121,18 @@ module Bulkrax
           expect(partial_import_filename).to eq('failed_corrected_entries.csv')
         end
       end
+
+      context 'in a multi tenant application' do
+        # TODO(alishaevn): get this spec to work
+        before do
+          ENV['HYKU_MULTITENANT'] = 'true'
+          # Site.instance.account.name = 'hyku'
+        end
+
+        xit 'returns the path of the partial import file' do
+          expect(subject.write_partial_import_file(file))
+            .to eq("tmp/imports/hyku/#{importer.id}_#{importer.created_at.strftime('%Y%m%d%H%M%S')}/failed_corrected_entries.csv")
+        end
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,8 +53,8 @@ RSpec.configure do |config|
 
   config.after(:each, clean_downloads: true) do
     FileUtils.rm_rf(Dir.glob("#{ENV.fetch('RAILS_TMP', Dir.tmpdir)}/*_entries.csv"))
-    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.import_path, '1', '/*_entries.csv').to_s))
-    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.export_path, '1', '1', '/*.csv').to_s))
+    FileUtils.rm_rf(Dir.glob(File.join(import_base_path, '1', '/*_entries.csv').to_s))
+    FileUtils.rm_rf(Dir.glob(File.join(export_base_path, '1', '1', '/*.csv').to_s))
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,8 +53,8 @@ RSpec.configure do |config|
 
   config.after(:each, clean_downloads: true) do
     FileUtils.rm_rf(Dir.glob("#{ENV.fetch('RAILS_TMP', Dir.tmpdir)}/*_entries.csv"))
-    FileUtils.rm_rf(Dir.glob(File.join(import_base_path, '1', '/*_entries.csv').to_s))
-    FileUtils.rm_rf(Dir.glob(File.join(export_base_path, '1', '1', '/*.csv').to_s))
+    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.base_path.call('import'), '1', '/*_entries.csv').to_s))
+    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.base_path.call('export'), '1', '1', '/*.csv').to_s))
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,8 +53,12 @@ RSpec.configure do |config|
 
   config.after(:each, clean_downloads: true) do
     FileUtils.rm_rf(Dir.glob("#{ENV.fetch('RAILS_TMP', Dir.tmpdir)}/*_entries.csv"))
-    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.base_path.call('import'), '1', '/*_entries.csv').to_s))
-    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.base_path.call('export'), '1', '1', '/*.csv').to_s))
+    # Account for single tenant and multi tenant files
+    # 'hyku' should be the only tenant referred to in the specs
+    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.import_path, '1', '/*_entries.csv').to_s))
+    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.import_path, 'hyku', '1', '1', '/*.csv').to_s))
+    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.export_path, '1', '/*_entries.csv').to_s))
+    FileUtils.rm_rf(Dir.glob(File.join(Bulkrax.export_path, 'hyku', '1', '1', '/*.csv').to_s))
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
# Related issue
https://gitlab.com/notch8/britishlibrary/-/issues/148#note_686505543

# Expected behavior
- import and export paths will now have the tenant name for hyku apps
- imports a csv and a zip successfully
- exports a csv successfully
- previously imported csv's/zip still have a valid import path, but the csv/zip should be re-imported for consistency and to avoid future issues
- previously exported csv's don't have a valid download anymore so they need to be re-exported

# Demo
| csv import | zip import | export|
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/134754583-062d28e2-0aeb-4298-8b70-8214c76262a8.png) | ![image](https://user-images.githubusercontent.com/29032869/134754596-d96d1996-a974-4348-bead-a0cec9e2ee0a.png) |  ![image](https://user-images.githubusercontent.com/29032869/134754696-43e4499e-c6e1-4036-8edf-63f9cd061d61.png) | 