### PR TITLE
Remove legacy collection relationships logic from object factory

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -51,7 +51,7 @@ module Bulkrax
           importer_run_id: importer_run_id
         )
         return false # stop current job from continuing to run after rescheduling
-      end 
+      end
 
       @parent_entry ||= Bulkrax::Entry.where(identifier: parent_identifier,
                                              importerexporter_id: ImporterRun.find(importer_run_id).importer_id,

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -83,17 +83,7 @@ module Bulkrax
     # This is adding the reverse relationship, from the child to the parent
     def collection_parent_work_child
       child_records[:works].each do |child_record|
-        attrs = { id: child_record.id, member_of_collections_attributes: { 0 => { id: parent_record.id } } }
-        ObjectFactory.new(
-          attributes: attrs,
-          source_identifier_value: nil, # sending the :id in the attrs means the factory doesn't need a :source_identifier_value
-          work_identifier: parent_entry&.parser&.work_identifier,
-          related_parents_parsed_mapping: parent_entry&.parser&.related_parents_parsed_mapping,
-          replace_files: false,
-          user: user,
-          klass: child_record.class,
-          importer_run_id: importer_run_id
-        ).run
+        ::Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent_record, child: child_record)
         # TODO: add counters for :processed_parents and :failed_parents
         Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
       end

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -101,19 +101,9 @@ module Bulkrax
 
     # Collection-Collection membership is added to the as member_ids
     def collection_parent_collection_child
-      child_record = child_records[:collections].first
-      attrs = { id: parent_record.id, child_collection_id: child_record.id }
-      ObjectFactory.new(
-        attributes: attrs,
-        source_identifier_value: nil, # sending the :id in the attrs means the factory doesn't need a :source_identifier_value
-        work_identifier: parent_entry&.parser&.work_identifier,
-        related_parents_parsed_mapping: parent_entry&.parser&.related_parents_parsed_mapping,
-        replace_files: false,
-        user: user,
-        klass: parent_record.class,
-        importer_run_id: importer_run_id
-      ).run
-      # TODO: add counters for :processed_parents and :failed_parents
+      child_records[:collections].each do |child_record|
+        ::Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent_record, child: child_record)
+      end
       Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
     end
 

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -104,19 +104,11 @@ module Bulkrax
         records_hash[i] = { id: child_record.id }
       end
       attrs = {
-        id: parent_record.id,
         work_members_attributes: records_hash
       }
-      ObjectFactory.new(
-        attributes: attrs,
-        source_identifier_value: nil, # sending the :id in the attrs means the factory doesn't need a :source_identifier_value
-        work_identifier: parent_entry&.parser&.work_identifier,
-        related_parents_parsed_mapping: parent_entry&.parser&.related_parents_parsed_mapping,
-        replace_files: false,
-        user: user,
-        klass: parent_record.class,
-        importer_run_id: importer_run_id
-      ).run
+      parent_record.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX if parent_record.respond_to?(:reindex_extent)
+      env = Hyrax::Actors::Environment.new(parent_record, Ability.new(user), attrs)
+      Hyrax::CurationConcern.actor.update(env)
       # TODO: add counters for :processed_parents and :failed_parents
       Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
     end

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -51,7 +51,7 @@ module Bulkrax
           importer_run_id: importer_run_id
         )
         return false # stop current job from continuing to run after rescheduling
-      end
+      end 
 
       @parent_entry ||= Bulkrax::Entry.where(identifier: parent_identifier,
                                              importerexporter_id: ImporterRun.find(importer_run_id).importer_id,
@@ -93,8 +93,8 @@ module Bulkrax
     def collection_parent_collection_child
       child_records[:collections].each do |child_record|
         ::Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent_record, child: child_record)
+        Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
       end
-      Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
     end
 
     # Work-Work membership is added to the parent as member_ids

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -39,15 +39,11 @@ module Bulkrax
 
     describe '#perform' do
       context 'when adding a child work to a parent collection' do
-        let(:factory_attrs) do
-          base_factory_attrs.merge(
-            attributes: {
-              id: child_record.id,
-              member_of_collections_attributes: { 0 => { id: parent_record.id } }
-            },
-            klass: child_record.class,
-            importer_run_id: importer.current_run.id
-          )
+        let(:collection_work_attrs) do
+          {
+            parent: parent_record,
+            child: child_record
+          }
         end
 
         context 'with a Bulkrax::Entry source_identifier' do
@@ -60,11 +56,9 @@ module Bulkrax
             )
           end
 
-          it 'creates and runs the object factory' do
-            expect(ObjectFactory).to receive(:new).with(factory_attrs).and_return(parent_factory)
-            expect(parent_factory).to receive(:run)
+          it 'runs NestedCollectionPersistenceService' do
+            expect(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs)
             allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
-
             create_relationships_job.perform(
               parent_identifier: parent_entry.identifier,
               importer_run_id: importer.current_run.id
@@ -72,25 +66,14 @@ module Bulkrax
           end
 
           context 'importer run' do
-            let(:factory) { instance_double(ObjectFactory, run: child_record) }
-
-            before do
-              allow(ObjectFactory).to receive(:new).and_return(factory)
-              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
-            end
-
             it 'increments processed relationships' do
+              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
+              allow(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs).and_return(true)
               create_relationships_job.perform(
                 parent_identifier: parent_entry.identifier,
                 importer_run_id: importer.current_run.id
               )
-
-              expect(importer.last_run.processed_relationships).to equal(1)
-              # create_relationships_job.perform(
-              #   entry_identifier: child_entry.identifier,
-              #   parent_identifier: parent_entry.identifier,
-              #   importer_run: importer.current_run
-              # )
+              expect(importer.current_run.reload.processed_relationships).to eq(1)
             end
           end
         end
@@ -112,9 +95,8 @@ module Bulkrax
             )
           end
 
-          it 'creates the object factory' do
-            expect(ObjectFactory).to receive(:new).with(factory_attrs).and_return(child_factory)
-
+          it 'runs NestedCollectionPersistenceService' do
+            expect(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs)
             create_relationships_job.perform(
               parent_identifier: parent_entry.identifier,
               importer_run_id: importer.current_run.id
@@ -122,18 +104,14 @@ module Bulkrax
           end
 
           context 'importer run' do
-            before do
-              allow(ObjectFactory).to receive(:new).and_return(child_factory)
-              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
-            end
-
             it 'increments processed relationships' do
+              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
+              allow(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs).and_return(true)
               create_relationships_job.perform(
                 parent_identifier: parent_entry.identifier,
                 importer_run_id: importer.current_run.id
               )
-
-              expect(importer.last_run.processed_relationships).to equal(1)
+              expect(importer.current_run.reload.processed_relationships).to eq(1)
             end
           end
         end
@@ -145,15 +123,11 @@ module Bulkrax
         let(:parent_record) { build(:collection) }
         let(:child_record) { build(:another_collection) }
         let(:pending_rel_col) { build(:pending_relationship_collection_child) }
-        let(:factory_attrs) do
-          base_factory_attrs.merge(
-            attributes: {
-              id: parent_record.id,
-              child_collection_id: child_record.id
-            },
-            klass: parent_record.class,
-            importer_run_id: importer.current_run.id
-          )
+        let(:collection_collection_attrs) do
+          {
+            parent: parent_record,
+            child: child_record
+          }
         end
 
         context 'with a Bulkrax::Entry source_identifier' do
@@ -167,8 +141,8 @@ module Bulkrax
             )
           end
 
-          it 'creates the object factory' do
-            expect(ObjectFactory).to receive(:new).with(factory_attrs).and_return(child_factory)
+          it 'runs NestedCollectionPersistenceService' do
+            expect(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_collection_attrs)
             allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_col])
 
             create_relationships_job.perform(
@@ -178,21 +152,14 @@ module Bulkrax
           end
 
           context 'importer run' do
-            let(:factory) { instance_double(ObjectFactory, run: child_record) }
-
-            before do
-              allow(ObjectFactory).to receive(:new).and_return(factory)
-            end
-
             it 'increments processed children' do
               allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_col])
-
+              allow(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_collection_attrs).and_return(true)
               create_relationships_job.perform(
                 parent_identifier: parent_entry.identifier,
                 importer_run_id: importer.current_run.id
               )
-
-              expect(importer.last_run.processed_relationships).to equal(1)
+              expect(importer.current_run.reload.processed_relationships).to eq(1)
             end
           end
         end
@@ -214,8 +181,8 @@ module Bulkrax
             )
           end
 
-          it 'creates the object factory' do
-            expect(ObjectFactory).to receive(:new).with(factory_attrs).and_return(child_factory)
+          it 'runs NestedCollectionPersistenceService' do
+            expect(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_collection_attrs)
 
             create_relationships_job.perform(
               parent_identifier: parent_entry.identifier,
@@ -224,17 +191,14 @@ module Bulkrax
           end
 
           context 'importer run' do
-            before do
-              allow(ObjectFactory).to receive(:new).and_return(parent_factory)
-            end
-
             it 'increments processed children' do
+              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_col])
+              allow(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_collection_attrs).and_return(true)
               create_relationships_job.perform(
                 parent_identifier: parent_entry.identifier,
                 importer_run_id: importer.current_run.id
               )
-
-              expect(importer.last_run.processed_relationships).to equal(1)
+              expect(importer.current_run.reload.processed_relationships).to eq(1)
             end
           end
         end
@@ -245,17 +209,8 @@ module Bulkrax
         let(:child_entry) { create(:bulkrax_csv_entry_work, identifier: 'child_entry_work', importerexporter: importer) }
         let(:parent_record) { build(:work) }
         let(:child_record) { build(:another_work) }
-        let(:factory_attrs) do
-          base_factory_attrs.merge(
-            attributes: {
-              id: parent_record.id,
-              work_members_attributes: { 0 => { id: child_record.id } }
-            },
-            klass: parent_record.class,
-            importer_run_id: importer.current_run.id
-          )
-        end
-
+        let(:env) { Hyrax::Actors::Environment }
+        
         context 'with a Bulkrax::Entry source_identifier' do
           it 'calls #work_parent_work_child' do
             expect(create_relationships_job).to receive(:work_parent_work_child)
@@ -267,31 +222,26 @@ module Bulkrax
               )
           end
 
-          it 'creates the object factory' do
-            expect(ObjectFactory).to receive(:new).with(factory_attrs).and_return(parent_factory)
+          it 'runs CurationConcern' do
             allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
-
+            allow(Ability).to receive(:new).with(importer.user)
+            expect(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env))
             create_relationships_job.perform(
-                parent_identifier: parent_entry.identifier,
-                importer_run_id: importer.current_run.id
-              )
+              parent_identifier: parent_entry.identifier,
+              importer_run_id: importer.current_run.id
+            )
           end
-
+          
           context 'importer run' do
-            let(:factory) { instance_double(ObjectFactory, run: child_record) }
-
-            before do
-              allow(ObjectFactory).to receive(:new).and_return(factory)
-              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
-            end
-
             it 'increments processed children' do
+              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
+              allow(Ability).to receive(:new).with(importer.user)
+              allow(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env)).and_return(true)
               create_relationships_job.perform(
                 parent_identifier: parent_entry.identifier,
                 importer_run_id: importer.current_run.id
               )
-
-              expect(importer.last_run.processed_relationships).to equal(1)
+              expect(importer.current_run.reload.processed_relationships).to eq(1)
             end
           end
         end
@@ -313,10 +263,10 @@ module Bulkrax
               )
           end
 
-          it 'creates the object factory' do
-            expect(ObjectFactory).to receive(:new).with(factory_attrs).and_return(parent_factory)
+          it 'runs CurationConcern' do
             allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
-
+            allow(Ability).to receive(:new).with(importer.user)
+            expect(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env))
             create_relationships_job.perform(
                 parent_identifier: parent_entry.identifier,
                 importer_run_id: importer.current_run.id
@@ -324,18 +274,15 @@ module Bulkrax
           end
 
           context 'importer run' do
-            before do
-              allow(ObjectFactory).to receive(:new).and_return(child_factory)
-              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
-            end
-
             it 'increments processed children' do
+              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
+              allow(Ability).to receive(:new).with(importer.user)
+              allow(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env)).and_return(true)
               create_relationships_job.perform(
                 parent_identifier: parent_entry.identifier,
                 importer_run_id: importer.current_run.id
               )
-
-              expect(importer.last_run.processed_relationships).to equal(1)
+              expect(importer.current_run.reload.processed_relationships).to equal(1)
             end
           end
         end

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -7,14 +7,14 @@ module Bulkrax
   RSpec.describe CreateRelationshipsJob, type: :job do
     subject(:create_relationships_job) { described_class.new }
     let(:importer) { FactoryBot.create(:bulkrax_importer_csv_complex) }
-    let(:parent_entry)  { create(:bulkrax_csv_entry_collection, importerexporter: importer) }
-    let(:child_entry)   { create(:bulkrax_csv_entry_work, importerexporter: importer) }
+    let(:parent_entry) { create(:bulkrax_csv_entry_collection, importerexporter: importer) }
+    let(:child_entry) { create(:bulkrax_csv_entry_work, importerexporter: importer) }
     let(:parent_record) { build(:collection) }
-    let(:child_record)  { build(:work) }
+    let(:child_record) { build(:work) }
     let(:parent_factory) { instance_double(ObjectFactory, find: parent_record, run: parent_record) }
     let(:child_factory) { instance_double(ObjectFactory, find: child_record, run: child_record) }
-    let(:pending_rel)   { build(:pending_relationship_collection_parent) }
-    let(:pending_rel_work)   { build(:pending_relationship_work_parent) }
+    let(:pending_rel) { build(:pending_relationship_collection_parent) }
+    let(:pending_rel_work) { build(:pending_relationship_work_parent) }
 
     before do
       allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -15,15 +15,6 @@ module Bulkrax
     let(:child_factory) { instance_double(ObjectFactory, find: child_record, run: child_record) }
     let(:pending_rel)   { build(:pending_relationship_collection_parent) }
     let(:pending_rel_work)   { build(:pending_relationship_work_parent) }
-    let(:base_factory_attrs) do
-      {
-        source_identifier_value: nil,
-        work_identifier: :source,
-        related_parents_parsed_mapping: parent_entry.parser.related_parents_parsed_mapping,
-        replace_files: false,
-        user: importer.user
-      }
-    end
 
     before do
       allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -201,7 +201,7 @@ module Bulkrax
         let(:parent_record) { build(:work) }
         let(:child_record) { build(:another_work) }
         let(:env) { Hyrax::Actors::Environment }
-        
+
         context 'with a Bulkrax::Entry source_identifier' do
           it 'calls #work_parent_work_child' do
             expect(create_relationships_job).to receive(:work_parent_work_child)
@@ -222,7 +222,7 @@ module Bulkrax
               importer_run_id: importer.current_run.id
             )
           end
-          
+
           context 'importer run' do
             it 'increments processed children' do
               allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -254,7 +254,7 @@ module Bulkrax
               )
           end
 
-          it 'runs CurationConcern' do
+          it 'runs CurationConcern Actor' do
             allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
             allow(Ability).to receive(:new).with(importer.user)
             expect(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env))


### PR DESCRIPTION
Separated relationships handling away from `ObjectFactory` and into `CreateRelationshipsJob` that was creating an `ActiveFedora::ObjectNotFoundError`

Relationships include:
- Collection Parent -> Collection Child
- Collection Parent -> Work Child
- Work Parent -> Work Child