### PR TITLE
identifier-mixup

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -249,7 +249,7 @@ module Bulkrax
       identifiers = []
       split_references = record[parent_field_mapping].split(/\s*[;|]\s*/)
       split_references.each do |c_reference|
-        matching_collection_entries = importerexporter.entries.select { |e| e.raw_metadata[work_identifier] == c_reference && e.is_a?(CsvCollectionEntry) }
+        matching_collection_entries = importerexporter.entries.select { |e| e.raw_metadata[source_identifier] == c_reference && e.is_a?(CsvCollectionEntry) }
         raise ::StandardError, 'Only expected to find one matching entry' if matching_collection_entries.count > 1
         identifiers << matching_collection_entries.first&.identifier
       end


### PR DESCRIPTION
# expected behavior
- use `source_identifier` instead of `work_identifier`
- `source_identifier` is the value on the csv and the "from" in bulkrax.rb
- `work_identifier` is the "to" value in bulkrax.rb
- these are not always the same