### PR TITLE
serialize the parents db column

### DIFF
--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -4,5 +4,6 @@ module Bulkrax
   class ImporterRun < ApplicationRecord
     belongs_to :importer
     has_many :statuses, as: :runnable, dependent: :destroy
+    serialize :parents, Array
   end
 end


### PR DESCRIPTION
related to: #431 

# summary
serialize the `parents` column on the importer runs table to be an array so that it can be mapped over and the proper relationships will be formed 

# expected behavior
``` ruby
# before
importer_run.parents => '[]Warriors'

# after
importer_run.parents => ['Warriors']
```