### PR TITLE
Better error message for FileSets missing files

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -59,6 +59,7 @@ module Bulkrax
       if factory_class == Collection
         add_collection_type_gid
       elsif factory_class == FileSet
+        validate_presence_of_filename!
         add_path_to_file
         validate_presence_of_parent!
       else

--- a/app/models/bulkrax/csv_file_set_entry.rb
+++ b/app/models/bulkrax/csv_file_set_entry.rb
@@ -17,6 +17,12 @@ module Bulkrax
       parsed_metadata['file']
     end
 
+    def validate_presence_of_filename!
+      return if parsed_metadata&.[]('file')&.map(&:present?)&.any?
+
+      raise StandardError, 'File set must have a filename'
+    end
+
     def validate_presence_of_parent!
       return if parsed_metadata[related_parents_parsed_mapping]&.map(&:present?)&.any?
 

--- a/spec/models/bulkrax/csv_file_set_entry_spec.rb
+++ b/spec/models/bulkrax/csv_file_set_entry_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Bulkrax
+  RSpec.describe CsvFileSetEntry, type: :model do
+    subject(:entry) { described_class.new }
+
+    describe '#validate_presence_of_filename!' do
+      context 'when filename is missing' do
+        before do
+          entry.parsed_metadata = {}
+        end
+
+        it 'raises a StandardError' do
+          expect { entry.validate_presence_of_filename! }
+            .to raise_error(StandardError, 'File set must have a filename')
+        end
+      end
+
+      context 'when filename is present' do
+        before do
+          entry.parsed_metadata = { 'file' => ['test.png'] }
+        end
+
+        it 'does not raise a StandardError' do
+          expect { entry.validate_presence_of_filename! }
+            .not_to raise_error(StandardError)
+        end
+      end
+
+      context 'when filename is an array containing an empty string' do
+        before do
+          entry.parsed_metadata = { 'file' => [''] }
+        end
+
+        it 'raises a StandardError' do
+          expect { entry.validate_presence_of_filename! }
+            .to raise_error(StandardError, 'File set must have a filename')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Display a more descriptive error message when `FileSet` entries are missing a parsed filename. This replaces the ambiguous `NoMethodError` that was previously being thrown: 

![Show Entry Digital Collections Online 2022-04-27 at 3 29 04 PM](https://user-images.githubusercontent.com/32469930/165641956-9bac037f-31f1-4211-9d4e-9761476131eb.jpg)
