### PR TITLE
unable to reference a parent work/collection by id in 3.0+

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -140,14 +140,14 @@ module Bulkrax
     def create_collection(attrs)
       attrs = clean_attrs(attrs)
       attrs = collection_type(attrs)
-      persist_collection_memberships(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
+      pass_collection_to_be_persisted(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
       object.attributes = attrs
       object.apply_depositor_metadata(@user)
       object.save!
     end
 
     def update_collection(attrs)
-      persist_collection_memberships(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
+      pass_collection_to_be_persisted(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
       object.attributes = attrs
       object.save!
     end
@@ -182,12 +182,20 @@ module Bulkrax
       actor.update_metadata(file_set_attrs)
     end
 
+    def pass_collection_to_be_persisted(parent:, child:)
+      if parent.is_a? Array
+        parent.each { |par| persist_collection_memberships(par, child) }
+      else
+        persist_collection_memberships(parent, child)
+      end
+    end
+
     # Add child to parent's #member_collections
     # Add parent to child's #member_of_collections
-    def persist_collection_memberships(parent:, child:)
+    def persist_collection_memberships(parent, child)
       parent.reject!(&:blank?) if parent.respond_to?(:reject!)
       child.reject!(&:blank?) if child.respond_to?(:reject!)
-      return if parent.blank? || child.blank?
+      return if parent.invalid? || child.invalid?
 
       ::Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: child)
     end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -140,16 +140,16 @@ module Bulkrax
     def create_collection(attrs)
       attrs = clean_attrs(attrs)
       attrs = collection_type(attrs)
-      pass_collection_to_be_persisted(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
       object.attributes = attrs
       object.apply_depositor_metadata(@user)
       object.save!
+      pass_collection_to_be_persisted(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
     end
 
     def update_collection(attrs)
-      pass_collection_to_be_persisted(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
       object.attributes = attrs
       object.save!
+      pass_collection_to_be_persisted(parent: find_collection(attributes[related_parents_parsed_mapping]), child: object) if attributes[related_parents_parsed_mapping].present?
     end
 
     # This method is heavily inspired by Hyrax's AttachFilesToWorkJob
@@ -195,7 +195,7 @@ module Bulkrax
     def persist_collection_memberships(parent, child)
       parent.reject!(&:blank?) if parent.respond_to?(:reject!)
       child.reject!(&:blank?) if child.respond_to?(:reject!)
-      return if parent.invalid? || child.invalid?
+      return if parent.blank? || child.blank?
 
       ::Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent, child: child)
     end

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -87,8 +87,8 @@ module Bulkrax
         ObjectFactory.new(
           attributes: attrs,
           source_identifier_value: nil, # sending the :id in the attrs means the factory doesn't need a :source_identifier_value
-          work_identifier: parent_entry.parser.work_identifier,
-          related_parents_parsed_mapping: parent_entry.parser.related_parents_parsed_mapping,
+          work_identifier: parent_entry&.parser&.work_identifier,
+          related_parents_parsed_mapping: parent_entry&.parser&.related_parents_parsed_mapping,
           replace_files: false,
           user: user,
           klass: child_record.class,
@@ -106,8 +106,8 @@ module Bulkrax
       ObjectFactory.new(
         attributes: attrs,
         source_identifier_value: nil, # sending the :id in the attrs means the factory doesn't need a :source_identifier_value
-        work_identifier: parent_entry.parser.work_identifier,
-        related_parents_parsed_mapping: parent_entry.parser.related_parents_parsed_mapping,
+        work_identifier: parent_entry&.parser&.work_identifier,
+        related_parents_parsed_mapping: parent_entry&.parser&.related_parents_parsed_mapping,
         replace_files: false,
         user: user,
         klass: parent_record.class,
@@ -130,8 +130,8 @@ module Bulkrax
       ObjectFactory.new(
         attributes: attrs,
         source_identifier_value: nil, # sending the :id in the attrs means the factory doesn't need a :source_identifier_value
-        work_identifier: parent_entry.parser.work_identifier,
-        related_parents_parsed_mapping: parent_entry.parser.related_parents_parsed_mapping,
+        work_identifier: parent_entry&.parser&.work_identifier,
+        related_parents_parsed_mapping: parent_entry&.parser&.related_parents_parsed_mapping,
         replace_files: false,
         user: user,
         klass: parent_record.class,

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -31,7 +31,7 @@ module Bulkrax
     # Whether the @base_entry is the parent or the child in the relationship is determined by the presence of a
     # parent_identifier or child_identifier param. For example, if a parent_identifier is passed, we know @base_entry
     # is the child in the relationship, and vice versa if a child_identifier is passed.
-    def perform(parent_identifier:, importer_run_id:)
+    def perform(parent_identifier:, importer_run_id:) # rubocop:disable Metrics/AbcSize
       pending_relationships = Bulkrax::PendingRelationship.find_each.select do |rel|
         rel.bulkrax_importer_run_id == importer_run_id && rel.parent_id == parent_identifier
       end.sort_by(&:order)

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -21,7 +21,7 @@ module Bulkrax
 
     queue_as :import
 
-    attr_accessor :child_records, :child_entry, :parent_record, :parent_entry, :importer_run_id
+    attr_accessor :child_records, :parent_record, :parent_entry, :importer_run_id
 
     # @param parent_identifier [String] Work/Collection ID or Bulkrax::Entry source_identifiers
     # @param importer_run [Bulkrax::ImporterRun] current importer run (needed to properly update counters)
@@ -41,7 +41,7 @@ module Bulkrax
       @child_records = { works: [], collections: [] }
       pending_relationships.each do |rel|
         raise ::StandardError, %("#{rel}" needs either a child or a parent to create a relationship) if rel.child_id.nil? || rel.parent_id.nil?
-        @child_entry, child_record = find_record(rel.child_id, importer_run_id)
+        child_entry, child_record = find_record(rel.child_id, importer_run_id)
         child_record.is_a?(::Collection) ? @child_records[:collections] << child_record : @child_records[:works] << child_record
       end
 

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -21,7 +21,7 @@ module Bulkrax
 
     queue_as :import
 
-    attr_accessor :child_records, :parent_record, :parent_entry, :importer_run_id
+    attr_accessor :child_records, :child_entry, :parent_record, :parent_entry, :importer_run_id
 
     # @param parent_identifier [String] Work/Collection ID or Bulkrax::Entry source_identifiers
     # @param importer_run [Bulkrax::ImporterRun] current importer run (needed to properly update counters)
@@ -41,7 +41,7 @@ module Bulkrax
       @child_records = { works: [], collections: [] }
       pending_relationships.each do |rel|
         raise ::StandardError, %("#{rel}" needs either a child or a parent to create a relationship) if rel.child_id.nil? || rel.parent_id.nil?
-        child_entry, child_record = find_record(rel.child_id, importer_run_id)
+        @child_entry, child_record = find_record(rel.child_id, importer_run_id)
         child_record.is_a?(::Collection) ? @child_records[:collections] << child_record : @child_records[:works] << child_record
       end
 

--- a/app/models/concerns/bulkrax/dynamic_record_lookup.rb
+++ b/app/models/concerns/bulkrax/dynamic_record_lookup.rb
@@ -11,7 +11,8 @@ module Bulkrax
     def find_record(identifier, importer_run_id = nil)
       # check for our entry in our current importer first
       importer_id = ImporterRun.find(importer_run_id).importer_id
-      record = Entry.find_by(identifier: identifier, importerexporter_id: importer_id) || Entry.find_by(identifier: identifier)
+      default_scope = { identifier: identifier, importerexporter_type: 'Bulkrax::Importer' }
+      record = Entry.find_by(default_scope, importerexporter_id: importer_id) || Entry.find_by(default_scope)
 
       # TODO(alishaevn): discuss whether we are only looking for Collection models here
       # use ActiveFedora::Base.find(identifier) instead?

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -27,8 +27,8 @@ module Bulkrax
 
     before do
       allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])
-      allow(Entry).to receive(:find_by).with(identifier: child_entry.identifier, importerexporter_id: importer.id).and_return(child_entry)
-      allow(Entry).to receive(:find_by).with(identifier: parent_entry.identifier, importerexporter_id: importer.id).and_return(parent_entry)
+      allow(Entry).to receive(:find_by).with({ identifier: child_entry.identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer.id }).and_return(child_entry)
+      allow(Entry).to receive(:find_by).with({ identifier: parent_entry.identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer.id }).and_return(parent_entry)
       allow(parent_entry).to receive(:factory).and_return(parent_factory)
       allow(child_entry).to receive(:factory).and_return(child_factory)
     end

--- a/spec/models/concerns/bulkrax/dynamic_record_lookup_spec.rb
+++ b/spec/models/concerns/bulkrax/dynamic_record_lookup_spec.rb
@@ -21,7 +21,7 @@ module Bulkrax
         let(:source_identifier) { 'bulkrax_identifier_1' }
 
         it 'looks through entries, collections, and all work types' do
-          expect(Entry).to receive(:find_by).with(identifier: source_identifier, importerexporter_id: importer_id).once
+          expect(Entry).to receive(:find_by).with({ identifier: source_identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer_id }).once
           expect(::Collection).to receive(:where).with(id: source_identifier).once.and_return([])
           expect(::Work).to receive(:where).with(id: source_identifier).once.and_return([])
 
@@ -34,7 +34,7 @@ module Bulkrax
           let(:record) { instance_double(::Work, title: ["Found through Entry's factory"]) }
 
           before do
-            allow(Entry).to receive(:find_by).with(identifier: source_identifier, importerexporter_id: importer_id).and_return(entry)
+            allow(Entry).to receive(:find_by).with({ identifier: source_identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer_id }).and_return(entry)
             allow(entry).to receive(:factory).and_return(factory)
           end
 
@@ -46,9 +46,10 @@ module Bulkrax
             expect(entry).to receive(:factory)
             expect(factory).to receive(:find)
 
-            _, found_record = subject.find_record(source_identifier, importer_run_id)
+            found_entry, found_record = subject.find_record(source_identifier, importer_run_id)
 
             expect(found_record.title).to eq(record.title)
+            expect(found_entry.identifier).to eq(entry.identifier)
           end
         end
 
@@ -63,7 +64,7 @@ module Bulkrax
         let(:id) { 'xyz6789' }
 
         it 'looks through entries, collections, and all work types' do
-          expect(Entry).to receive(:find_by).with(identifier: id, importerexporter_id: importer_id).once
+          expect(Entry).to receive(:find_by).with({ identifier: id, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer_id }).once
           expect(::Collection).to receive(:where).with(id: id).once.and_return([])
           expect(::Work).to receive(:where).with(id: id).once.and_return([])
 


### PR DESCRIPTION
ref: #471 && #475

# expected behavior
- users can add a child work to a preexisting collection using the collection's id
- users can add a child work to a preexisting work using the preexisting work's id
- users can add a child collection to a preexisting collection using the preexisting collections's id

# demo
| work to collection | work to work |  collection to collection |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/164119946-40206872-b467-470e-b273-d578366a9474.png) | ![image](https://user-images.githubusercontent.com/29032869/164119886-267269f2-d517-4e17-883e-4459cd40338b.png) | <img width="1169" alt="image" src="https://user-images.githubusercontent.com/29032869/165091135-c5864a2d-36d5-4fea-b4bd-af08bfe5de01.png"> |