### PR TITLE
Respect nil values

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -56,7 +56,7 @@ module Bulkrax
     end
 
     def find
-      return find_by_id if attributes[:id]
+      return find_by_id if attributes[:id].present?
       return search_by_identifier if attributes[work_identifier].present?
     end
 

--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -20,9 +20,9 @@ module Bulkrax
         return unless content.send(self.if[0], Regexp.new(self.if[1]))
       end
 
-      @result = content.to_s.gsub(/\s/, ' ') # remove any line feeds and tabs
-      @result.strip!
-      process_split
+      # @result will evaluate to an empty string for nil content values
+      @result = content.to_s.gsub(/\s/, ' ').strip # remove any line feeds and tabs
+      process_split if @result.present?
       @result = @result[0] if @result.is_a?(Array) && @result.size == 1
       process_parse
       return @result
@@ -66,14 +66,14 @@ module Bulkrax
     end
 
     def parse_subject(src)
-      string = src.to_s.strip.downcase
+      string = src.strip.downcase
       return if string.blank?
 
       string.slice(0, 1).capitalize + string.slice(1..-1)
     end
 
     def parse_types(src)
-      src.to_s.strip.titleize
+      src.strip.titleize
     end
 
     # Allow for mapping a model field to the work type or collection

--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -43,7 +43,6 @@ module Bulkrax
 
         value = if matcher
                   result = matcher.result(self, node_content)
-                  next unless result
                   matched_metadata(multiple, name, result, object_multiple)
                 elsif multiple
                   Rails.logger.info("Bulkrax Column automatically matched #{node_name}, #{node_content}")
@@ -53,7 +52,7 @@ module Bulkrax
                   single_metadata(node_content)
                 end
 
-        set_parsed_data(object_multiple, object_name, name, index, value) if value
+        set_parsed_data(object_multiple, object_name, name, index, value)
       end
     end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -71,7 +71,7 @@ module Bulkrax
         next if collection.blank?
         break if records.find_index(collection).present? && limit_reached?(limit, records.find_index(collection))
 
-        new_entry = find_or_create_entry(collection_entry_class, unique_collection_identifier(collection), 'Bulkrax::Importer', collection.to_h.compact)
+        new_entry = find_or_create_entry(collection_entry_class, unique_collection_identifier(collection), 'Bulkrax::Importer', collection.to_h)
         # TODO: add support for :delete option
         ImportCollectionJob.perform_now(new_entry.id, current_run.id)
         increment_counters(index, true)
@@ -87,7 +87,7 @@ module Bulkrax
         break if limit_reached?(limit, records.find_index(work))
 
         seen[work[source_identifier]] = true
-        new_entry = find_or_create_entry(entry_class, work[source_identifier], 'Bulkrax::Importer', work.to_h.compact)
+        new_entry = find_or_create_entry(entry_class, work[source_identifier], 'Bulkrax::Importer', work.to_h)
         if work[:delete].present?
           DeleteWorkJob.send(perform_method, new_entry, current_run)
         else


### PR DESCRIPTION
**https://github.com/samvera-labs/bulkrax/pull/373 must be merged first or we'll have the same problem that's fixed there.**

Ref: https://gitlab.com/notch8/britishlibrary/-/issues/185

# Expected behavior
- on import, all cell values (empty or filled in) are accounted for
- if a user would like to delete data on an import, remove the value from the cell under the appropriate header in the csv, and it will be removed from the metadata for that work
- metadata and files can be removed this way

# Demo
| | csv's | before | after |
| --- | --- | --- | --- |
| metadata only | with all values: [185_bc.csv](https://github.com/samvera-labs/bulkrax/files/7376400/185_bc.csv)<br> with only required values: [185_bc_round_trip.csv](https://github.com/samvera-labs/bulkrax/files/7376402/185_bc_round_trip.csv) | ![image](https://user-images.githubusercontent.com/29032869/137983674-1af2b67e-bdc3-41d4-9e90-c7cf5074ebac.png) | ![image](https://user-images.githubusercontent.com/29032869/137983726-94477707-1c26-48cf-ab3b-4ce17940f5a3.png) |
| metadata and file | with all values and a file:  [185_gw.csv](https://github.com/samvera-labs/bulkrax/files/7376409/185_gw.csv)<br> with all values, but no file: [185_gw_round_trip.csv](https://github.com/samvera-labs/bulkrax/files/7376410/185_gw_round_trip.csv) | ![image](https://user-images.githubusercontent.com/29032869/137984323-16773b97-4660-4fd9-afee-bd3649ab2c84.png) |  ![image](https://user-images.githubusercontent.com/29032869/137984377-5ac2c5f1-19ca-4566-a703-2e3921b3fb2c.png) |