### PR TITLE
435 Add check for presence of Release Notes labels on PRs

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Branches
 on:
   pull_request:
     branches:

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,4 +1,4 @@
-name: Branches
+name: Verify
 on:
   pull_request:
     branches:
@@ -10,7 +10,7 @@ on:
 jobs:
   branches:
     runs-on: ubuntu-latest
-
+    name: Disallow "master" branch name
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -3,7 +3,12 @@ on:
   pull_request:
     branches:
       - '**'
-    types: [labeled, unlabeled]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   check_pr_labels:

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -15,3 +15,4 @@ jobs:
         uses: agilepathway/label-checker@v1.0.105
         with:
           one_of: patch-ver,minor-ver,major-ver,bug-fix,enhancement,breaking-change,database-changes,ignore-for-release
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check_pr_labels:
     runs-on: ubuntu-latest
-    name: PR has a Release Note label
+    name: PR has required labels
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
           one_of: patch-ver,minor-ver,major-ver,bug-fix,enhancement,breaking-change,database-changes,ignore-for-release
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check PR for cla-signed labels
+      - name: Check PR for cla-signed label
         uses: docker://agilepathway/pull-request-label-checker:latest
         with:
           one_of: cla-signed

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -1,4 +1,4 @@
-name: Labels
+name: Verify
 on:
   pull_request:
     branches:
@@ -13,7 +13,7 @@ on:
 jobs:
   check_pr_labels:
     runs-on: ubuntu-latest
-
+    name: PR has a Release Note label
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check PR for Release Notes labels
-        uses: agilepathway/label-checker@v1.0.105
+        uses: docker://agilepathway/pull-request-label-checker:latest
         with:
           one_of: patch-ver,minor-ver,major-ver,bug-fix,enhancement,breaking-change,database-changes,ignore-for-release
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - '**'
+    types: [labeled, unlabeled]
 
 jobs:
   check_pr_labels:

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -22,3 +22,9 @@ jobs:
         with:
           one_of: patch-ver,minor-ver,major-ver,bug-fix,enhancement,breaking-change,database-changes,ignore-for-release
           repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check PR for cla-signed labels
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: cla-signed
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -1,0 +1,17 @@
+name: Labels
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  check_pr_labels:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check PR for Release Notes labels
+        uses: agilepathway/label-checker@v1.0.105
+        with:
+          one_of: patch-ver,minor-ver,major-ver,bug-fix,enhancement,breaking-change,database-changes,ignore-for-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7'] # TODO add 3.0 compat , '3.0']
+        ruby: ['2.5', '2.6', '2.7'] # TODO add 3.0 compat , '3.0']
     name: Run specs with ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,7 @@ Common checks that may occur in our repositories:
 2. RuboCop/Bixby - where we check for style violations
 3. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
 4. CodeClimate - is our code remaining healthy (at least according to static code analysis)
+5. Required Labels - the label required by [samvera-lab's cla-bot](https://github.com/samvera-labs/cla-bot) and an appropriate [semver](https://semver.org/) label (see [release.yml](https://github.com/samvera-labs/bulkrax/blob/main/.github/release.yml))
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 


### PR DESCRIPTION
Closes #435 

Adds [this action](https://github.com/marketplace/actions/label-checker-for-pull-requests) for verifying Release Labels on PRs 