### PR TITLE
417 Do not stop all collections from importing when one fails

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -3,7 +3,10 @@
 require 'csv'
 
 module Bulkrax
-  class CsvEntry < Entry
+  # TODO: We need to rework this class some to address the Metrics/ClassLength rubocop offense.
+  # We do too much in these entry classes. We need to extract the common logic from the various
+  # entry models into a module that can be shared between them.
+  class CsvEntry < Entry # rubocop:disable Metrics/ClassLength
     serialize :raw_metadata, JSON
 
     def self.fields_from_data(data)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -229,10 +229,19 @@ module Bulkrax
         'Creating Collections using the collection_field_mapping will no longer be supported as of Bulkrax version 3.0.' \
         ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
       )
-      @possible_collection_ids ||= record.inject([]) do |memo, (key, value)|
-        memo += value.split(/\s*[:;|]\s*/) if self.class.collection_field.to_s == key_without_numbers(key) && value.present?
-        memo
-      end || []
+      return @possible_collection_ids if @possible_collection_ids.present?
+
+      collection_field_mapping = self.class.collection_field
+      return [] unless collection_field_mapping.present? && record[collection_field_mapping].present?
+
+      identifiers = []
+      split_titles = record[collection_field_mapping].split(/\s*[:;|]\s*/)
+      split_titles.each do |c_title|
+        matching_collection_entries = importerexporter.entries.select { |e| e.raw_metadata['title'] == c_title }
+        raise ::StandardError, 'Only expected to find one matching entry' if matching_collection_entries.count > 1
+        identifiers << matching_collection_entries.first&.identifier
+      end
+      @possible_collection_ids = identifiers.presence || []
     end
 
     def collections_created?

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -238,13 +238,13 @@ module Bulkrax
       return [] unless collection_field_mapping.present? && record[collection_field_mapping].present?
 
       identifiers = []
-      split_titles = record[collection_field_mapping].split(/\s*[:;|]\s*/)
+      split_titles = record[collection_field_mapping].split(/\s*[;|]\s*/)
       split_titles.each do |c_title|
         matching_collection_entries = importerexporter.entries.select { |e| e.raw_metadata['title'] == c_title }
         raise ::StandardError, 'Only expected to find one matching entry' if matching_collection_entries.count > 1
         identifiers << matching_collection_entries.first&.identifier
       end
-      @possible_collection_ids = identifiers.presence || []
+      @possible_collection_ids = identifiers.compact.presence || []
     end
 
     def collections_created?

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -88,10 +88,6 @@ module Bulkrax
       collections.each_with_index do |collection, index|
         next if collection.blank?
         break if records.find_index(collection).present? && limit_reached?(limit, records.find_index(collection))
-        ActiveSupport::Deprecation.warn(
-          'Creating Collections using the collection_field_mapping will no longer be supported as of Bulkrax version 3.0.' \
-          ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
-        )
 
         ## BEGIN
         # Add required metadata to collections being imported using the collection_field_mapping, which only have a :title
@@ -104,6 +100,10 @@ module Bulkrax
         increment_counters(index, collection: true)
         # TODO: add support for :delete option
         if collection.key?(:from_collection_field_mapping)
+          ActiveSupport::Deprecation.warn(
+            'Creating Collections using the collection_field_mapping will no longer be supported as of Bulkrax version 3.0.' \
+            ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
+          )
           # When importing collections using the deprecated collection_field_mapping, the collection MUST be created
           # before the work, so we use #perform_now to make sure that happens. The downside is, if a collection fails
           # to import, it will stop the rest of the collections from importing successfully.
@@ -154,11 +154,11 @@ module Bulkrax
     # Add required metadata to collections being imported using the collection_field_mapping, which only have a :title
     # TODO: Remove once collection_field_mapping is removed
     def add_required_collection_metadata(raw_collection_data)
+      return unless raw_collection_data.key?(:from_collection_field_mapping)
       ActiveSupport::Deprecation.warn(
         'Creating Collections using the collection_field_mapping will no longer be supported as of Bulkrax version 3.0.' \
         ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
       )
-      return unless raw_collection_data.key?(:from_collection_field_mapping)
 
       uci = unique_collection_identifier(raw_collection_data)
       {

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -96,16 +96,7 @@ module Bulkrax
         ## BEGIN
         # Add required metadata to collections being imported using the collection_field_mapping, which only have a :title
         # TODO: Remove once collection_field_mapping is removed
-        metadata = if collection.key?(:from_collection_field_mapping)
-                     uci = unique_collection_identifier(collection)
-                     {
-                       title: collection[:title],
-                       work_identifier => uci,
-                       source_identifier => uci,
-                       visibility: 'open',
-                       collection_type_gid: ::Hyrax::CollectionType.find_or_create_default_collection_type.gid
-                     }
-                   end
+        metadata = add_required_collection_metadata(collection)
         collection_hash = metadata.presence || collection
         ## END
 
@@ -158,6 +149,25 @@ module Bulkrax
       importer.record_status
     rescue StandardError => e
       status_info(e)
+    end
+
+    # Add required metadata to collections being imported using the collection_field_mapping, which only have a :title
+    # TODO: Remove once collection_field_mapping is removed
+    def add_required_collection_metadata(raw_collection_data)
+      ActiveSupport::Deprecation.warn(
+        'Creating Collections using the collection_field_mapping will no longer be supported as of Bulkrax version 3.0.' \
+        ' Please configure Bulkrax to use related_parents_field_mapping and related_children_field_mapping instead.'
+      )
+      return unless raw_collection_data.key?(:from_collection_field_mapping)
+
+      uci = unique_collection_identifier(raw_collection_data)
+      {
+        title: raw_collection_data[:title],
+        work_identifier => uci,
+        source_identifier => uci,
+        visibility: 'open',
+        collection_type_gid: ::Hyrax::CollectionType.find_or_create_default_collection_type.gid
+      }
     end
 
     def write_partial_import_file(file)

--- a/spec/fixtures/csv/failed_collection.csv
+++ b/spec/fixtures/csv/failed_collection.csv
@@ -1,0 +1,3 @@
+source_identifier,model,title,description
+fc1,Collection,,Failed collection's description
+fc2,Collection,Valid Collection,Processed after failed collection

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -150,7 +150,7 @@ module Bulkrax
         end
 
         it 'runs an ImportCollectionJob for each entry' do
-          expect(ImportCollectionJob).to receive(:perform_now).twice
+          expect(ImportCollectionJob).to receive(:perform_later).twice
 
           subject.create_collections
         end


### PR DESCRIPTION
Closes #417 

Use `#perform_later` for collections that are not imported using the `collection_field_mapping`