### PR TITLE
Bulkrax Views Not Overridable

### DIFF
--- a/lib/bulkrax/engine.rb
+++ b/lib/bulkrax/engine.rb
@@ -25,7 +25,7 @@ module Bulkrax
     config.after_initialize do
       my_engine_root = Bulkrax::Engine.root.to_s
       paths = ActionController::Base.view_paths.collect(&:to_s)
-      hyrax_path = paths.detect { |path| path.match('/hyrax-') }
+      hyrax_path = paths.detect { |path| path.match(/\/hyrax-[\d\.]+.*/) }
       paths = if hyrax_path
                 paths.insert(paths.index(hyrax_path), my_engine_root + '/app/views')
               else


### PR DESCRIPTION
app was matching on hyrax- before, which was fine UNLESS you application was named hyrax- or was in a directory called hyrax-. Current Hyrax Dockerfile puts all apps in hyrax-webapp causing load order issues on views.  We now match with a more specific regexp to make sure we only see hyrax-X.X.X or hyrax-X.X.X-pre