### PR TITLE
Remove check for CLA from CI

### DIFF
--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -22,9 +22,3 @@ jobs:
         with:
           one_of: patch-ver,minor-ver,major-ver,bug-fix,enhancement,breaking-change,database-changes,ignore-for-release
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check PR for cla-signed label
-        uses: docker://agilepathway/pull-request-label-checker:latest
-        with:
-          one_of: cla-signed
-          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to [this commit](https://github.com/samvera-labs/cla-bot/commit/4bc9dd5a3ebe0230405ae4d7a27c2a21f525d782) in the cla-bot, CLAs are no longer required by Samvera. This PR removes the GitHub workflow that required the `cla-lable` to be present on all PRs 