### PR TITLE
i298- bug fix to handle numerated file headers

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -46,6 +46,7 @@ module Bulkrax
 
       self.parsed_metadata = {}
       add_identifier
+      add_ingested_metadata
       add_metadata_for_model
       add_visibility
       add_ingested_metadata


### PR DESCRIPTION
# Summary 
Bug: importing csv's with numerated file header ('file_1', 'file_2') would not attach files.

PR switches the order in which #add_ingested_metadata and #add_metadata_for_model were called, to resolve this bug.