### PR TITLE
Bulkrax 3+ update to display collection title on importer show page w…

### DIFF
--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -97,13 +97,8 @@
               <% @work_entries.each do |e| %>
                 <tr>
                   <td><%= link_to e.identifier, bulkrax.importer_entry_path(@importer.id, e.id) %></td>
-                  <% if e.parsed_metadata.present? && e.parsed_metadata.dig("collections").present? %>
-                    <td><%= e.parsed_metadata.dig("collections").map {|c| c['id'] }.join('; ') %></td>
-                  <% elsif e.raw_metadata.present? %>
-                    <td><%= Array.wrap(e.raw_metadata.dig("collection")).join(';') %></td>
-                  <% else %>
-                    <td></td>
-                  <% end %>
+                  <% collection_titles = e.collection_ids.map {|id| c = Collection.find id; c.title.first } %>
+                  <td><%= collection_titles.join('; ') %></td>
                   <td><%= e.id %></td>
                   <% if e.status == "Complete" %>
                     <td><span class="glyphicon glyphicon-ok" style="color: green;"></span> <%= e.status %></td>


### PR DESCRIPTION
Bulkrax 3+ update to display collection title on importer show page work entries section

The current code displays the title of a collection if the csv is imported the collection_field_mapping way (w the collection header) because it takes the value off of the collections key of parsed or raw metadata, even though a Collection can no longer be created this way. 

Since that has been deprecated, this code updates how titles get retrieved.

BEFORE
![image](https://user-images.githubusercontent.com/10081604/162290235-b5244477-fbaf-4cd1-aef0-4abbf48776a6.png)

AFTER

<img width="1190" alt="Screen Shot 2022-04-07 at 1 35 06 PM" src="https://user-images.githubusercontent.com/10081604/162291444-d3404e8f-0214-42c8-90a2-6ed83165dfca.png">

