### PR TITLE
Updates the migration versioning to be 5.1 for compatibility issues

### DIFF
--- a/db/migrate/20211004170708_change_bulkrax_statuses_error_message_column_type_to_text.rb
+++ b/db/migrate/20211004170708_change_bulkrax_statuses_error_message_column_type_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeBulkraxStatusesErrorMessageColumnTypeToText < ActiveRecord::Migration[5.2]
+class ChangeBulkraxStatusesErrorMessageColumnTypeToText < ActiveRecord::Migration[5.1]
   def change
     change_column :bulkrax_statuses, :error_message, :text
   end


### PR DESCRIPTION
Receiving an error in CI on our tests for GBH when updating the most current version of Bulkrax. You can see the error in CI located here at line 295: https://gitlab.com/notch8/GBH/-/jobs/1704295565

We should just be able to update the version back to 5.1.

Documentation: https://stackoverflow.com/questions/47126483/what-are-the-brackets-5-1-after-activerecord-migration-and-how-does-it-work

```rake aborted!
ArgumentError: Unknown migration version "5.2"; expected one of "4.2", "5.0", "5.1"
/usr/local/bundle/gems/activerecord-5.1.7/lib/active_record/migration/compatibility.rb:9:in `find'
/usr/local/bundle/gems/activerecord-5.1.7/lib/active_record/migration.rb:533:in `[]'
/usr/local/bundle/bundler/gems/bulkrax-0b9240097222/db/migrate/20211004170708_change_bulkrax_statuses_error_message_column_type_to_text.rb:1:in `<top (required)>'```

