### PR TITLE
Draft: export thumbnails

### DIFF
--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -101,11 +101,11 @@ module Bulkrax
     def exporter_params
       params[:exporter][:export_source] = params[:exporter]["export_source_#{params[:exporter][:export_from]}".to_sym]
       if params[:exporter][:date_filter] == "1"
-        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type,
+        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type, :include_thumbnails,
                                        :parser_klass, :limit, :start_date, :finish_date, :work_visibility,
                                        :workflow_status, field_mapping: {})
       else
-        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type,
+        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type, :include_thumbnails,
                                        :parser_klass, :limit, :work_visibility, :workflow_status,
                                        field_mapping: {}).merge(start_date: nil, finish_date: nil)
       end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -209,6 +209,17 @@ module Bulkrax
 
       filenames = file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
       handle_join_on_export(file_mapping, filenames, mapping['file']&.[]('join')&.present?)
+      build_thumbnail_files
+    end
+
+    def build_thumbnail_files
+      return unless hyrax_record.work? && importerexporter.include_thumbnails
+
+      thumbnail_mapping = 'thumbnail_file' 
+      file_sets = Array.wrap(hyrax_record.thumbnail)
+ 
+      filenames = file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
+      handle_join_on_export(thumbnail_mapping, filenames, false)
     end
 
     def handle_join_on_export(key, values, join)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -209,21 +209,17 @@ module Bulkrax
 
       filenames = map_file_sets(file_sets)
       handle_join_on_export(file_mapping, filenames, mapping['file']&.[]('join')&.present?)
-      build_thumbnail_files
+      build_thumbnail_files if hyrax_record.work?
     end
 
     def build_thumbnail_files
-      return unless hyrax_record.work? && importerexporter.include_thumbnails
+      return unless importerexporter.include_thumbnails
 
       thumbnail_mapping = 'thumbnail_file'
       file_sets = Array.wrap(hyrax_record.thumbnail)
 
       filenames = map_file_sets(file_sets)
       handle_join_on_export(thumbnail_mapping, filenames, false)
-    end
-
-    def map_file_sets(file_sets)
-      file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
     end
 
     def handle_join_on_export(key, values, join)
@@ -297,6 +293,12 @@ module Bulkrax
       f = File.join(path, file)
       return f if File.exist?(f)
       raise "File #{f} does not exist"
+    end
+
+    private
+
+    def map_file_sets(file_sets)
+      file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
     end
   end
 end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -218,6 +218,7 @@ module Bulkrax
       thumbnail_mapping = 'thumbnail_file'
       file_sets = Array.wrap(hyrax_record.thumbnail)
 
+      filenames = map_file_sets(file_sets)
       handle_join_on_export(thumbnail_mapping, filenames, false)
     end
 

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -207,7 +207,7 @@ module Bulkrax
       file_mapping = mapping['file']&.[]('from')&.first || 'file'
       file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
 
-      filenames = file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
+      filenames = map_file_sets(file_sets)
       handle_join_on_export(file_mapping, filenames, mapping['file']&.[]('join')&.present?)
       build_thumbnail_files
     end
@@ -215,11 +215,14 @@ module Bulkrax
     def build_thumbnail_files
       return unless hyrax_record.work? && importerexporter.include_thumbnails
 
-      thumbnail_mapping = 'thumbnail_file' 
+      thumbnail_mapping = 'thumbnail_file'
       file_sets = Array.wrap(hyrax_record.thumbnail)
- 
-      filenames = file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
+
       handle_join_on_export(thumbnail_mapping, filenames, false)
+    end
+
+    def map_file_sets(file_sets)
+      file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
     end
 
     def handle_join_on_export(key, values, join)

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -51,6 +51,10 @@ module Bulkrax
       self.start_date.present? || self.finish_date.present?
     end
 
+    def include_thumbnails?
+      self.include_thumbnails
+    end
+
     def work_visibility_list
       [
         ['Any', ''],

--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -28,6 +28,7 @@ module Bulkrax
       return if hyrax_record.is_a?(Collection)
 
       file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
+      file_sets << hyrax_record.thumbnail if hyrax_record.work? && exporter.include_thumbnails
       file_sets.each do |fs|
         path = File.join(exporter_export_path, 'files')
         FileUtils.mkdir_p(path)

--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -28,7 +28,7 @@ module Bulkrax
       return if hyrax_record.is_a?(Collection)
 
       file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
-      file_sets << hyrax_record.thumbnail if hyrax_record.work? && exporter.include_thumbnails
+      file_sets << hyrax_record.thumbnail if hyrax_record.thumbnail.present? && hyrax_record.work? && exporter.include_thumbnails
       file_sets.each do |fs|
         path = File.join(exporter_export_path, 'files')
         FileUtils.mkdir_p(path)

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -60,6 +60,9 @@
     hint: 'leave blank or 0 for all records',
     label: t('bulkrax.exporter.labels.limit') %>
 
+  <%= form.input :include_thumbnails?,
+                 as: :boolean,
+                 label: t('bulkrax.exporter.labels.include_thumbnails') %>
   <%= form.input :date_filter,
                  as: :boolean,
                  label: t('bulkrax.exporter.labels.filter_by_date') %>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -30,6 +30,11 @@
     </p>
 
     <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.include_thumbnails') %>:</strong>
+      <%= @exporter.include_thumbnails %>
+    </p>
+
+    <p class='bulkrax-p-align'>
       <strong><%= t('bulkrax.exporter.labels.export_from') %>:</strong>
       <%= @exporter.export_from %>
     </p>

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -16,6 +16,7 @@ en:
         filter_by_date: Filter By Date
         finish_date: End Date
         full: Metadata and Files
+        include_thumbnails: Include Thumbnails?
         importer: Importer
         limit: Limit
         metadata: Metadata Only

--- a/db/migrate/20220412233954_add_include_thumbnails_to_bulkrax_exporters.rb
+++ b/db/migrate/20220412233954_add_include_thumbnails_to_bulkrax_exporters.rb
@@ -1,0 +1,5 @@
+class AddIncludeThumbnailsToBulkraxExporters < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bulkrax_exporters, :include_thumbnails, :boolean, default: false
+  end
+end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -961,7 +961,7 @@ module Bulkrax
           entry.parsed_metadata = {}
           allow(hyrax_record).to receive(:is_a?).with(FileSet).and_return(false)
         end
- 
+
         it 'gets called by #build_files' do
           expect(entry).to receive(:build_thumbnail_files).once
           entry.build_files

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_30_165510) do
+ActiveRecord::Schema.define(version: 2022_04_12_233954) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2022_03_30_165510) do
     t.date "finish_date"
     t.string "work_visibility"
     t.string "workflow_status"
+    t.boolean "include_thumbnails", default: false
     t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 


### PR DESCRIPTION
# Summary

PALS would like to contribute back the following work: 

1. The ability to export thumbnails, similar to the way files get exported.

## Screenshots

From the export form, if a user checks to include thumbnails the csv will get exported with a "thumbnail_file" column header and filenames as its values. The actual files/thumbnails will be included in the files directory of the exported zipped file. 
<img width="916" alt="Screen Shot 2022-04-12 at 4 32 41 PM" src="https://user-images.githubusercontent.com/10081604/163075057-3611a27b-47e7-45a3-afa0-8fc9d55090fe.png">
<img width="1247" alt="Screen Shot 2022-04-12 at 4 32 12 PM" src="https://user-images.githubusercontent.com/10081604/163075064-e344af62-3a4b-4083-bdf9-dbd3201558fa.png">
<img width="1254" alt="Screen Shot 2022-04-12 at 4 24 29 PM" src="https://user-images.githubusercontent.com/10081604/163075068-a61a0132-4dae-4758-8923-793f5f6dcd5b.png">



