### PR TITLE
call increment_counters before perform_now job

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -111,8 +111,8 @@ module Bulkrax
 
         new_entry = find_or_create_entry(collection_entry_class, collection_hash[source_identifier], 'Bulkrax::Importer', collection_hash)
         # TODO: add support for :delete option
-        ImportCollectionJob.perform_now(new_entry.id, current_run.id)
         increment_counters(index, collection: true)
+        ImportCollectionJob.perform_now(new_entry.id, current_run.id)
       end
       importer.record_status
     rescue StandardError => e

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -110,8 +110,8 @@ module Bulkrax
         ## END
 
         new_entry = find_or_create_entry(collection_entry_class, collection_hash[source_identifier], 'Bulkrax::Importer', collection_hash)
-        # TODO: add support for :delete option
         increment_counters(index, collection: true)
+        # TODO: add support for :delete option
         ImportCollectionJob.perform_now(new_entry.id, current_run.id)
       end
       importer.record_status


### PR DESCRIPTION
This PR fixes the "pending" status bug. While importing a csv work and collection, the importer's index page would remain "pending" even though the work and collection had completed successfully. 

We need to call the #increment_counters method before the ImportCollectionJob since it's a perform_now job. 
