### PR TITLE
fixes export zip downloads inline #389

### DIFF
--- a/app/models/concerns/bulkrax/download_behavior.rb
+++ b/app/models/concerns/bulkrax/download_behavior.rb
@@ -30,7 +30,7 @@ module Bulkrax
 
     # Create some headers for the datastream
     def content_options
-      { disposition: 'inline', type: download_content_type, filename: file_name }
+      { disposition: 'attachment', type: download_content_type, filename: file_name }
     end
 
     # render an HTTP HEAD response


### PR DESCRIPTION
content-type for export download is application/zip so content-dispos should be attachment