### PR TITLE
Fix NoMethodError on ImporterRun#parents

### DIFF
--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -4,5 +4,7 @@ module Bulkrax
   class ImporterRun < ApplicationRecord
     belongs_to :importer
     has_many :statuses, as: :runnable, dependent: :destroy
+
+    serialize :parents, Array
   end
 end

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -43,7 +43,6 @@ module Bulkrax
     end
 
     def add_parent_to_import_run(parent_id, run)
-      run.parents = [] if run.parents.nil?
       run.parents << parent_id
       run.save
     end

--- a/db/migrate/20220330165510_remove_array_true_from_importer_run_parents_column.rb
+++ b/db/migrate/20220330165510_remove_array_true_from_importer_run_parents_column.rb
@@ -1,0 +1,5 @@
+class RemoveArrayTrueFromImporterRunParentsColumn < ActiveRecord::Migration[5.2]
+  def change
+    change_column :bulkrax_importer_runs, :parents, :text, array: false, default: nil
+  end
+end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -670,6 +670,20 @@ module Bulkrax
       end
     end
 
+    describe '#add_parent_to_import_run' do
+      subject(:entry) { described_class.new(importerexporter: importer) }
+      let(:importer) { FactoryBot.build(:bulkrax_importer_csv, importer_runs: [importer_run]) }
+      let(:importer_run) { build(:bulkrax_importer_run) }
+
+      it 'adds the parent_id to the run' do
+        expect(importer_run.parents).to eq([])
+
+        entry.add_parent_to_import_run('dummy', importer_run)
+
+        expect(importer_run.parents).to eq(['dummy'])
+      end
+    end
+
     describe '#build_relationship_metadata' do
       subject(:entry) { described_class.new(importerexporter: exporter) }
       let(:exporter) { create(:bulkrax_exporter, :with_relationships_mappings) }

--- a/spec/models/bulkrax/importer_run_spec.rb
+++ b/spec/models/bulkrax/importer_run_spec.rb
@@ -4,6 +4,12 @@ require 'rails_helper'
 
 module Bulkrax
   RSpec.describe ImporterRun, type: :model do
-    pending "add some examples to (or delete) #{__FILE__}"
+    subject(:importer_run) { build(:bulkrax_importer_run) }
+
+    describe '#parents' do
+      it 'is an Array' do
+        expect(importer_run.parents).to be_an(Array)
+      end
+    end
   end
 end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_03_212810) do
+ActiveRecord::Schema.define(version: 2022_03_30_165510) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false


### PR DESCRIPTION
## Intended for v3.0 major release

After merging, release v3.0.0.beta3

## Summary 

`ImporterRun#parents` was being set to a String instead of an Array: 

```ruby
i.last_run.parents
=> "[]irc1irc1" # should be ["irc1", "irc1"]
```

### Fix 

Serialize `ImporterRun#parents` as an Array. This fixes this bug: 

![DEVELOPMENT  Sidekiq 2022-03-29 at 11 41 17 AM](https://user-images.githubusercontent.com/32469930/160730205-9eb06ece-03ae-46af-b5dc-26b6620851ba.jpg)

### Why the database change? 

This bug was not a problem on projects using postgres because postgres natively supports storing data as arrays. However, other databases (e.g. mysql) do _not_ natively storing data as arrays. Because of this, `#serialize` is preferable since it has more compatibility 