### PR TITLE
i350 - fix for multile ui elements on index page

### DIFF
--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -1,8 +1,3 @@
-
-<% content_for(:head) do %>
-  <meta name="turbolinks-cache-control" content="no-cache">
-<% end %>
-
 <% provide :page_header do %>
   <h1><span class="fa fa-cloud-download" aria-hidden="true"></span> Exporters</h1>
   <div class="pull-right">
@@ -10,6 +5,10 @@
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.exporter.new') %>
     <% end %>
   </div>
+<% end %>
+
+<% content_for(:head) do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
 <div class="panel panel-default">

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -1,3 +1,8 @@
+
+<% content_for(:head) do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>
+
 <% provide :page_header do %>
   <h1><span class="fa fa-cloud-download" aria-hidden="true"></span> Exporters</h1>
   <div class="pull-right">

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -5,10 +5,10 @@
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.exporter.new') %>
     <% end %>
   </div>
+<% end %>
 
-  <% content_for(:head) do %>
-    <meta name="turbolinks-cache-control" content="no-cache">
-  <% end %>
+<% content_for(:head) do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
 <div class="panel panel-default">

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -5,10 +5,10 @@
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.exporter.new') %>
     <% end %>
   </div>
-<% end %>
 
-<% content_for(:head) do %>
-  <meta name="turbolinks-cache-control" content="no-cache">
+  <% content_for(:head) do %>
+    <meta name="turbolinks-cache-control" content="no-cache">
+  <% end %>
 <% end %>
 
 <div class="panel panel-default">

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -5,10 +5,10 @@
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.importer.new') %>
     <% end %>
   </div>
-  
-  <% content_for(:head) do %>
-    <meta name="turbolinks-cache-control" content="no-cache">
-  <% end %>
+<% end %>
+
+<% content_for(:head) do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
 <div class="panel panel-default">

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -1,3 +1,8 @@
+
+<% content_for(:head) do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end%>
+
 <% provide :page_header do %>
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importers</h1>
   <div class="pull-right">
@@ -6,10 +11,6 @@
     <% end %>
   </div>
 <% end %>
-
-<% content_for(:head) do %>
-  <meta name="turbolinks-cache-control" content="no-cache">
-<% end%>
 
 <div class="panel panel-default">
   <div class="panel-body">

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -1,8 +1,3 @@
-
-<% content_for(:head) do %>
-  <meta name="turbolinks-cache-control" content="no-cache">
-<% end %>
-
 <% provide :page_header do %>
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importers</h1>
   <div class="pull-right">
@@ -10,6 +5,10 @@
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.importer.new') %>
     <% end %>
   </div>
+<% end %>
+
+<% content_for(:head) do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
 <div class="panel panel-default">

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -7,6 +7,10 @@
   </div>
 <% end %>
 
+<% content_for(:head) do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end%>
+
 <div class="panel panel-default">
   <div class="panel-body">
     <% if @importers.present? %>

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -5,10 +5,10 @@
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.importer.new') %>
     <% end %>
   </div>
-<% end %>
-
-<% content_for(:head) do %>
-  <meta name="turbolinks-cache-control" content="no-cache">
+  
+  <% content_for(:head) do %>
+    <meta name="turbolinks-cache-control" content="no-cache">
+  <% end %>
 <% end %>
 
 <div class="panel panel-default">

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -1,7 +1,7 @@
 
 <% content_for(:head) do %>
   <meta name="turbolinks-cache-control" content="no-cache">
-<% end%>
+<% end %>
 
 <% provide :page_header do %>
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importers</h1>


### PR DESCRIPTION
# Bug: 
Clicking on the back button on an importer's show page, to return to the index pages, would produce duplicate elements within the UI. 

# BEFORE 
![image](https://user-images.githubusercontent.com/10081604/153685282-a635ca62-13ea-4a9f-b271-92156ea88553.png)

# Summary:
- [ ] tell turbolinks to not cache the JS sections or we get multiple ui elements when clicking the back button

# ref: 
https://github.com/samvera-labs/bulkrax/issues/350

# AFTER: 

![i350-demo](https://user-images.githubusercontent.com/10081604/153685075-fd1ac05e-4719-481b-91d4-5b224f3563c0.gif)
