### PR TITLE
i401 i402 fix bugs with collection_field_mapping and parent-child jobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,8 @@ inherit_gem:
 # @see https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
 Metrics/BlockLength:
   Max: 495
+  Exclude:
+    - 'spec/**/*'
 
 Metrics/ModuleLength:
   Exclude:

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -9,7 +9,7 @@ module Bulkrax
     # Use identifier set by CsvParser#unique_collection_identifier, which falls back
     # on the Collection's first title if record[source_identifier] is not present
     def add_identifier
-      self.parsed_metadata[work_identifier] = [self.identifier]
+      self.parsed_metadata[work_identifier] = [self.identifier].flatten
     end
 
     def add_collection_type_gid

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -9,7 +9,7 @@ module Bulkrax
     # Use identifier set by CsvParser#unique_collection_identifier, which falls back
     # on the Collection's first title if record[source_identifier] is not present
     def add_identifier
-      self.parsed_metadata[work_identifier] = self.identifier
+      self.parsed_metadata[work_identifier] = [self.identifier]
     end
 
     def add_collection_type_gid

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -26,13 +26,13 @@ module Bulkrax
 
     def parent_jobs
       self.parsed_metadata[related_parents_parsed_mapping].each do |parent_identifier|
-        CreateRelationshipsJob.perform_later(entry_identifier: self.identifier, parent_identifier: parent_identifier, importer_run: self.last_run)
+        CreateRelationshipsJob.perform_later(entry_identifier: self.identifier, parent_identifier: parent_identifier, importer_run: self.last_run) if parent_identifier.present?
       end
     end
 
     def child_jobs
       self.parsed_metadata[related_children_parsed_mapping].each do |child_identifier|
-        CreateRelationshipsJob.perform_later(entry_identifier: self.identifier, child_identifier: child_identifier, importer_run: self.last_run)
+        CreateRelationshipsJob.perform_later(entry_identifier: self.identifier, child_identifier: child_identifier, importer_run: self.last_run) if child_identifier.present?
       end
     end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -25,7 +25,7 @@ module Bulkrax
       # retrieve a list of unique collections
       records.map do |r|
         collections = []
-        r[collection_field_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title } } if r[collection_field_mapping].present?
+        r[collection_field_mapping].split(/\s*[;|]\s*/).each { |title| collections << { title: title, from_collection_field_mapping: true } } if r[collection_field_mapping].present?
         model_field_mappings.each do |model_mapping|
           collections << r if r[model_mapping.to_sym]&.downcase == 'collection'
         end
@@ -79,16 +79,20 @@ module Bulkrax
           ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
         )
 
-        metadata = if collection.key?(:title) && collection.keys.count == 1
-          {
-            title: [collection[:title]],
-            source_identifier: [collection[:title]],
-            visibility: 'open',
-            collection_type_gid: Hyrax::CollectionType.find_or_create_default_collection_type.gid
-          }
-        end
+        ## BEGIN
+        # Add required metadata to collections being imported using the collection_field_mapping, which only have a :title
+        # TODO: Remove once collection_field_mapping is removed
+        metadata = if collection.delete(:from_collection_field_mapping)
+                     {
+                       title: [collection[:title]],
+                       work_identifier => [collection[:title]],
+                       visibility: 'open',
+                       collection_type_gid: ::Hyrax::CollectionType.find_or_create_default_collection_type.gid
+                     }
+                   end
+        collection_hash = metadata.presence || collection
+        ## END
 
-        collection_hash = metadata.present? ? metadata : collection
         new_entry = find_or_create_entry(collection_entry_class, unique_collection_identifier(collection_hash), 'Bulkrax::Importer', collection_hash)
         # TODO: add support for :delete option
         ImportCollectionJob.perform_now(new_entry.id, current_run.id)

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -8,17 +8,18 @@ module Bulkrax
     let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
 
     describe '#collections' do
+      let(:all_collection_titles) { subject.collections.collect { |c| c[:title] } }
+
       before do
         importer.parser_fields = { import_file_path: './spec/fixtures/csv/mixed_works_and_collections.csv' }
       end
 
       it 'includes collection titles listed in the :collection column' do
-        expect(subject.collections).to include({ title: "Second Work's Collection" })
+        expect(all_collection_titles).to include("Second Work's Collection")
       end
 
       it 'includes rows whose :model is set to Collection' do
-        expect(subject.collections.collect { |w| w[:title] })
-          .to contain_exactly('Collection 1 Title', 'Collection 2 Title', "Second Work's Collection")
+        expect(all_collection_titles).to include('Collection 1 Title', 'Collection 2 Title')
       end
 
       it 'matches :model column case-insensitively' do
@@ -45,15 +46,21 @@ module Bulkrax
           end
 
           it 'the collection field mapping is used' do
-            expect(subject.collections).to include({ title: 'parent mapping' })
-            expect(subject.collections).not_to include({ title: 'collection mapping' })
+            expect(all_collection_titles).to include('parent mapping')
+            expect(all_collection_titles).not_to include('collection mapping')
           end
         end
 
         context 'is not set' do
           it 'the mapping falls back on :collection' do
-            expect(subject.collections).not_to include({ title: 'parent mapping' })
-            expect(subject.collections).to include({ title: 'collection mapping' })
+            expect(all_collection_titles).not_to include('parent mapping')
+            expect(all_collection_titles).to include('collection mapping')
+          end
+        end
+
+        context 'is used to import a collection' do
+          it 'a :from_collection_field_mapping key-value pair is added to their data' do
+            expect(subject.collections).to include({ title: 'collection mapping', from_collection_field_mapping: true })
           end
         end
       end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -59,7 +59,7 @@ module Bulkrax
         end
 
         context 'is used to import a collection' do
-          it 'a :from_collection_field_mapping key-value pair is added to their data' do
+          it 'a :from_collection_field_mapping key-value pair is added to its data' do
             expect(subject.collections).to include({ title: 'collection mapping', from_collection_field_mapping: true })
           end
         end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -163,7 +163,7 @@ module Bulkrax
         end
 
         context 'when collection record does not have a source_identifier' do
-          let(:record_hash) { { title: 'no source id | alt title' } }
+          let(:record_hash) { { title: 'no source id | alt title', from_collection_field_mapping: true } }
 
           it "uses the record's first title as the entry's identifier" do
             subject.create_collections


### PR DESCRIPTION
Resolves #401 
Resolves #402 

- [x] Add required metadata to collections being imported using the `collection_field_mapping` so they do not throw errors  
- [x] Don't throw an error when trying to create a parent-child relationships with a blank identifier 
- [x] Don't try to create parent-child relationships when running importer in validate only mode 

Verified that I was able to created collections and associated them to works using the old and new ways. 