### PR TITLE
Don't skip blank values when parsing CSV metadata

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -70,7 +70,6 @@ module Bulkrax
       )
       record.sort.each do |key, value|
         next if self.parser.collection_field_mapping.to_s == key_without_numbers(key)
-        next if value.blank?
 
         index = key[/\d+/].to_i - 1 if key[/\d+/].to_i != 0
         add_metadata(key_without_numbers(key), value, index)

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -290,7 +290,7 @@ module Bulkrax
         it 'succeeds' do
           metadata = subject.build_metadata
           expect(metadata['multiple_objects'][0]['first_name']).to eq('Fake')
-          expect(metadata['multiple_objects'][0]['last_name']).to eq(nil)
+          expect(metadata['multiple_objects'][0]['last_name']).to eq('')
           expect(metadata['multiple_objects'][0]['position']).to include('Leader', 'Jester', 'Queen')
           expect(metadata['multiple_objects'][0]['language']).to eq('English')
           expect(metadata['multiple_objects'][1]['first_name']).to eq('Judge')


### PR DESCRIPTION
Remove logic that directly conflicts with logic introduced in #374 