### PR TITLE
Add ability to import Collections with metadata

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,12 +8,12 @@
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 45
+  Max: 43
 
 # Offense count: 6
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 236
+  Max: 231
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 43
+  Max: 45
 
 # Offense count: 6
 # Configuration parameters: CountComments.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 6
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 231
+  Max: 232
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 6
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 232
+  Max: 234
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 6
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 234
+  Max: 236
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -5,15 +5,16 @@ module Bulkrax
     extend ActiveModel::Callbacks
     include Bulkrax::FileFactory
     define_model_callbacks :save, :create
-    attr_reader :attributes, :object, :source_identifier_value, :klass, :replace_files, :update_files, :work_identifier
+    attr_reader :attributes, :object, :source_identifier_value, :klass, :replace_files, :update_files, :work_identifier, :collection_field_mapping
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(attributes:, source_identifier_value:, work_identifier:, replace_files: false, user: nil, klass: nil, update_files: false)
+    def initialize(attributes:, source_identifier_value:, work_identifier:, collection_field_mapping:, replace_files: false, user: nil, klass: nil, update_files: false)
       @attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes)
       @replace_files = replace_files
       @update_files = update_files
       @user = user || User.batch_user
       @work_identifier = work_identifier
+      @collection_field_mapping = collection_field_mapping
       @source_identifier_value = source_identifier_value
       @klass = klass || Bulkrax.default_work_type.constantize
     end
@@ -159,10 +160,10 @@ module Bulkrax
 
     def member_of_collections
       ms = object.member_of_collection_ids.to_a.map { |id| find_collection(id) }
-      if attributes[parser.collection_field_mapping].present?
+      if attributes[collection_field_mapping].present?
         ms.concat(
           Array.wrap(
-            find_collection(attributes[parser.collection_field_mapping])
+            find_collection(attributes[collection_field_mapping])
           )
         )
       end
@@ -193,7 +194,7 @@ module Bulkrax
     def create_attributes
       return transform_attributes if klass == Collection
       ActiveSupport::Deprecation.warn("Passing collection or collections directly to the ObjectFactory is no longer supported. Please update your Entry class to call add_collections instead.") if attributes[:collection].present? || attributes[:collections].present?
-      transform_attributes.except(:collections, :collection, parser.collection_field_mapping)
+      transform_attributes.except(:collections, :collection, collection_field_mapping)
     end
 
     # Strip out the :collection key, and add the member_of_collection_ids,
@@ -201,7 +202,7 @@ module Bulkrax
     def attribute_update
       return transform_attributes.except(:id) if klass == Collection
       ActiveSupport::Deprecation.warn("Passing collection or collections directly to the ObjectFactory is no longer supported. Please update your Entry class to call add_collections instead.") if attributes[:collection].present? || attributes[:collections].present?
-      transform_attributes.except(:id, :collections, :collection, parser.collection_field_mapping)
+      transform_attributes.except(:id, :collections, :collection, collection_field_mapping)
     end
 
     # Override if we need to map the attributes from the parser in
@@ -210,10 +211,6 @@ module Bulkrax
       @transform_attributes = attributes.slice(*permitted_attributes)
       @transform_attributes.merge!(file_attributes(update_files)) if with_files
       @transform_attributes
-    end
-
-    def parser
-      Entry.find_by(identifier: source_identifier_value)&.parser || ApplicationParser
     end
 
     # Regardless of what the Parser gives us, these are the properties we are prepared to accept.

--- a/app/jobs/bulkrax/child_relationships_job.rb
+++ b/app/jobs/bulkrax/child_relationships_job.rb
@@ -77,6 +77,7 @@ module Bulkrax
       Bulkrax::ObjectFactory.new(attributes: attrs,
                                  source_identifier_value: child_works_hash[work_id][entry.parser.source_identifier],
                                  work_identifier: entry.parser.work_identifier,
+                                 collection_field_mapping: entry.parser.collection_field_mapping,
                                  replace_files: false,
                                  user: user,
                                  klass: child_works_hash[work_id][:class_name].constantize).run
@@ -92,6 +93,7 @@ module Bulkrax
       Bulkrax::ObjectFactory.new(attributes: attrs,
                                  source_identifier_value: entry.identifier,
                                  work_identifier: entry.parser.work_identifier,
+                                 collection_field_mapping: entry.parser.collection_field_mapping,
                                  replace_files: false,
                                  user: user,
                                  klass: entry.factory_class).run
@@ -111,6 +113,7 @@ module Bulkrax
       Bulkrax::ObjectFactory.new(attributes: attrs,
                                  source_identifier_value: entry.identifier,
                                  work_identifier: entry.parser.work_identifier,
+                                 collection_field_mapping: entry.parser.collection_field_mapping,
                                  replace_files: false,
                                  user: user,
                                  klass: entry.factory_class).run

--- a/app/jobs/bulkrax/import_collection_job.rb
+++ b/app/jobs/bulkrax/import_collection_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  class ImportWorkCollectionJob < ApplicationJob
+  class ImportCollectionJob < ApplicationJob
     queue_as :import
 
     # rubocop:disable Rails/SkipsModelValidations

--- a/app/jobs/bulkrax/import_work_collection_job.rb
+++ b/app/jobs/bulkrax/import_work_collection_job.rb
@@ -28,7 +28,7 @@ module Bulkrax
       collection          = entry.factory.find
       permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: collection.id)
 
-      Hyrax::PermissionTemplateAccess.create!(
+      Hyrax::PermissionTemplateAccess.find_or_create_by!(
         permission_template_id: permission_template.id,
         agent_id: user.user_key,
         agent_type: 'user',

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -30,7 +30,7 @@ module Bulkrax
     end
 
     def update_current_run_counters(importer)
-      importer.current_run.total_work_entries = importer.parser.works_total
+      importer.current_run.total_work_entries = importer.limit || importer.parser.works_total || importer.parser.total
       importer.current_run.total_collection_entries = importer.parser.collections_total
       importer.current_run.save!
     end

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -30,7 +30,7 @@ module Bulkrax
     end
 
     def update_current_run_counters(importer)
-      importer.current_run.total_work_entries = importer.limit || importer.parser.works_total || importer.parser.total
+      importer.current_run.total_work_entries = importer.limit || importer.parser.works_total
       importer.current_run.total_collection_entries = importer.parser.collections_total
       importer.current_run.save!
     end

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -30,7 +30,7 @@ module Bulkrax
     end
 
     def update_current_run_counters(importer)
-      importer.current_run.total_work_entries = importer.limit || importer.parser.total
+      importer.current_run.total_work_entries = importer.parser.works_total
       importer.current_run.total_collection_entries = importer.parser.collections_total
       importer.current_run.save!
     end

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -10,7 +10,7 @@ module Bulkrax
       self.parsed_metadata = {}
       self.parsed_metadata[work_identifier] = self.identifier
       record.each do |key, value|
-        next if %w[collection collections].include?(key_without_numbers(key))
+        next if self.parser.collection_field_mapping.to_s == key_without_numbers(key)
 
         index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
         add_metadata(key_without_numbers(key), value, index)

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -7,13 +7,25 @@ module Bulkrax
     end
 
     def build_metadata
-      self.parsed_metadata = self.raw_metadata
+      self.parsed_metadata = {}
+      self.parsed_metadata[work_identifier] = self.identifier
+      record.each do |key, value|
+        next if %w[collection collections].include?(key_without_numbers(key))
+
+        index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
+        add_metadata(key_without_numbers(key), value, index)
+      end
+      add_collection_type_gid
+      add_visibility
+      add_rights_statement
+      add_collections
       add_local
-      return self.parsed_metadata
+
+      self.parsed_metadata
     end
 
-    def collections_created?
-      true
+    def add_collection_type_gid
+      self.parsed_metadata['collection_type_gid'] = ::Hyrax::CollectionType.find_or_create_default_collection_type.gid if self.parsed_metadata['collection_type_gid'].blank?
     end
   end
 end

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -6,22 +6,10 @@ module Bulkrax
       Collection
     end
 
-    def build_metadata
-      self.parsed_metadata = {}
+    # Use identifier set by CsvParser#unique_collection_identifier, which falls back
+    # on the Collection's first title if record[source_identifier] is not present
+    def add_identifier
       self.parsed_metadata[work_identifier] = self.identifier
-      record.each do |key, value|
-        next if self.parser.collection_field_mapping.to_s == key_without_numbers(key)
-
-        index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
-        add_metadata(key_without_numbers(key), value, index)
-      end
-      add_collection_type_gid
-      add_visibility
-      add_rights_statement
-      add_collections
-      add_local
-
-      self.parsed_metadata
     end
 
     def add_collection_type_gid

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -25,7 +25,9 @@ module Bulkrax
     end
 
     def add_collection_type_gid
-      self.parsed_metadata['collection_type_gid'] = ::Hyrax::CollectionType.find_or_create_default_collection_type.gid if self.parsed_metadata['collection_type_gid'].blank?
+      return if self.parsed_metadata['collection_type_gid'].present?
+
+      self.parsed_metadata['collection_type_gid'] = ::Hyrax::CollectionType.find_or_create_default_collection_type.gid
     end
   end
 end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -47,7 +47,7 @@ module Bulkrax
       self.parsed_metadata = {}
       self.parsed_metadata[work_identifier] = [record[source_identifier]]
       record.each do |key, value|
-        next if %w[collection collections].include?(key_without_numbers(key))
+        next if self.parser.collection_field_mapping.to_s == key_without_numbers(key)
 
         index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
         add_metadata(key_without_numbers(key), value, index)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -45,20 +45,37 @@ module Bulkrax
       raise StandardError, "Missing required elements, missing element(s) are: #{importerexporter.parser.missing_elements(keys_without_numbers(record.keys)).join(', ')}" unless importerexporter.parser.required_elements?(keys_without_numbers(record.keys))
 
       self.parsed_metadata = {}
+      add_identifier
+      add_metadata_for_model
+      add_visibility
+      add_ingested_metadata
+      add_rights_statement
+      add_collections
+      add_local
+
+      self.parsed_metadata
+    end
+
+    def add_identifier
       self.parsed_metadata[work_identifier] = [record[source_identifier]]
+    end
+
+    def add_metadata_for_model
+      if factory_class == Collection
+        add_collection_type_gid
+      else
+        add_file unless importerexporter.metadata_only?
+        add_admin_set_id
+      end
+    end
+
+    def add_ingested_metadata
       record.each do |key, value|
         next if self.parser.collection_field_mapping.to_s == key_without_numbers(key)
 
         index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
         add_metadata(key_without_numbers(key), value, index)
       end
-      add_file unless importerexporter.metadata_only?
-      add_visibility
-      add_rights_statement
-      add_admin_set_id
-      add_collections
-      add_local
-      self.parsed_metadata
     end
 
     def add_file

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -100,7 +100,7 @@ module Bulkrax
       @current_run ||= if file? && zip?
                          self.importer_runs.create!
                        else
-                         self.importer_runs.create!(total_work_entries: parser.works_total, total_collection_entries: parser.collections_total)
+                         self.importer_runs.create!(total_work_entries: self.limit || parser.works_total || parser.total, total_collection_entries: parser.collections_total)
                        end
     end
 

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -100,7 +100,7 @@ module Bulkrax
       @current_run ||= if file? && zip?
                          self.importer_runs.create!
                        else
-                         self.importer_runs.create!(total_work_entries: self.limit || parser.works_total || parser.total, total_collection_entries: parser.collections_total)
+                         self.importer_runs.create!(total_work_entries: self.limit || parser.works_total, total_collection_entries: parser.collections_total)
                        end
     end
 

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -100,7 +100,7 @@ module Bulkrax
       @current_run ||= if file? && zip?
                          self.importer_runs.create!
                        else
-                         self.importer_runs.create!(total_work_entries: self.limit || parser.total, total_collection_entries: parser.collections_total)
+                         self.importer_runs.create!(total_work_entries: parser.works_total, total_collection_entries: parser.collections_total)
                        end
     end
 

--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -125,12 +125,12 @@ module Bulkrax
       field = field.gsub('_attributes', '')
 
       return false if excluded?(field)
-      return true if ['id', 'collections', 'file', 'remote_files', 'model', 'delete'].include?(field)
+      return true if %W[id file remote_files model delete #{parser.collection_field_mapping}].include?(field)
       return factory_class.method_defined?(field) && factory_class.properties[field].present?
     end
 
     def multiple?(field)
-      return true if field == 'file' || field == 'remote_files' || field == 'collections'
+      return true if %W[file remote_files #{parser.collection_field_mapping}].include?(field)
       return false if field == 'model'
 
       field_supported?(field) && factory_class&.properties&.[](field)&.[]('multiple')

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -68,6 +68,7 @@ module Bulkrax
       @factory ||= Bulkrax::ObjectFactory.new(attributes: self.parsed_metadata,
                                               source_identifier_value: identifier,
                                               work_identifier: parser.work_identifier,
+                                              collection_field_mapping: parser.collection_field_mapping,
                                               replace_files: replace_files,
                                               user: user,
                                               klass: factory_class,

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -82,7 +82,7 @@ module Bulkrax
            else
              Bulkrax.default_work_type
            end
-      fc.constantize
+      fc.camelcase.constantize
     rescue NameError
       nil
     rescue

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -82,7 +82,7 @@ module Bulkrax
            else
              Bulkrax.default_work_type
            end
-      fc.camelcase.constantize
+      fc.downcase.camelcase.constantize
     rescue NameError
       nil
     rescue

--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -25,6 +25,7 @@ module Bulkrax
       if collection
         current_run.total_collection_entries = index + 1 unless parser.collections_total.positive?
       else
+        # TODO: differentiate between work and collection counts for exporters
         current_run.total_work_entries = index + 1 unless limit.to_i.positive? || parser.total.positive?
       end
       current_run.enqueued_records = index + 1

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  class ApplicationParser
+  class ApplicationParser # rubocop:disable Metrics/ClassLength
     attr_accessor :importerexporter, :headers
     alias importer importerexporter
     alias exporter importerexporter

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -60,6 +60,17 @@ module Bulkrax
       @identifier_hash
     end
 
+    def collection_field_mapping
+      Bulkrax.collection_field_mapping[self.entry_class.to_s]&.to_sym || :collection
+    end
+
+    def model_field_mappings
+      model_mappings = Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || []
+      model_mappings |= ['model']
+
+      model_mappings
+    end
+
     def perform_method
       if self.validate_only
         'perform_now'

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -58,7 +58,7 @@ module Bulkrax
           collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid
         }
         new_entry = find_or_create_entry(collection_entry_class, collection, 'Bulkrax::Importer', metadata)
-        ImportWorkCollectionJob.perform_now(new_entry.id, current_run.id)
+        ImportCollectionJob.perform_now(new_entry.id, current_run.id)
         increment_counters(index, true)
       end
     end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -83,7 +83,7 @@ module Bulkrax
     end
 
     def collections
-      records.map { |r| r[:collection].split(/\s*[;|]\s*/) if r[:collection].present? }.flatten.compact.uniq
+      records.map { |r| r[collection_field_mapping].split(/\s*[;|]\s*/) if r[collection_field_mapping].present? }.flatten.compact.uniq
     end
 
     def collections_total

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -90,8 +90,10 @@ module Bulkrax
       collections.size
     end
 
-    # @todo not yet supported
-    def works_total; end
+    # TODO: change to differentiate between collection and work records when adding ability to import collection metadata
+    def works_total
+      total
+    end
 
     def total
       metadata_paths.count

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -90,6 +90,9 @@ module Bulkrax
       collections.size
     end
 
+    # @todo not yet supported
+    def works_total; end
+
     def total
       metadata_paths.count
     end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -2,7 +2,7 @@
 
 require 'csv'
 module Bulkrax
-  class CsvParser < ApplicationParser
+  class CsvParser < ApplicationParser # rubocop:disable Metrics/ClassLength
     include ErroredEntries
     def self.export_supported?
       true

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -74,7 +74,7 @@ module Bulkrax
         next if collection.blank?
         break if records.find_index(collection).present? && limit_reached?(limit, records.find_index(collection))
 
-        new_entry = find_or_create_entry(collection_entry_class, collection_entry_identifier(collection), 'Bulkrax::Importer', collection.to_h.compact)
+        new_entry = find_or_create_entry(collection_entry_class, unique_collection_identifier(collection), 'Bulkrax::Importer', collection.to_h.compact)
         # TODO: add support for :delete option
         ImportCollectionJob.perform_now(new_entry.id, current_run.id)
         increment_counters(index, true)
@@ -275,7 +275,7 @@ module Bulkrax
 
     private
 
-    def collection_entry_identifier(collection_hash)
+    def unique_collection_identifier(collection_hash)
       entry_uid = collection_hash[source_identifier]
       entry_uid ||= if Bulkrax.fill_in_blank_source_identifiers.present?
                       Bulkrax.fill_in_blank_source_identifiers.call(self, records.find_index(collection_hash))

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -276,7 +276,7 @@ module Bulkrax
     private
 
     def collection_entry_identifier(collection_hash)
-      entry_uid = collection_hash[work_identifier]
+      entry_uid = collection_hash[source_identifier]
       entry_uid ||= if Bulkrax.fill_in_blank_source_identifiers.present?
                       Bulkrax.fill_in_blank_source_identifiers.call(self, records.find_index(collection_hash))
                     else

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -18,14 +18,11 @@ module Bulkrax
     end
 
     def collections
-      col_mapping = Bulkrax.collection_field_mapping[self.entry_class.to_s]&.to_sym || :collection
-      model_mappings = Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || []
-      model_mappings |= ['model']
       # retrieve a list of unique collections
       records.map do |r|
         collections = []
-        r[col_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } } if r[col_mapping].present?
-        model_mappings.each do |model_mapping|
+        r[collection_field_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } } if r[collection_field_mapping].present?
+        model_field_mappings.each do |model_mapping|
           collections << r if r[model_mapping.to_sym]&.downcase == 'collection'
         end
         collections

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -62,12 +62,14 @@ module Bulkrax
         next if collection.blank?
         title_array = collection[:title].split(/\s*[;|]\s*/)
         identifier = collection[work_identifier] || title_array.first
+
         metadata = {
-          title: title_array,
-          work_identifier => identifier,
           visibility: 'open',
           collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid
-        }
+        }.merge!(collection.select { |k, _v| ::Collection.attribute_method?(k) })
+        metadata[:title] = title_array
+        metadata[work_identifier] = identifier
+
         new_entry = find_or_create_entry(collection_entry_class, identifier, 'Bulkrax::Importer', metadata)
         ImportWorkCollectionJob.perform_now(new_entry.id, current_run.id)
         increment_counters(index, true)

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -19,7 +19,7 @@ module Bulkrax
 
     def collections
       col_mapping = Bulkrax.collection_field_mapping[self.entry_class.to_s]&.to_sym || :collection
-      model_mappings = Bulkrax.field_mappings[self.class.to_s].dig('model', :from) || []
+      model_mappings = Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || []
       model_mappings |= ['model']
       # retrieve a list of unique collections
       records.map do |r|

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -24,10 +24,10 @@ module Bulkrax
       # retrieve a list of unique collections
       records.map do |r|
         collections = []
+        r[col_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } } if r[col_mapping].present?
         model_mappings.each do |model_mapping|
           collections << r if r[model_mapping.to_sym]&.downcase == 'collection'
         end
-        r[col_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } } if r[col_mapping].present?
         collections
       end.flatten.compact.uniq
     end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -9,14 +9,12 @@ module Bulkrax
     end
 
     def collections
-      collection_field_mapping = Bulkrax.collection_field_mapping[self.entry_class.to_s]&.to_sym || :collection
+      col_mapping = Bulkrax.collection_field_mapping[self.entry_class.to_s]&.to_sym || :collection
       # retrieve a list of unique collections
       records.map do |r|
         collections = []
         collections << r if r[:model]&.downcase == 'collection'
-        if r[collection_field_mapping].present?
-          r[collection_field_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } }
-        end
+        r[col_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } } if r[col_mapping].present?
         collections
       end.flatten.compact.uniq
     end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -22,7 +22,7 @@ module Bulkrax
       # retrieve a list of unique collections
       records.map do |r|
         collections = []
-        Bulkrax.field_mappings[self.class.to_s].dig('model', :from).each do |model_mapping|
+        Bulkrax.field_mappings[self.class.to_s].dig('model', :from)&.each do |model_mapping|
           collections << r if r[model_mapping.to_sym]&.downcase == 'collection'
         end
         r[col_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } } if r[col_mapping].present?

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -119,8 +119,10 @@ module Bulkrax
       end
     end
 
-    # @todo not yet supported
-    def works_total; end
+    # TODO: change to differentiate between collection and work records when adding ability to import collection metadata
+    def works_total
+      total
+    end
 
     def create_parent_child_relationships; end
 

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -119,6 +119,9 @@ module Bulkrax
       end
     end
 
+    # @todo not yet supported
+    def works_total; end
+
     def create_parent_child_relationships; end
 
     def total

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -75,7 +75,7 @@ module Bulkrax
 
         new_entry = collection_entry_class.where(importerexporter: importerexporter, identifier: unique_collection_identifier, raw_metadata: metadata).first_or_create!
         # perform now to ensure this gets created before work imports start
-        ImportWorkCollectionJob.perform_now(new_entry.id, importerexporter.current_run.id)
+        ImportCollectionJob.perform_now(new_entry.id, importerexporter.current_run.id)
         increment_counters(index, true)
       end
     end

--- a/app/parsers/bulkrax/xml_parser.rb
+++ b/app/parsers/bulkrax/xml_parser.rb
@@ -12,8 +12,10 @@ module Bulkrax
     # @todo not yet supported
     def create_collections; end
 
-    # @todo not yet supported
-    def works_total; end
+    # TODO: change to differentiate between collection and work records when adding ability to import collection metadata
+    def works_total
+      total
+    end
 
     # @todo not yet supported
     def import_fields; end

--- a/app/parsers/bulkrax/xml_parser.rb
+++ b/app/parsers/bulkrax/xml_parser.rb
@@ -13,6 +13,9 @@ module Bulkrax
     def create_collections; end
 
     # @todo not yet supported
+    def works_total; end
+
+    # @todo not yet supported
     def import_fields; end
 
     def valid_import?

--- a/spec/fixtures/csv/collections.csv
+++ b/spec/fixtures/csv/collections.csv
@@ -1,0 +1,3 @@
+source_identifier,model,title,description
+1,Collection,Collection 1 Title,First collection's description
+2,collection,Collection 2 Title,Second collection's description

--- a/spec/fixtures/csv/mixed_works_and_collections.csv
+++ b/spec/fixtures/csv/mixed_works_and_collections.csv
@@ -1,0 +1,5 @@
+source_identifier,model,title,description,collection
+col_1,Collection,Collection 1 Title,First collection's description,
+work_1,Work,Work 1 Title,First work's description,
+col_2,collection,Collection 2 Title,Second collection's description,
+work_2,work,Work 2 Title,Second work's description,Second Work's Collection

--- a/spec/jobs/bulkrax/child_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/child_relationships_job_spec.rb
@@ -42,6 +42,7 @@ module Bulkrax
           attributes: { id: "work_id", work_members_attributes: { 0 => { id: "another_work_id" } } },
           source_identifier_value: 'entry_work',
           work_identifier: :source,
+          collection_field_mapping: :collection,
           replace_files: false,
           user: importer.user,
           klass: Work
@@ -95,6 +96,7 @@ module Bulkrax
           attributes: { collections: [{ id: "collection_id" }], id: "another_work_id" },
           source_identifier_value: 'csv_entry',
           work_identifier: :source,
+          collection_field_mapping: :collection,
           replace_files: false,
           user: importer.user,
           klass: Work
@@ -132,6 +134,7 @@ module Bulkrax
           attributes: { children: ["collection_id"], id: "collection_id" },
           source_identifier_value: 'entry_collection',
           work_identifier: :source,
+          collection_field_mapping: :collection,
           replace_files: false,
           user: importer.user,
           klass: Collection

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -6,6 +6,45 @@ module Bulkrax
   RSpec.describe CsvParser do
     subject { described_class.new(importer) }
 
+    describe '#create_collections' do
+      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
+      # let(:entry) { FactoryBot.create(:bulkrax_csv_entry_collection, importerexporter: importer) }
+
+      context 'when importing collections by title through works' do
+        before do
+          importer.parser_fields = { import_file_path: './spec/fixtures/csv/good.csv' }
+          allow(ImportCollectionJob).to receive(:perform_now)
+        end
+
+        it 'creates CSV collection entries for each collection' do
+          expect { subject.create_collections }.to change(CsvCollectionEntry, :count).by(2)
+        end
+
+        it 'runs an ImportCollectionJob for each entry' do
+          expect(ImportCollectionJob).to receive(:perform_now).twice
+
+          subject.create_collections
+        end
+      end
+
+      context 'when importing collections with metadata' do
+        before do
+          importer.parser_fields = { import_file_path: './spec/fixtures/csv/collections.csv' }
+          allow(ImportCollectionJob).to receive(:perform_now)
+        end
+
+        it 'creates CSV collection entries for each collection' do
+          expect { subject.create_collections }.to change(CsvCollectionEntry, :count).by(2)
+        end
+
+        it 'runs an ImportCollectionJob for each entry' do
+          expect(ImportCollectionJob).to receive(:perform_now).twice
+
+          subject.create_collections
+        end
+      end
+    end
+
     describe '#create_works' do
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
       let(:entry) { FactoryBot.create(:bulkrax_entry, importerexporter: importer) }
@@ -87,45 +126,6 @@ module Bulkrax
           subject.records
           expect(subject.total).to eq(2)
           expect(subject.collections_total).to eq(2)
-        end
-      end
-    end
-
-    describe '#create_collections' do
-      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
-      # let(:entry) { FactoryBot.create(:bulkrax_csv_entry_collection, importerexporter: importer) }
-
-      context 'when importing collections by title through works' do
-        before do
-          importer.parser_fields = { import_file_path: './spec/fixtures/csv/good.csv' }
-          allow(ImportCollectionJob).to receive(:perform_now)
-        end
-
-        it 'creates CSV collection entries for each collection' do
-          expect { subject.create_collections }.to change(CsvCollectionEntry, :count).by(2)
-        end
-
-        it 'runs an ImportCollectionJob for each entry' do
-          expect(ImportCollectionJob).to receive(:perform_now).twice
-
-          subject.create_collections
-        end
-      end
-
-      context 'when importing collections with metadata' do
-        before do
-          importer.parser_fields = { import_file_path: './spec/fixtures/csv/collections.csv' }
-          allow(ImportCollectionJob).to receive(:perform_now)
-        end
-
-        it 'creates CSV collection entries for each collection' do
-          expect { subject.create_collections }.to change(CsvCollectionEntry, :count).by(2)
-        end
-
-        it 'runs an ImportCollectionJob for each entry' do
-          expect(ImportCollectionJob).to receive(:perform_now).twice
-
-          subject.create_collections
         end
       end
     end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -42,7 +42,7 @@ module Bulkrax
 
         context 'is set' do
           before do
-            allow(Bulkrax).to receive(:collection_field_mapping).and_return({ 'Bulkrax::CsvEntry' => 'parent' })
+            allow(subject).to receive(:collection_field_mapping).and_return(:parent)
           end
 
           it 'the collection field mapping is used' do
@@ -52,10 +52,6 @@ module Bulkrax
         end
 
         context 'is not set' do
-          before do
-            allow(Bulkrax).to receive(:collection_field_mapping).and_return({})
-          end
-
           it 'the mapping falls back on :collection' do
             expect(subject.collections).not_to include({ title: 'parent mapping' })
             expect(subject.collections).to include({ title: 'collection mapping' })
@@ -474,6 +470,30 @@ module Bulkrax
         expect(headers).to include('multiple_objects_position_1_1')
         expect(headers).to include('multiple_objects_position_1_2')
         expect(headers).to include('multiple_objects_first_name_2')
+      end
+    end
+
+    describe '#collection_field_mapping' do
+      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
+
+      context 'when the mapping is set' do
+        before do
+          allow(Bulkrax).to receive(:collection_field_mapping).and_return({ 'Bulkrax::CsvEntry' => 'parent' })
+        end
+
+        it 'returns the mapping' do
+          expect(subject.collection_field_mapping).to eq(:parent)
+        end
+      end
+
+      context 'when the mapping is not set' do
+        before do
+          allow(Bulkrax).to receive(:collection_field_mapping).and_return({})
+        end
+
+        it 'returns :collection' do
+          expect(subject.collection_field_mapping).to eq(:collection)
+        end
       end
     end
   end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -74,9 +74,7 @@ module Bulkrax
 
         context 'when :model has field mappings' do
           before do
-            allow(Bulkrax)
-              .to receive(:field_mappings)
-              .and_return({ 'Bulkrax::CsvParser' => { 'model' => { from: ['map_1', 'map_2'] } } })
+            allow(subject).to receive(:model_field_mappings).and_return(['map_1', 'map_2', 'model'])
           end
 
           it 'uses the field mappings' do
@@ -86,12 +84,6 @@ module Bulkrax
         end
 
         context 'when :model does not have field mappings' do
-          before do
-            allow(Bulkrax)
-              .to receive(:field_mappings)
-              .and_return({})
-          end
-
           it 'uses :model' do
             expect(subject.collections).to include({ model: 'Collection', title: 'C3' })
             expect(subject.collections).not_to include({ map_1: 'Collection', title: 'C1' })
@@ -493,6 +485,32 @@ module Bulkrax
 
         it 'returns :collection' do
           expect(subject.collection_field_mapping).to eq(:collection)
+        end
+      end
+    end
+
+    describe '#model_field_mappings' do
+      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
+
+      context 'when mappings are set' do
+        before do
+          allow(Bulkrax)
+            .to receive(:field_mappings)
+            .and_return({ 'Bulkrax::CsvParser' => { 'model' => { from: ['map_1', 'map_2'] } } })
+        end
+
+        it 'includes the mappings' do
+          expect(subject.model_field_mappings).to include('map_1', 'map_2')
+        end
+
+        it 'always includes "model"' do
+          expect(subject.model_field_mappings).to include('model')
+        end
+      end
+
+      context 'when mappings are set' do
+        it 'falls back on "model"' do
+          expect(subject.model_field_mappings).to eq(['model'])
         end
       end
     end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -19,7 +19,7 @@ module Bulkrax
 
       it 'includes rows whose :model is set to Collection' do
         expect(subject.collections.collect { |w| w[:title] })
-          .to contain_exactly(*['Collection 1 Title', 'Collection 2 Title', "Second Work's Collection"])
+          .to contain_exactly('Collection 1 Title', 'Collection 2 Title', "Second Work's Collection")
       end
 
       it 'matches :model column case-insensitively' do
@@ -32,10 +32,12 @@ module Bulkrax
         before do
           allow(subject)
             .to receive(:records)
-            .and_return([
-              { collection: 'collection mapping', title: 'W1', model: 'work' },
-              { parent: 'parent mapping', title: 'W2', model: 'work' }
-            ])
+            .and_return(
+              [
+                { collection: 'collection mapping', title: 'W1', model: 'work' },
+                { parent: 'parent mapping', title: 'W2', model: 'work' }
+              ]
+            )
         end
 
         context 'is set' do
@@ -65,11 +67,13 @@ module Bulkrax
         before do
           allow(subject)
             .to receive(:records)
-            .and_return([
-              { map_1: 'Collection', title: 'C1' },
-              { map_2: 'Collection', title: 'C2' },
-              { model: 'Collection', title: 'C3' }
-            ])
+            .and_return(
+              [
+                { map_1: 'Collection', title: 'C1' },
+                { map_2: 'Collection', title: 'C2' },
+                { model: 'Collection', title: 'C3' }
+              ]
+            )
         end
 
         context 'when :model has field mappings' do
@@ -110,7 +114,7 @@ module Bulkrax
 
       it 'returns all work records' do
         expect(subject.works.collect { |w| w[:source_identifier] })
-          .to contain_exactly(*['work_1', 'work_2'])
+          .to contain_exactly('work_1', 'work_2')
       end
     end
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -18,23 +18,8 @@ module Bulkrax
       end
 
       it 'includes rows whose :model is set to Collection' do
-        collection_1_raw_data = {
-          source_identifier: 'col_1',
-          model: 'Collection',
-          title: 'Collection 1 Title',
-          description: "First collection's description",
-          collection: nil
-        }
-        collection_2_raw_data = {
-          source_identifier: 'col_2',
-          model: 'collection',
-          title: 'Collection 2 Title',
-          description: "Second collection's description",
-          collection: nil
-        }
-
-        expect(subject.collections).to include(collection_1_raw_data)
-        expect(subject.collections).to include(collection_2_raw_data)
+        expect(subject.collections.collect { |w| w[:title] })
+          .to contain_exactly(*['Collection 1 Title', 'Collection 2 Title', "Second Work's Collection"])
       end
 
       it 'matches :model column case-insensitively' do
@@ -113,6 +98,19 @@ module Bulkrax
             expect(subject.collections).not_to include({ map_2: 'Collection', title: 'C2' })
           end
         end
+      end
+    end
+
+    describe '#works' do
+      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
+
+      before do
+        importer.parser_fields = { import_file_path: './spec/fixtures/csv/mixed_works_and_collections.csv' }
+      end
+
+      it 'returns all work records' do
+        expect(subject.works.collect { |w| w[:source_identifier] })
+          .to contain_exactly(*['work_1', 'work_2'])
       end
     end
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -154,6 +154,47 @@ module Bulkrax
           subject.create_collections
         end
       end
+
+      describe 'setting collection entry identifiers' do
+        before do
+          allow(subject)
+            .to receive(:collections)
+            .and_return([record_hash])
+        end
+
+        context 'when collection record has a source_identifier' do
+          let(:record_hash) { { source_identifier: 'csid' } }
+
+          it "uses the record's source_identifier as the entry's identifier" do
+            subject.create_collections
+
+            expect(importer.entries.last.identifier).to eq('csid')
+          end
+        end
+
+        context 'when collection record does not have a source_identifier' do
+          let(:record_hash) { { title: 'no source id | alt title' } }
+
+          it "uses the record's first title as the entry's identifier" do
+            subject.create_collections
+
+            expect(importer.entries.last.identifier).to eq('no source id')
+          end
+
+          context 'when Bulkrax is set to fill in blank source_identifiers' do
+            before do
+              allow(Bulkrax).to receive_message_chain(:fill_in_blank_source_identifiers, :present?).and_return(true)
+              allow(Bulkrax).to receive_message_chain(:fill_in_blank_source_identifiers, :call).and_return("#{importer.id}-99")
+            end
+
+            it "uses the generated identifier as the entry's identifier" do
+              subject.create_collections
+
+              expect(importer.entries.last.identifier).to eq("#{importer.id}-99")
+            end
+          end
+        end
+      end
     end
 
     describe '#create_works' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -5,10 +5,9 @@ require 'rails_helper'
 module Bulkrax
   RSpec.describe CsvParser do
     subject { described_class.new(importer) }
+    let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
 
     describe '#collections' do
-      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
-
       before do
         importer.parser_fields = { import_file_path: './spec/fixtures/csv/mixed_works_and_collections.csv' }
       end
@@ -94,8 +93,6 @@ module Bulkrax
     end
 
     describe '#works' do
-      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
-
       before do
         importer.parser_fields = { import_file_path: './spec/fixtures/csv/mixed_works_and_collections.csv' }
       end
@@ -107,8 +104,6 @@ module Bulkrax
     end
 
     describe '#create_collections' do
-      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
-
       context 'when importing collections by title through works' do
         before do
           importer.parser_fields = { import_file_path: './spec/fixtures/csv/good.csv' }
@@ -186,7 +181,6 @@ module Bulkrax
     end
 
     describe '#create_works' do
-      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
       let(:entry) { FactoryBot.create(:bulkrax_entry, importerexporter: importer) }
 
       before do
@@ -466,8 +460,6 @@ module Bulkrax
     end
 
     describe '#collection_field_mapping' do
-      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
-
       context 'when the mapping is set' do
         before do
           allow(Bulkrax).to receive(:collection_field_mapping).and_return({ 'Bulkrax::CsvEntry' => 'parent' })
@@ -490,8 +482,6 @@ module Bulkrax
     end
 
     describe '#model_field_mappings' do
-      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
-
       context 'when mappings are set' do
         before do
           allow(Bulkrax)

--- a/spec/parsers/bulkrax/xml_parser_spec.rb
+++ b/spec/parsers/bulkrax/xml_parser_spec.rb
@@ -86,5 +86,32 @@ module Bulkrax
         end
       end
     end
+
+    describe '#model_field_mappings' do
+      subject(:xml_parser) { described_class.new(importer) }
+      let(:importer) { FactoryBot.create(:bulkrax_importer_xml) }
+
+      context 'when mappings are set' do
+        before do
+          allow(Bulkrax)
+            .to receive(:field_mappings)
+            .and_return({ 'Bulkrax::XmlParser' => { 'model' => { from: ['map_1', 'map_2'] } } })
+        end
+
+        it 'includes the mappings' do
+          expect(xml_parser.model_field_mappings).to include('map_1', 'map_2')
+        end
+
+        it 'always includes "model"' do
+          expect(xml_parser.model_field_mappings).to include('model')
+        end
+      end
+
+      context 'when mappings are set' do
+        it 'falls back on "model"' do
+          expect(xml_parser.model_field_mappings).to eq(['model'])
+        end
+      end
+    end
   end
 end

--- a/spec/parsers/bulkrax/xml_parser_spec.rb
+++ b/spec/parsers/bulkrax/xml_parser_spec.rb
@@ -61,5 +61,30 @@ module Bulkrax
         end
       end
     end
+
+    describe '#collection_field_mapping' do
+      subject(:xml_parser) { described_class.new(importer) }
+      let(:importer) { FactoryBot.create(:bulkrax_importer_xml) }
+
+      context 'when the mapping is set' do
+        before do
+          allow(Bulkrax).to receive(:collection_field_mapping).and_return({ 'Bulkrax::XmlEntry' => 'parent' })
+        end
+
+        it 'returns the mapping' do
+          expect(xml_parser.collection_field_mapping).to eq(:parent)
+        end
+      end
+
+      context 'when the mapping is not set' do
+        before do
+          allow(Bulkrax).to receive(:collection_field_mapping).and_return({})
+        end
+
+        it 'returns :collection' do
+          expect(xml_parser.collection_field_mapping).to eq(:collection)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# Summary

Add ability to import collections with metadata when `:model` or model mappings are set to Collection **(CSV only)** 

| model | source_identifier | title | description |
| --- | --- | --- | --- |
| Collection | collection_1 | First Collection | Lorem ipsum |

Retains ability to import Collections by title when importing works 

| model | source_identifier | title | collection |
| --- | --- | --- | --- |
| Work | work_1 | First Work | Parent Collection |