### PR TITLE
remove parents column serialization in the importer run

### DIFF
--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -4,6 +4,5 @@ module Bulkrax
   class ImporterRun < ApplicationRecord
     belongs_to :importer
     has_many :statuses, as: :runnable, dependent: :destroy
-    # serialize :parents, Array
   end
 end

--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -4,6 +4,6 @@ module Bulkrax
   class ImporterRun < ApplicationRecord
     belongs_to :importer
     has_many :statuses, as: :runnable, dependent: :destroy
-    serialize :parents, Array
+    # serialize :parents, Array
   end
 end


### PR DESCRIPTION
related: #439 

# summary
I dropped, created, migrated and seeded the db on louisville. afterwards, it [updated the schema](https://gitlab.com/notch8/louisville-hyku/-/merge_requests/66). after this change, I was unable to even access the importer dashboard page because of the error below.

on the related pr above, we removed the default value of the `parents` array, which is what I believe makes the serialization no longer necessary.

# expected behavior
- an import can be successfully run after updating bulkrax in a client app to the `9a12f142` commit on `main`

# demo
| before | after |
| --- | --- |
| ![Screen Shot 2022-03-17 at 2 44 19 PM](https://user-images.githubusercontent.com/29032869/158903537-d9e78496-6184-4cc2-adc8-a624edd88a41.png) | ![image](https://user-images.githubusercontent.com/29032869/158904717-7a99095b-4453-449a-8780-0b814eff4c97.png) |