### PR TITLE
Export generated metadata

### DIFF
--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -101,11 +101,11 @@ module Bulkrax
     def exporter_params
       params[:exporter][:export_source] = params[:exporter]["export_source_#{params[:exporter][:export_from]}".to_sym]
       if params[:exporter][:date_filter] == "1"
-        params.fetch(:exporter).permit(:generated_metadata, :name, :user_id, :export_source, :export_from, :export_type,
+        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type, :generated_metadata,
                                        :include_thumbnails, :parser_klass, :limit, :start_date, :finish_date, :work_visibility,
                                        :workflow_status, field_mapping: {})
       else
-        params.fetch(:exporter).permit(:generated_metadata, :name, :user_id, :export_source, :export_from, :export_type,
+        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type, :generated_metadata,
                                        :include_thumbnails, :parser_klass, :limit, :work_visibility, :workflow_status,
                                        field_mapping: {}).merge(start_date: nil, finish_date: nil)
       end

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -101,12 +101,12 @@ module Bulkrax
     def exporter_params
       params[:exporter][:export_source] = params[:exporter]["export_source_#{params[:exporter][:export_from]}".to_sym]
       if params[:exporter][:date_filter] == "1"
-        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type, :include_thumbnails,
-                                       :parser_klass, :limit, :start_date, :finish_date, :work_visibility,
+        params.fetch(:exporter).permit(:generated_metadata, :name, :user_id, :export_source, :export_from, :export_type,
+                                       :include_thumbnails, :parser_klass, :limit, :start_date, :finish_date, :work_visibility,
                                        :workflow_status, field_mapping: {})
       else
-        params.fetch(:exporter).permit(:name, :user_id, :export_source, :export_from, :export_type, :include_thumbnails,
-                                       :parser_klass, :limit, :work_visibility, :workflow_status,
+        params.fetch(:exporter).permit(:generated_metadata, :name, :user_id, :export_source, :export_from, :export_type,
+                                       :include_thumbnails, :parser_klass, :limit, :work_visibility, :workflow_status,
                                        field_mapping: {}).merge(start_date: nil, finish_date: nil)
       end
     end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -235,11 +235,11 @@ module Bulkrax
     end
 
     def build_generated_metadata
-      return unless Hyrax.config.curation_concerns.include?(hyrax_record.class)
+      return unless hyrax_record.work? || Hyrax.config.curation_concerns.include?(hyrax_record.class)
 
       generated_metadata_keys = ["create_date", "date_modified", "date_uploaded"]
       generated_metadata_hash = generated_metadata_keys.each do |attr|
-        self.parsed_metadata[attr] = hyrax_record.as_json[attr].strftime("%-d/%-m/%y: %H:%M %Z") if hyrax_record.as_json[attr].present?
+        self.parsed_metadata[attr] = hyrax_record.as_json[attr] if hyrax_record.as_json[attr].present?
       end
       self.parsed_metadata
     end

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -99,6 +99,7 @@ module Bulkrax
       build_relationship_metadata
       build_mapping_metadata
       build_files unless hyrax_record.is_a?(Collection)
+      build_generated_metadata if importerexporter.generated_metadata
       self.parsed_metadata
     end
 
@@ -231,6 +232,16 @@ module Bulkrax
         end
         parsed_metadata.delete(key)
       end
+    end
+
+    def build_generated_metadata
+      return unless Hyrax.config.curation_concerns.include?(hyrax_record.class)
+
+      generated_metadata_keys = ["create_date", "date_modified", "date_uploaded"]
+      generated_metadata_hash = generated_metadata_keys.each do |attr|
+        self.parsed_metadata[attr] = hyrax_record.as_json[attr].strftime("%-d/%-m/%y: %H:%M %Z") if hyrax_record.as_json[attr].present?
+      end
+      self.parsed_metadata
     end
 
     # In order for the existing exported hyrax_record, to be updated by a re-import

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -235,7 +235,7 @@ module Bulkrax
     end
 
     def build_generated_metadata
-      return unless hyrax_record.work? || Hyrax.config.curation_concerns.include?(hyrax_record.class)
+      return unless !hyrax_record.is_a?(FileSet) && !hyrax_record.is_a?(Collection)
 
       generated_metadata_keys = ["create_date", "date_modified", "date_uploaded"]
       generated_metadata_hash = generated_metadata_keys.each do |attr|

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -238,7 +238,7 @@ module Bulkrax
       return unless !hyrax_record.is_a?(FileSet) && !hyrax_record.is_a?(Collection)
 
       generated_metadata_keys = ["create_date", "date_modified", "date_uploaded"]
-      generated_metadata_hash = generated_metadata_keys.each do |attr|
+      generated_metadata_keys.each do |attr|
         self.parsed_metadata[attr] = hyrax_record.as_json[attr] if hyrax_record.as_json[attr].present?
       end
       self.parsed_metadata

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -55,6 +55,10 @@ module Bulkrax
       self.include_thumbnails
     end
 
+    def generated_metadata?
+      self.generated_metadata
+    end
+
     def work_visibility_list
       [
         ['Any', ''],

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -60,9 +60,14 @@
     hint: 'leave blank or 0 for all records',
     label: t('bulkrax.exporter.labels.limit') %>
 
+  <%= form.input :generated_metadata?,
+                 as: :boolean,
+                 label: t('bulkrax.exporter.labels.generated_metadata') %>
+
   <%= form.input :include_thumbnails?,
                  as: :boolean,
                  label: t('bulkrax.exporter.labels.include_thumbnails') %>
+
   <%= form.input :date_filter,
                  as: :boolean,
                  label: t('bulkrax.exporter.labels.filter_by_date') %>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -30,7 +30,7 @@
     </p>
 
     <p class='bulkrax-p-align'>
-      <strong><%= t('bulkrax.exporter.labels.generated_metadata') %>:</strong>
+      <strong><%= t('bulkrax.exporter.labels.include_thumbnails') %>:</strong>
       <%= @exporter.include_thumbnails %>
     </p>
 

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -25,13 +25,18 @@
     </p>
 
     <p class='bulkrax-p-align'>
-      <strong><%= t('bulkrax.exporter.labels.export_type') %>:</strong>
-      <%= @exporter.export_type %>
+      <strong><%= t('bulkrax.exporter.labels.generated_metadata') %>:</strong>
+      <%= @exporter.generated_metadata %>
     </p>
 
     <p class='bulkrax-p-align'>
-      <strong><%= t('bulkrax.exporter.labels.include_thumbnails') %>:</strong>
+      <strong><%= t('bulkrax.exporter.labels.generated_metadata') %>:</strong>
       <%= @exporter.include_thumbnails %>
+    </p>
+
+    <p class='bulkrax-p-align'>
+      <strong><%= t('bulkrax.exporter.labels.export_type') %>:</strong>
+      <%= @exporter.export_type %>
     </p>
 
     <p class='bulkrax-p-align'>

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -17,6 +17,7 @@ en:
         finish_date: End Date
         full: Metadata and Files
         include_thumbnails: Include Thumbnails?
+        generated_metadata: Include Generated Metadata?
         importer: Importer
         limit: Limit
         metadata: Metadata Only

--- a/db/migrate/20220413180915_add_generated_metadata_to_bulkrax_exporters.rb
+++ b/db/migrate/20220413180915_add_generated_metadata_to_bulkrax_exporters.rb
@@ -1,0 +1,5 @@
+class AddGeneratedMetadataToBulkraxExporters < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bulkrax_exporters, :generated_metadata, :boolean, default: false
+  end
+end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -1025,14 +1025,14 @@ module Bulkrax
           OpenStruct.new(
             has_model: ['Work'],
             work?: true,
-            date_uploaded: datetime,
+            date_uploaded: datetime
           )
         end
         let(:datetime) { DateTime.now }
 
         before do
           entry.parsed_metadata = {}
-          allow(hyrax_record).to receive(:as_json).and_return({"date_uploaded" => datetime})
+          allow(hyrax_record).to receive(:as_json).and_return({ "date_uploaded" => datetime })
         end
 
         context 'when exporter includes generated metadata' do
@@ -1042,7 +1042,7 @@ module Bulkrax
             expect(entry).to receive(:build_generated_metadata).once
             entry.build_export_metadata
           end
- 
+
           it "adds the work's file set's filenames to the 'date_uploaded' key in parsed_metadata" do
             exporter.generated_metadata = true
 

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -1010,6 +1010,49 @@ module Bulkrax
         end
       end
     end
+
+    describe '#build_generated_metadata' do
+      subject(:entry) { described_class.new(importerexporter: exporter) }
+      let(:exporter) { create(:bulkrax_exporter, :with_relationships_mappings, generated_metadata: false) }
+
+      before do
+        allow(entry).to receive(:hyrax_record).and_return(hyrax_record)
+        allow(entry).to receive(:build_files)
+      end
+
+      context 'when record is a curation concern model' do
+        let(:hyrax_record) do
+          OpenStruct.new(
+            has_model: ['Work'],
+            work?: true,
+            date_uploaded: datetime,
+          )
+        end
+        let(:datetime) { DateTime.now }
+
+        before do
+          entry.parsed_metadata = {}
+          allow(hyrax_record).to receive(:as_json).and_return({"date_uploaded" => datetime})
+        end
+
+        context 'when exporter includes generated metadata' do
+          it 'gets called by #build_export_metadata' do
+            exporter.generated_metadata = true
+
+            expect(entry).to receive(:build_generated_metadata).once
+            entry.build_export_metadata
+          end
+ 
+          it "adds the work's file set's filenames to the 'date_uploaded' key in parsed_metadata" do
+            exporter.generated_metadata = true
+
+            entry.build_generated_metadata
+
+            expect(entry.parsed_metadata["date_uploaded"]).to eq(datetime)
+          end
+        end
+      end
+    end
   end
 end
 # rubocop: enable Metrics/BlockLength

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_233954) do
+ActiveRecord::Schema.define(version: 2022_04_13_180915) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2022_04_12_233954) do
     t.string "work_visibility"
     t.string "workflow_status"
     t.boolean "include_thumbnails", default: false
+    t.boolean "generated_metadata", default: false
     t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 


### PR DESCRIPTION
ref: https://github.com/samvera-labs/bulkrax/pull/462

# Summary

PALS would like to contribute back the following work: 

1. The ability to export generated metadata, like: created_date, date_uploaded, date_modified

## Screenshots

From the export form, if a user checks to include generated metadata, the csv will get exported with a generated metadata column headers and datetimestamps as their values. 
<img width="1439" alt="Screen Shot 2022-04-13 at 3 46 25 PM" src="https://user-images.githubusercontent.com/10081604/163290154-d9d346ab-36b8-47fe-b1ef-fe0b9ac8351a.png">
<img width="1145" alt="Screen Shot 2022-04-13 at 3 46 03 PM" src="https://user-images.githubusercontent.com/10081604/163290159-4487bd99-171d-464b-a9eb-c3a8866ca929.png">
<img width="532" alt="Screen Shot 2022-04-13 at 3 45 51 PM" src="https://user-images.githubusercontent.com/10081604/163290160-3f2bd175-ab11-4c6b-b9b8-3c09e869f01d.png">

