### PR TITLE
Add Collections and FileSets to CSV exports

### DIFF
--- a/app/models/bulkrax/csv_file_set_entry.rb
+++ b/app/models/bulkrax/csv_file_set_entry.rb
@@ -12,7 +12,7 @@ module Bulkrax
 
         parsed_metadata['file'][i] = path_to_file
       end
-      raise ::StandardError, 'one or more file paths are invalid' unless parsed_metadata['file'].map { |file_path| ::File.file?(file_path) }.all?
+      raise ::StandardError, "one or more file paths are invalid: #{parsed_metadata['file'].join(', ')}" unless parsed_metadata['file'].map { |file_path| ::File.file?(file_path) }.all?
 
       parsed_metadata['file']
     end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -208,8 +208,8 @@ module Bulkrax
       complete_entry_identifiers = complete_statuses.map { |s| s.statusable&.identifier&.gsub(':', '\:') }
       extra_filters = extra_filters.presence || '*:*'
 
-      { '@work_ids' => ::Hyrax.config.curation_concerns, '@collection_ids' => [::Collection], '@file_set_ids' => [::FileSet] }.each do |instance_var, models_to_search|
-        instance_variable_set(instance_var.to_sym, ActiveFedora::SolrService.get(
+      { :@work_ids => ::Hyrax.config.curation_concerns, :@collection_ids => [::Collection], :@file_set_ids => [::FileSet] }.each do |instance_var, models_to_search|
+        instance_variable_set(instance_var, ActiveFedora::SolrService.get(
           extra_filters.to_s,
           fq: [
             "#{work_identifier}_sim:(#{complete_entry_identifiers.join(' OR ')})",

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -176,6 +176,11 @@ module Bulkrax
       output
     end
 
+    def current_work_ids
+      ActiveSupport::Deprication.warn('Bulkrax::CsvParser#current_work_ids will be replaced with #current_record_ids in version 3.0')
+      current_record_ids
+    end
+
     def current_record_ids
       @work_ids = []
       @collection_ids = []

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -177,13 +177,15 @@ module Bulkrax
     end
 
     def current_record_ids
-      @work_ids, @collection_ids, @file_set_ids = []
+      @work_ids = []
+      @collection_ids = []
+      @file_set_ids = []
 
       case importerexporter.export_from
       when 'all'
         @work_ids = ActiveFedora::SolrService.query("has_model_ssim:(#{Hyrax.config.curation_concerns.join(' OR ')}) #{extra_filters}", rows: 2_147_483_647).map(&:id)
-        @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:(Collection) #{extra_filters}", rows: 2_147_483_647).map(&:id)
-        @file_set_ids = ActiveFedora::SolrService.query("has_model_ssim:(FileSet) #{extra_filters}", rows: 2_147_483_647).map(&:id)
+        @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:Collection #{extra_filters}", rows: 2_147_483_647).map(&:id)
+        @file_set_ids = ActiveFedora::SolrService.query("has_model_ssim:FileSet #{extra_filters}", rows: 2_147_483_647).map(&:id)
       when 'collection'
         @work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source + extra_filters}", rows: 2_000_000_000).map(&:id)
       when 'worktype'

--- a/spec/factories/bulkrax_exporters.rb
+++ b/spec/factories/bulkrax_exporters.rb
@@ -33,4 +33,11 @@ FactoryBot.define do
     limit { 0 }
     field_mapping { nil }
   end
+
+  trait :all do
+    name { 'Export from All' }
+    export_type { 'metadata' }
+    export_from { 'all' }
+    export_source { nil }
+  end
 end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -420,6 +420,16 @@ module Bulkrax
 
           parser.create_new_entries
         end
+
+        it 'exported entries are given the correct class' do
+          expect { parser.create_new_entries }
+            .to change(CsvFileSetEntry, :count)
+            .by(3)
+            .and change(CsvCollectionEntry, :count)
+            .by(1)
+            .and change(CsvEntry, :count)
+            .by(6) # 6 csv entries minus 3 file set entries minus 1 collection entry equals 2 work entries
+        end
       end
     end
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -350,11 +350,13 @@ module Bulkrax
     describe '#create_new_entries' do
       subject(:parser) { described_class.new(exporter) }
       let(:exporter)   { FactoryBot.create(:bulkrax_exporter_worktype) }
+      # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
+      let(:work_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
+      let(:collection_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
+      let(:file_set_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
 
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
-        # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
-        work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-        expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
+        expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
         expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
         parser.create_new_entries
       end
@@ -363,9 +365,7 @@ module Bulkrax
         let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype, limit: 1) }
 
         it 'invokes Bulkrax::ExportWorkJob once' do
-          # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
-          work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
+          expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
           parser.create_new_entries
         end
@@ -375,10 +375,49 @@ module Bulkrax
         let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype, limit: 0) }
 
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
-          # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
-          work_ids = [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))]
-          expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids)
+          expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(2).times
+          parser.create_new_entries
+        end
+      end
+
+      context 'when exporting all' do
+        let(:exporter) { FactoryBot.create(:bulkrax_exporter, :all) }
+
+        before do
+          allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr, collection_ids_solr, file_set_ids_solr)
+        end
+
+        it 'exports works, collections, and file sets' do
+          expect(ExportWorkJob).to receive(:perform_now).exactly(6).times
+
+          parser.create_new_entries
+        end
+
+        it 'exports all works' do
+          work_entry_ids = Entry.where(identifier: work_ids_solr.map(&:id)).map(&:id)
+          work_entry_ids.each do |id|
+            expect(ExportWorkJob).to receive(:perform_now).with(id, exporter.last_run.id).once
+          end
+
+          parser.create_new_entries
+        end
+
+        it 'exports all collections' do
+          collection_entry_ids = Entry.where(identifier: collection_ids_solr.map(&:id)).map(&:id)
+          collection_entry_ids.each do |id|
+            expect(ExportWorkJob).to receive(:perform_now).with(id, exporter.last_run.id).once
+          end
+
+          parser.create_new_entries
+        end
+
+        it 'exports all file sets' do
+          file_set_entry_ids = Entry.where(identifier: file_set_ids_solr.map(&:id)).map(&:id)
+          file_set_entry_ids.each do |id|
+            expect(ExportWorkJob).to receive(:perform_now).with(id, exporter.last_run.id).once
+          end
+
           parser.create_new_entries
         end
       end


### PR DESCRIPTION
When exporting "All" or from an Importer, include Collection and FileSet records in the export. 

**NOTE:** when exporting from an importer, Collections that were imported using the deprecated `collection_field_mapping` are not included in the export 