### PR TITLE
Random NoMethodError on import

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -250,7 +250,7 @@ module Bulkrax
       split_references = record[parent_field_mapping].split(/\s*[;|]\s*/)
       split_references.each do |c_reference|
         matching_collection_entries = importerexporter.entries.select do |e|
-          (e.raw_metadata[source_identifier] == c_reference) &&
+          (e.raw_metadata&.[](source_identifier) == c_reference) &&
             e.is_a?(CsvCollectionEntry)
         end
         raise ::StandardError, 'Only expected to find one matching entry' if matching_collection_entries.count > 1


### PR DESCRIPTION
### Summary

Inconsistent error on first run of import: `NoMethodError - undefined method '[]' for nil`
Error clears after a re-run.

Found that the raw metadata of imported entries returns a `nil` value due to import jobs still loading, hence the `NoMethodError` on the first run and not the rerun. Issue is resolved with `&.` that prevents block from erroring out.