### PR TITLE
fix visibility so it gets respected when importing

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -40,8 +40,8 @@ module Bulkrax
 
       self.parsed_metadata = {}
       add_identifier
-      add_visibility
       add_ingested_metadata
+      add_visibility
       add_metadata_for_model
       add_rights_statement
       add_collections

--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -139,6 +139,7 @@ module Bulkrax
           file
           remote_files
           model
+          visibility
           delete
           #{parser.collection_field_mapping}
           #{related_parents_parsed_mapping}


### PR DESCRIPTION
Previously, when importing using the `visibility` CSV column, the value set on the importer would always be used, even when a row declared a different visibility within the metadata. 

Changes include: 

- Adding fallback visibility _after_ parsing metadata 
- Add visibility to Bulkrax's list of supported fields 
  - This is necessary because `field_supported?("visibility")` returns `false` without this 