### PR TITLE
Support numerated headers for parent-child relationship imports

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -44,7 +44,7 @@ module Bulkrax
       add_visibility
       add_ingested_metadata
       add_rights_statement
-      add_relationships
+      add_collections
       add_local
 
       self.parsed_metadata

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -26,6 +26,10 @@ module Bulkrax
     end
 
     def build_metadata
+      ActiveSupport::Deprecation.warn(
+        'Creating Collections using the collection_field_mapping will no longer be supported as of version Bulkrax v2.' \
+        ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
+      )
       self.parsed_metadata = {}
       self.parsed_metadata[work_identifier] = [record.header.identifier]
 
@@ -39,7 +43,7 @@ module Bulkrax
       add_visibility
       add_rights_statement
       add_admin_set_id
-      add_relationships
+      add_collections
       add_local
 
       return self.parsed_metadata

--- a/app/models/bulkrax/rdf_entry.rb
+++ b/app/models/bulkrax/rdf_entry.rb
@@ -55,6 +55,10 @@ module Bulkrax
     end
 
     def build_metadata
+      ActiveSupport::Deprecation.warn(
+        'Creating Collections using the collection_field_mapping will no longer be supported as of version Bulkrax v2.' \
+        ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
+      )
       raise StandardError, 'Record not found' if record.nil?
       raise StandardError, "Missing source identifier (#{source_identifier})" if self.raw_metadata[source_identifier].blank?
 
@@ -69,7 +73,7 @@ module Bulkrax
       add_visibility
       add_rights_statement
       add_admin_set_id
-      add_relationships
+      add_collections
       add_local
       self.parsed_metadata['file'] = self.raw_metadata['file']
 

--- a/app/models/bulkrax/xml_entry.rb
+++ b/app/models/bulkrax/xml_entry.rb
@@ -39,6 +39,10 @@ module Bulkrax
     end
 
     def build_metadata
+      ActiveSupport::Deprecation.warn(
+        'Creating Collections using the collection_field_mapping will no longer be supported as of version Bulkrax v2.' \
+        ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
+      )
       raise StandardError, 'Record not found' if record.nil?
       raise StandardError, "Missing source identifier (#{source_identifier})" if self.raw_metadata[source_identifier].blank?
       self.parsed_metadata = {}
@@ -55,7 +59,7 @@ module Bulkrax
       add_visibility
       add_rights_statement
       add_admin_set_id
-      add_relationships
+      add_collections
       self.parsed_metadata['file'] = self.raw_metadata['file']
 
       add_local

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -70,34 +70,6 @@ module Bulkrax
       self.parsed_metadata['admin_set_id'] = importerexporter.admin_set_id if self.parsed_metadata['admin_set_id'].blank?
     end
 
-    def add_relationships
-      add_parents
-      add_children
-      add_collections
-    end
-
-    def add_parents
-      return if raw_metadata[related_parents_raw_mapping].blank?
-
-      parents_matcher = self.class.matcher(related_parents_parsed_mapping, self.mapping[related_parents_parsed_mapping].symbolize_keys)
-      self.parsed_metadata[related_parents_parsed_mapping] = if parents_matcher.present?
-                                                               [parents_matcher.result(self, raw_metadata[related_parents_raw_mapping])].flatten
-                                                             else
-                                                               raw_metadata[related_parents_raw_mapping].split(/\s*[;|]\s*/)
-                                                             end
-    end
-
-    def add_children
-      return if raw_metadata[related_children_raw_mapping].blank?
-
-      children_matcher = self.class.matcher(related_children_parsed_mapping, self.mapping[related_children_parsed_mapping].symbolize_keys)
-      self.parsed_metadata[related_children_parsed_mapping] = if children_matcher.present?
-                                                                [children_matcher.result(self, raw_metadata[related_children_raw_mapping])].flatten
-                                                              else
-                                                                raw_metadata[related_children_raw_mapping].split(/\s*[;|]\s*/)
-                                                              end
-    end
-
     def add_collections
       return if find_collection_ids.blank?
 

--- a/spec/factories/bulkrax_importers.rb
+++ b/spec/factories/bulkrax_importers.rb
@@ -43,6 +43,15 @@ FactoryBot.define do
     parser_fields { { 'import_file_path' => 'spec/fixtures/csv/good.csv' } }
     field_mapping { {} }
     after :create, &:current_run
+
+    trait :with_relationships_mappings do
+      field_mapping do
+        {
+          'parents' => { 'from' => ['parents_column'], related_parents_field_mapping: true },
+          'children' => { 'from' => ['children_column'], related_children_field_mapping: true }
+        }
+      end
+    end
   end
 
   factory :bulkrax_importer_csv_complex, class: 'Bulkrax::Importer' do

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -53,6 +53,76 @@ module Bulkrax
         end
       end
 
+      context 'with parent-child relationships' do
+        let(:importer) { FactoryBot.create(:bulkrax_importer_csv, :with_relationships_mappings) }
+        let(:required_data) do
+          {
+            'source_identifier' => '1',
+            'title' => 'test'
+          }
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:raw_metadata).and_return(data)
+        end
+
+        context 'with multiple values split by a pipe character' do
+          let(:data) do
+            required_data.merge(
+              {
+                'parents_column' => 'parent_1 | parent_2',
+                'children_column' => 'child_1|child_2'
+              }
+            )
+          end
+
+          it 'succeeds' do
+            metadata = subject.build_metadata
+            expect(metadata['parents']).to include('parent_1', 'parent_2')
+            expect(metadata['children']).to include('child_1', 'child_2')
+          end
+        end
+
+        context 'with enumerated columns appended' do
+          let(:data) do
+            required_data.merge(
+              {
+                'parents_column_1' => 'parent_1',
+                'parents_column_2' => 'parent_2',
+                'children_column_1' => 'child_1',
+                'children_column_2' => 'child_2'
+              }
+            )
+          end
+
+          it 'succeeds' do
+            metadata = subject.build_metadata
+            expect(metadata['parents']).to include('parent_1', 'parent_2')
+            expect(metadata['children']).to include('child_1', 'child_2')
+          end
+        end
+
+        context 'with enumerated columns prepended' do
+          let(:data) do
+            required_data.merge(
+              {
+                '1_parents_column' => 'parent_1',
+                '2_parents_column' => 'parent_2',
+                '1_children_column' => 'child_1',
+                '2_children_column' => 'child_2'
+              }
+            )
+          end
+
+          it 'succeeds' do
+            metadata = subject.build_metadata
+            expect(metadata['parents']).to include('parent_1', 'parent_2')
+            expect(metadata['children']).to include('child_1', 'child_2')
+          end
+        end
+      end
+
       context 'with enumerated columns appended' do
         before do
           allow_any_instance_of(ObjectFactory).to receive(:run!)


### PR DESCRIPTION
# Summary

Use existing logic to parse parent-child relationships instead of doing it manually 

Related: #371 

**Changes include:** 
- Remove manual parsing of relationship data (`#add_relationships`) 
- Add `#related_parents_parsed_mapping` and `#related_parents_parsed_mapping` to new `#supported_bulkrax_fields` method so they can be processed by `#add_metadata` 
- Respect the presence of `index` in `#set_parsed_data` for non-object data 