### PR TITLE
Condense "related" field mapping configs into the field_mappings

### DIFF
--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -32,9 +32,13 @@ module Bulkrax
       to: :importerexporter
 
     delegate :client,
-             :collection_name,
-             :user,
-             to: :parser
+      :collection_name,
+      :user,
+      :related_parents_raw_mapping,
+      :related_parents_parsed_mapping,
+      :related_children_raw_mapping,
+      :related_children_parsed_mapping,
+      to: :parser
 
     # Retrieve fields from the file
     # @param data - the source data
@@ -72,14 +76,6 @@ module Bulkrax
         ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
       )
       Bulkrax.collection_field_mapping[self.to_s]
-    end
-
-    def self.parents_field
-      Bulkrax.related_parents_field_mapping[self.to_s]
-    end
-
-    def self.children_field
-      Bulkrax.related_children_field_mapping[self.to_s]
     end
 
     def build

--- a/app/models/bulkrax/rdf_entry.rb
+++ b/app/models/bulkrax/rdf_entry.rb
@@ -26,7 +26,7 @@ module Bulkrax
       data = RDF::Writer.for(format).buffer do |writer|
         reader.each_statement do |statement|
           collections << statement.object.to_s if collection_field.present? && collection_field == statement.predicate.to_s
-          children << statement.object.to_s if children_field.present? && children_field == statement.predicate.to_s
+          children << statement.object.to_s if related_children_parsed_mapping.present? && related_children_parsed_mapping == statement.predicate.to_s
           delete = statement.object.to_s if /deleted/.match?(statement.predicate.to_s)
           writer << statement
         end
@@ -39,6 +39,15 @@ module Bulkrax
         collection: collections,
         children: children
       }
+    end
+
+    def self.related_children_parsed_mapping
+      return @related_children_parsed_mapping if @related_children_parsed_mapping.present?
+
+      rdf_related_children_field_mapping = Bulkrax.field_mappings['Bulkrax::RdfParser']&.select { |_, h| h.key?('related_children_field_mapping') }
+      return if rdf_related_children_field_mapping.blank?
+
+      @related_children_parsed_mapping = rdf_related_children_field_mapping&.keys&.first
     end
 
     def record

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -77,24 +77,24 @@ module Bulkrax
     end
 
     def add_parents
-      return if raw_metadata[self.class.parents_field].blank?
+      return if raw_metadata[related_parents_raw_mapping].blank?
 
-      parents_matcher = self.class.matcher(self.class.parents_field, self.mapping[self.class.parents_field].symbolize_keys)
+      parents_matcher = self.class.matcher(related_parents_parsed_mapping, self.mapping[related_parents_parsed_mapping].symbolize_keys)
       self.parsed_metadata['parents'] = if parents_matcher.present?
-                                          [parents_matcher.result(self, raw_metadata[self.class.parents_field])].flatten
+                                          [parents_matcher.result(self, raw_metadata[related_parents_raw_mapping])].flatten
                                         else
-                                          raw_metadata[self.class.parents_field].split(/\s*[;|]\s*/)
+                                          raw_metadata[related_parents_raw_mapping].split(/\s*[;|]\s*/)
                                         end
     end
 
     def add_children
-      return if raw_metadata[self.class.children_field].blank?
+      return if raw_metadata[related_children_raw_mapping].blank?
 
-      children_matcher = self.class.matcher(self.class.children_field, self.mapping[self.class.children_field].symbolize_keys)
+      children_matcher = self.class.matcher(related_children_parsed_mapping, self.mapping[related_children_parsed_mapping].symbolize_keys)
       self.parsed_metadata['children'] = if children_matcher.present?
-                                           [children_matcher.result(self, raw_metadata[self.class.children_field])].flatten
+                                           [children_matcher.result(self, raw_metadata[related_children_raw_mapping])].flatten
                                          else
-                                           raw_metadata[self.class.children_field].split(/\s*[;|]\s*/)
+                                           raw_metadata[related_children_raw_mapping].split(/\s*[;|]\s*/)
                                          end
     end
 

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -35,37 +35,6 @@ module Bulkrax
     self.removed_image_path = Bulkrax::Engine.root.join('spec', 'fixtures', 'removed.png').to_s
     self.server_name = 'bulkrax@example.com'
 
-    # @todo, merge related_children_field_mapping and related_parents_field_mapping into field_mappings,
-    # or make them settable per import some other way.
-
-    # Field_mapping for establishing a parent-child relationship (FROM parent TO child)
-    # This can be a Collection to Work, Collection to Collection, or Work to Work relationship
-    # This value IS NOT used for OAI, so setting the OAI Entries here will have no effect
-    # The mapping is supplied per Entry, provide the full class name as a string, eg. 'Bulkrax::CsvEntry'
-    # Example:
-    #   {
-    #     'Bulkrax::RdfEntry'  => 'http://opaquenamespace.org/ns/contents',
-    #     'Bulkrax::CsvEntry'  => 'children'
-    #   }
-    # By default, no related_children_field_mappings are added
-    self.related_children_field_mapping = {
-      'Bulkrax::CsvEntry' => 'children'
-    }
-
-    # Field_mapping for establishing a parent-child relationship (FROM child TO parent)
-    # This can be a Work to Collection, Collection to Collection, or Work to Work relationship
-    # This value IS NOT used for OAI, so setting the OAI Entries here will have no effect
-    # The mapping is supplied per Entry, provide the full class name as a string, eg. 'Bulkrax::CsvEntry'
-    # Example:
-    #   {
-    #     'Bulkrax::CsvEntry' => 'collection_ids',
-    #     'Bulkrax::CsvCollectionEntry' => 'collection_ids'
-    #   }
-    # The default value for CSV is collection_ids
-    self.related_parents_field_mapping = {
-      'Bulkrax::CsvEntry' => 'collection_ids'
-    }
-
     # NOTE: Creating Collections using the collection_field_mapping will no longer be supported as of version Bulkrax v2.
     #       Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.
     # TODO: remove collection_field_mapping when releasing v2

--- a/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
+++ b/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
@@ -19,30 +19,6 @@ Bulkrax.setup do |config|
   # Server name for oai request header
   # config.server_name = 'my_server@name.com'
 
-  # Field_mapping for establishing a parent-child relationship (FROM parent TO child)
-  # This can be a Collection to Work, Collection to Collection, or Work to Work relationship
-  # This value IS NOT used for OAI, so setting the OAI Entries here will have no effect
-  # The mapping is supplied per Entry, provide the full class name as a string, eg. 'Bulkrax::CsvEntry'
-  # Example:
-  #   {
-  #     'Bulkrax::RdfEntry'  => 'http://opaquenamespace.org/ns/contents',
-  #     'Bulkrax::CsvEntry'  => 'children'
-  #   }
-  # By default no parent-child relationships are added
-  # config.related_children_field_mapping = {}
-
-  # Field_mapping for establishing a parent-child relationship (FROM child TO parent)
-  # This can be a Work to Collection, Collection to Collection, or Work to Work relationship
-  # This value IS NOT used for OAI, so setting the OAI Entries here will have no effect
-  # The mapping is supplied per Entry, provide the full class name as a string, eg. 'Bulkrax::CsvEntry'
-  # Example:
-  #   {
-  #     'Bulkrax::CsvEntry' => 'collection_ids',
-  #     'Bulkrax::CsvCollectionEntry' => 'collection_ids'
-  #   }
-  # The default value for CSV is collection_ids
-  # config.related_parents_field_mapping = {}
-
   # NOTE: Creating Collections using the collection_field_mapping will no longer be supported as of version Bulkrax v2.
   #       Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.
   # Field_mapping for establishing a collection relationship (FROM work TO collection)

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -16,30 +16,6 @@ RSpec.describe Bulkrax do
       end
     end
 
-    context 'related_children_field_mapping' do
-      it 'responds to related_children_field_mapping' do
-        expect(described_class).to respond_to(:related_children_field_mapping)
-      end
-      it 'related_children_field_mapping is settable' do
-        expect(described_class).to respond_to(:related_children_field_mapping=)
-      end
-      it 'has a default value for CsvEntry' do
-        expect(described_class.related_children_field_mapping).to eq({ 'Bulkrax::CsvEntry' => 'children' })
-      end
-    end
-
-    context 'related_parents_field_mapping' do
-      it 'responds to related_parents_field_mapping' do
-        expect(described_class).to respond_to(:related_parents_field_mapping)
-      end
-      it 'related_parents_field_mapping is settable' do
-        expect(described_class).to respond_to(:related_parents_field_mapping=)
-      end
-      it 'has a default value for CsvEntry' do
-        expect(described_class.related_parents_field_mapping).to eq({ 'Bulkrax::CsvEntry' => 'collection_ids' })
-      end
-    end
-
     context 'collection_field_mapping' do
       it 'responds to collection_field_mapping' do
         expect(described_class).to respond_to(:collection_field_mapping)

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -75,16 +75,15 @@ module Bulkrax
     context 'with specified admin set' do
       let(:mapping) do
         {
-          'parents' => { 'from' => ['parents'] },
-          'children' => { 'from' => ['children'] }
+          'parents' => { 'from' => ['parents'], related_parents_field_mapping: true },
+          'children' => { 'from' => ['children'], related_children_field_mapping: true }
         }
       end
 
       before do
         importer.parser_fields['thumbnail_url'] = ''
-        allow(entry.class).to receive(:parents_field).and_return('parents')
-        allow(entry.class).to receive(:children_field).and_return('children')
         allow(entry).to receive(:mapping).and_return(mapping)
+        allow(importer).to receive(:mapping).and_return(mapping)
       end
 
       it 'adds admin set id to parsed metadata' do

--- a/spec/models/bulkrax/rdf_entry_spec.rb
+++ b/spec/models/bulkrax/rdf_entry_spec.rb
@@ -60,8 +60,6 @@ module Bulkrax
           subject.identifier = "http://example.org/ns/19158"
           allow_any_instance_of(ObjectFactory).to receive(:run!).and_return(instance_of(Work))
           allow(User).to receive(:batch_user)
-          allow(subject.class).to receive(:parents_field).and_return('parents')
-          allow(subject.class).to receive(:children_field).and_return('children')
         end
 
         it 'succeeds' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -470,5 +470,174 @@ module Bulkrax
         end
       end
     end
+
+    describe 'relationships field mappings' do
+      context 'when relationship field mappings are set' do
+        before do
+          importer.field_mapping = {
+            'parents' => { 'from' => ['parents_column'], related_parents_field_mapping: true },
+            'children' => { 'from' => ['children_column'], related_children_field_mapping: true },
+            'unrelated' => { 'from' => ['unrelated_column'] }
+          }
+        end
+
+        describe '#related_parents_raw_mapping' do
+          it 'returns the name of the column header containing parent relationship data' do
+            expect(subject.related_parents_raw_mapping).to eq('parents_column')
+          end
+
+          it 'looks for the related_parents_field_mapping' do
+            expect(subject).to receive(:get_field_mapping_hash_for).with('related_parents_field_mapping')
+
+            subject.related_parents_raw_mapping
+          end
+
+          it 'caches the result' do
+            expect(subject.instance_variable_get('@related_parents_raw_mapping')).to be_nil
+
+            subject.related_parents_raw_mapping
+
+            expect(subject.instance_variable_get('@related_parents_raw_mapping')).to eq('parents_column')
+          end
+
+          it 'caches the related_parents_field_mapping' do
+            expect(subject.instance_variables).not_to include(:@related_parents_field_mapping_hash)
+
+            subject.related_parents_raw_mapping
+
+            expect(subject.instance_variables).to include(:@related_parents_field_mapping_hash)
+          end
+        end
+
+        describe '#related_parents_parsed_mapping' do
+          it 'returns the name of the field that the parent relationship data should map to' do
+            expect(subject.related_parents_parsed_mapping).to eq('parents')
+          end
+
+          it 'looks for the related_parents_field_mapping' do
+            expect(subject).to receive(:get_field_mapping_hash_for).with('related_parents_field_mapping')
+
+            subject.related_parents_parsed_mapping
+          end
+
+          it 'caches the result' do
+            expect(subject.instance_variable_get('@related_parents_parsed_mapping')).to be_nil
+
+            subject.related_parents_parsed_mapping
+
+            expect(subject.instance_variable_get('@related_parents_parsed_mapping')).to eq('parents')
+          end
+
+          it 'caches the related_parents_field_mapping' do
+            expect(subject.instance_variables).not_to include(:@related_parents_field_mapping_hash)
+
+            subject.related_parents_parsed_mapping
+
+            expect(subject.instance_variables).to include(:@related_parents_field_mapping_hash)
+          end
+        end
+
+        describe '#related_children_raw_mapping' do
+          it 'returns the name of the column header containing child relationship data' do
+            expect(subject.related_children_raw_mapping).to eq('children_column')
+          end
+
+          it 'looks for the related_children_field_mapping' do
+            expect(subject).to receive(:get_field_mapping_hash_for).with('related_children_field_mapping')
+
+            subject.related_children_raw_mapping
+          end
+
+          it 'caches the result' do
+            expect(subject.instance_variable_get('@related_children_raw_mapping')).to be_nil
+
+            subject.related_children_raw_mapping
+
+            expect(subject.instance_variable_get('@related_children_raw_mapping')).to eq('children_column')
+          end
+
+          it 'caches the related_children_field_mapping' do
+            expect(subject.instance_variables).not_to include(:@related_children_field_mapping_hash)
+
+            subject.related_children_raw_mapping
+
+            expect(subject.instance_variables).to include(:@related_children_field_mapping_hash)
+          end
+        end
+
+        describe '#related_children_parsed_mapping' do
+          it 'returns the name of the field that the child relationship data should map to' do
+            expect(subject.related_children_parsed_mapping).to eq('children')
+          end
+
+          it 'looks for the related_children_field_mapping' do
+            expect(subject).to receive(:get_field_mapping_hash_for).with('related_children_field_mapping')
+
+            subject.related_children_parsed_mapping
+          end
+
+          it 'caches the result' do
+            expect(subject.instance_variable_get('@related_children_parsed_mapping')).to be_nil
+
+            subject.related_children_parsed_mapping
+
+            expect(subject.instance_variable_get('@related_children_parsed_mapping')).to eq('children')
+          end
+
+          it 'caches the related_children_field_mapping' do
+            expect(subject.instance_variables).not_to include(:@related_children_field_mapping_hash)
+
+            subject.related_children_parsed_mapping
+
+            expect(subject.instance_variables).to include(:@related_children_field_mapping_hash)
+          end
+        end
+      end
+
+      context 'when relationship field mappings are not set' do
+        describe '#related_parents_raw_mapping' do
+          it { expect(subject.related_parents_raw_mapping).to be_nil }
+        end
+
+        describe '#related_parents_parsed_mapping' do
+          it { expect(subject.related_parents_parsed_mapping).to be_nil }
+        end
+
+        describe '#related_children_raw_mapping' do
+          it { expect(subject.related_children_raw_mapping).to be_nil }
+        end
+
+        describe '#related_children_parsed_mapping' do
+          it { expect(subject.related_children_parsed_mapping).to be_nil }
+        end
+      end
+
+      context 'when duplicate relationship field mappings are present' do
+        before do
+          importer.field_mapping = {
+            'parents_1' => { 'from' => ['parents_column_1'], related_parents_field_mapping: true },
+            'parents_2' => { 'from' => ['parents_column_2'], related_parents_field_mapping: true },
+            'children_1' => { 'from' => ['children_column_1'], related_children_field_mapping: true },
+            'children_2' => { 'from' => ['children_column_2'], related_children_field_mapping: true }
+          }
+        end
+
+        describe '#related_parents_raw_mapping' do
+          it { expect { subject.related_parents_raw_mapping }.to raise_error(StandardError) }
+        end
+
+        describe '#related_parents_parsed_mapping' do
+          it { expect { subject.related_parents_parsed_mapping }.to raise_error(StandardError) }
+        end
+
+        describe '#related_children_raw_mapping' do
+          it { expect { subject.related_children_raw_mapping }.to raise_error(StandardError) }
+        end
+
+        describe '#related_children_parsed_mapping' do
+          it { expect { subject.related_children_parsed_mapping }.to raise_error(StandardError) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Refactor for #371 

# Summary

Resolves this TODO comment from `lib/bulkrax.rb`: 

> merge related_children_field_mapping and related_parents_field_mapping into field_mappings, or make them settable per import some other way.

Also, the original changes from #371 did not properly account for mappings where the "from" and the "to" are not the same value (e.g. `'hello' => { 'from' => ['world'] }`)

Now, `related_parents_field_mapping` and `related_children_field_mapping` can be set per parser in the `field_mappings` config, [similar to source_identifier](https://github.com/samvera-labs/bulkrax/wiki/Configuring-Bulkrax#work-identifier-fields-) 

### TODO

- [ ] Update [documentation](https://github.com/samvera-labs/bulkrax/wiki/Configuring-Bulkrax#parent-child-relationship-field-mappings) 