### PR TITLE
streamline parents lookup per run.

### DIFF
--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -4,5 +4,9 @@ module Bulkrax
   class ImporterRun < ApplicationRecord
     belongs_to :importer
     has_many :statuses, as: :runnable, dependent: :destroy
+
+    def parents
+      PendingRelationship.where(bulkrax_importer_run_id: id).pluck(:parent_id).uniq
+    end
   end
 end

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -28,7 +28,6 @@ module Bulkrax
       self.parsed_metadata[related_parents_parsed_mapping].each do |parent_identifier|
         next if parent_identifier.blank?
 
-        add_parent_to_import_run(parent_identifier, importerexporter.last_run)
         PendingRelationship.create!(child_id: self.identifier, parent_id: parent_identifier, bulkrax_importer_run_id: importerexporter.last_run.id, order: self.id)
       end
     end
@@ -37,15 +36,8 @@ module Bulkrax
       self.parsed_metadata[related_children_parsed_mapping].each do |child_identifier|
         next if child_identifier.blank?
 
-        add_parent_to_import_run(self.identifier, importerexporter.last_run)
         PendingRelationship.create!(parent_id: self.identifier, child_id: child_identifier, bulkrax_importer_run_id: importerexporter.last_run.id, order: self.id)
       end
-    end
-
-    def add_parent_to_import_run(parent_id, run)
-      run.parents = [] if run.parents.nil?
-      run.parents << parent_id
-      run.save
     end
 
     def find_collection_ids

--- a/db/migrate/20220301020307_add_parents_to_bulkrax_importer_runs.rb
+++ b/db/migrate/20220301020307_add_parents_to_bulkrax_importer_runs.rb
@@ -1,5 +1,0 @@
-class AddParentsToBulkraxImporterRuns < ActiveRecord::Migration[5.1]
-  def change
-    add_column :bulkrax_importer_runs, :parents, :text, array: true, default: "{}"
-  end
-end

--- a/db/migrate/20220330165510_remove_array_true_from_importer_run_parents_column.rb
+++ b/db/migrate/20220330165510_remove_array_true_from_importer_run_parents_column.rb
@@ -1,5 +1,0 @@
-class RemoveArrayTrueFromImporterRunParentsColumn < ActiveRecord::Migration[5.2]
-  def change
-    change_column :bulkrax_importer_runs, :parents, :text, array: false, default: nil
-  end
-end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -670,20 +670,6 @@ module Bulkrax
       end
     end
 
-    describe '#add_parent_to_import_run' do
-      subject(:entry) { described_class.new(importerexporter: importer) }
-      let(:importer) { FactoryBot.build(:bulkrax_importer_csv, importer_runs: [importer_run]) }
-      let(:importer_run) { build(:bulkrax_importer_run) }
-
-      it 'adds the parent_id to the run' do
-        expect(importer_run.parents).to eq([])
-
-        entry.add_parent_to_import_run('dummy', importer_run)
-
-        expect(importer_run.parents).to eq(['dummy'])
-      end
-    end
-
     describe '#build_relationship_metadata' do
       subject(:entry) { described_class.new(importerexporter: exporter) }
       let(:exporter) { create(:bulkrax_exporter, :with_relationships_mappings) }

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_30_165510) do
+ActiveRecord::Schema.define(version: 2022_03_03_212810) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -90,7 +90,6 @@ ActiveRecord::Schema.define(version: 2022_03_30_165510) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
-    t.text "parents"
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 


### PR DESCRIPTION
remove database column for parents and just use relationships look up each time.