### PR TITLE
Fix collection relationship importing, change export join character

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -182,6 +182,10 @@ module Bulkrax
     # Add child to parent's #member_collections
     # Add parent to child's #member_of_collections
     def persist_collection_memberships(parent:, child:)
+      parent.reject!(&:blank?) if parent.respond_to?(:reject!)
+      child.reject!(&:blank?) if child.respond_to?(:reject!)
+      return if parent.blank? || child.blank?
+
       ::Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: child)
     end
 
@@ -190,7 +194,7 @@ module Bulkrax
       when Hash
         Collection.find(id[:id])
       when String
-        Collection.find(id)
+        Collection.find(id) if id.present?
       when Array
         id.map { |i| find_collection(i) }
       else

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -153,7 +153,7 @@ module Bulkrax
       data = hyrax_record.send(key.to_s)
       if data.is_a?(ActiveTriples::Relation)
         if value['join']
-          self.parsed_metadata[key_for_export(key)] = data.map { |d| prepare_export_data(d) }.join('; ').to_s
+          self.parsed_metadata[key_for_export(key)] = data.map { |d| prepare_export_data(d) }.join(' | ').to_s # TODO: make split char dynamic
         else
           data.each_with_index do |d, i|
             self.parsed_metadata["#{key_for_export(key)}_#{i + 1}"] = prepare_export_data(d)

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -27,7 +27,7 @@ module Bulkrax
         importer_job.perform(1)
 
         expect(importer.current_run.total_work_entries).to eq(10)
-        expect(importer.current_run.total_collection_entries).to eq(422)
+        expect(importer.current_run.total_collection_entries).to eq(421)
       end
     end
 


### PR DESCRIPTION
# Summary 

### Intended for v3.0 major release 

After merging, release `v3.0.0.beta2` 

Changes: 

- Don't throw errors when Collection relationships are blank (e.g. `[""]`) 
- Change export join character to pipe instead of semicolon 
  - Many recent projects have been using the pipe character since semicolons are often valid metadata 
  - This change brings joining on export inline with changes in #441 