### PR TITLE
i421 - enqueued entries count bug

### DIFF
--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -22,16 +22,17 @@ module Bulkrax
 
     def increment_counters(index, collection: false, file_set: false)
       # Only set the totals if they were not set on initialization
+      importer_run = ImporterRun.find(current_run.id) # make sure fresh
       if collection
-        current_run.total_collection_entries = index + 1 unless parser.collections_total.positive?
+        importer_run.total_collection_entries = index + 1 unless parser.collections_total.positive?
       elsif file_set
-        current_run.total_file_set_entries = index + 1 unless parser.file_sets_total.positive?
+        importer_run.total_file_set_entries = index + 1 unless parser.file_sets_total.positive?
       else
         # TODO: differentiate between work and collection counts for exporters
-        current_run.total_work_entries = index + 1 unless limit.to_i.positive? || parser.total.positive?
+        importer_run.total_work_entries = index + 1 unless limit.to_i.positive? || parser.total.positive?
       end
-      current_run.enqueued_records += 1
-      current_run.save!
+      importer_run.enqueued_records += 1
+      importer_run.save!
     end
 
     def keys_without_numbers(keys)

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -85,7 +85,7 @@ module Bulkrax
     end
 
     def create_collections
-      collections.each_with_index do |collection|
+      collections.each_with_index do |collection, index|
         next if collection.blank?
         break if records.find_index(collection).present? && limit_reached?(limit, records.find_index(collection))
         ActiveSupport::Deprecation.warn(
@@ -110,6 +110,7 @@ module Bulkrax
         ## END
 
         new_entry = find_or_create_entry(collection_entry_class, collection_hash[source_identifier], 'Bulkrax::Importer', collection_hash)
+        increment_counters(index, collection: true)
         # TODO: add support for :delete option
         ImportCollectionJob.perform_now(new_entry.id, current_run.id)
       end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -85,7 +85,7 @@ module Bulkrax
     end
 
     def create_collections
-      collections.each_with_index do |collection, index|
+      collections.each_with_index do |collection|
         next if collection.blank?
         break if records.find_index(collection).present? && limit_reached?(limit, records.find_index(collection))
         ActiveSupport::Deprecation.warn(

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -110,7 +110,6 @@ module Bulkrax
         ## END
 
         new_entry = find_or_create_entry(collection_entry_class, collection_hash[source_identifier], 'Bulkrax::Importer', collection_hash)
-        increment_counters(index, collection: true)
         # TODO: add support for :delete option
         ImportCollectionJob.perform_now(new_entry.id, current_run.id)
       end


### PR DESCRIPTION
# Summary

- [ ] Entries Enqueued count would remain at 1, even though the job completed (and sidekiq had no enqueued jobs remaining) (sample had 2 works and 1 collection. The collection had 1 work)
- [ ] status remains as "pending" even though the job completes (when importing a larger sample ie: 2 collections, 4 works, 1 work in one collection, 3 in the other)

co-author @sephirothkod 

## Solution
Even though [current_run](https://github.com/samvera-labs/bulkrax/pull/420/files#diff-4eda1ce8a9d73a758fd0c6bf408cc877e883155d5a3472d372d13c3adab36ec0R25) was being saved, we needed to find it again for it to have the latest count updates from the database on each iteration. 

ref: https://github.com/samvera-labs/bulkrax/issues/421

## BEFORE
<img width="1061" alt="Screen Shot 2022-02-16 at 9 23 34 AM" src="https://user-images.githubusercontent.com/10081604/154320991-cd48892c-2c8b-47ba-9ef4-910f9ff8d697.png">
<img width="1067" alt="Screen Shot 2022-02-16 at 10 45 20 AM" src="https://user-images.githubusercontent.com/10081604/154341525-0219c0ca-203e-43e5-8d8c-c48a508da810.png">



## AFTER
<img width="1078" alt="Screen Shot 2022-02-16 at 9 11 50 AM" src="https://user-images.githubusercontent.com/10081604/154319808-fcc06c79-14cd-4cd5-bae9-8390315d7e22.png">
<img width="1266" alt="Screen Shot 2022-02-16 at 11 31 08 AM" src="https://user-images.githubusercontent.com/10081604/154341358-9844b33a-6066-43ff-9c5f-b871cf3c2718.png">

