### PR TITLE
Add port option to bulkrax API/CLI

### DIFF
--- a/lib/generators/bulkrax/templates/bin/importer
+++ b/lib/generators/bulkrax/templates/bin/importer
@@ -17,7 +17,8 @@ def main(opts = {})
   end
 
   update = opts[:importer_id].present?
-  url = build_url(opts.delete(:importer_id), opts.delete(:url))
+  port = opts[:port].presence
+  url = build_url(opts.delete(:importer_id), opts.delete(:url), port)
 
   headers = { 'Content-Type' => 'application/json' }
   headers['Authorization'] = "Token: #{opts.delete(:auth_token)}"
@@ -74,11 +75,12 @@ def build_params(opts = {})
   return params.compact
 end
 
-def build_url(importer_id, url)
+def build_url(importer_id, url, port = nil)
   if url.nil?
     protocol = Rails.application.config.force_ssl ? 'https://' : 'http://'
     host = Rails.application.config.action_mailer.default_url_options[:host]
     url = "#{protocol}#{host}"
+    url = "#{url}:#{port}" if port
   end
   path = Bulkrax::Engine.routes.url_helpers.polymorphic_path(Bulkrax::Importer)
   url = File.join(url, path)

--- a/lib/generators/bulkrax/templates/bin/importer
+++ b/lib/generators/bulkrax/templates/bin/importer
@@ -6,15 +6,7 @@ require_relative '../config/environment'
 require 'slop'
 
 def main(opts = {})
-  if opts[:importer_id].blank? && invalid?(opts)
-    puts 'Missing required parameters'
-    help
-  end
-
-  if opts[:auth_token].blank?
-    puts 'Missing Authentication Token --auth_token'
-    exit
-  end
+  check_required_params
 
   update = opts[:importer_id].present?
   port = opts[:port].presence
@@ -42,6 +34,18 @@ def main(opts = {})
              end
 
   puts "#{response.status} - #{response.body.truncate(200)}"
+end
+
+def check_required_params
+  if opts[:importer_id].blank? && invalid?(opts)
+    puts 'Missing required parameters'
+    help
+  end
+
+  if opts[:auth_token].blank? # rubocop:disable Style/GuardClause
+    puts 'Missing Authentication Token --auth_token'
+    exit
+  end
 end
 
 def invalid?(opts)

--- a/lib/generators/bulkrax/templates/config/bulkrax_api.yml
+++ b/lib/generators/bulkrax/templates/config/bulkrax_api.yml
@@ -82,3 +82,5 @@ bulkrax:
     auth_token:
       definition: 'Authentication token. Required for JSON requests only.'
       required: true
+    port:
+      definition: 'Port to use in http request. Defaults to 80. May need to set to 3000 when running in the development environment'


### PR DESCRIPTION
Fixes this error when using the API in development mode on an app configured to talk over port 3000: 

```
Failed to open TCP connection to localhost:80 (Cannot assign requested address - connect(2) for "localhost" port 80) (Faraday::ConnectionFailed)
```

- [x] Update [CLI documentation in Wiki](https://github.com/samvera-labs/bulkrax/wiki/CLI) 

Co-authored-by: Braydon Justice <braydon.justice@1268456bcltd.ca>