### PR TITLE
Show all added cloud files, not first ten

### DIFF
--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -49,7 +49,7 @@ function prepBulkrax(event) {
       for(var mutation of mutationsList) {
         if (mutation.type == 'childList') {
           browseButton = document.getElementById('browse');
-          var exp = /selected_files\[[0-9*]\]\[url\]/
+          var exp = /selected_files\[[0-9]*\]\[url\]/
           for (var node of mutation.addedNodes) {
             if (node.attributes != undefined) {
               var name = node.attributes.name.value


### PR DESCRIPTION
Even when adding many files to an import, only the first ten are listed. I think this was just a typo.