### PR TITLE
Collection title should be a string instead of an array

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -99,7 +99,7 @@ module Bulkrax
         metadata = if collection.delete(:from_collection_field_mapping)
                      uci = unique_collection_identifier(collection)
                      {
-                       title: [collection[:title]],
+                       title: collection[:title],
                        work_identifier => uci,
                        source_identifier => uci,
                        visibility: 'open',


### PR DESCRIPTION
When creating collections with the collection_field_mapping way, the collection's title would be displayed as an array. This PR allows it the default metadata value be saved as a string instead, so that it gets displayed properly.