### PR TITLE
Account for commons mistakes when importing controlled Questioning Authority fields

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -46,7 +46,7 @@ module Bulkrax
       add_visibility
       add_metadata_for_model
       add_rights_statement
-      sanitize_qa_uri_values!
+      sanitize_controlled_uri_values!
       add_local
 
       self.parsed_metadata

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -46,6 +46,7 @@ module Bulkrax
       add_visibility
       add_metadata_for_model
       add_rights_statement
+      sanitize_qa_uri_values
       add_local
 
       self.parsed_metadata

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -46,7 +46,7 @@ module Bulkrax
       add_visibility
       add_metadata_for_model
       add_rights_statement
-      sanitize_qa_uri_values
+      sanitize_qa_uri_values!
       add_local
 
       self.parsed_metadata

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -5,8 +5,6 @@ module Bulkrax
   module ImportBehavior
     extend ActiveSupport::Concern
 
-    LOCAL_QA_FIELDS = %w[rights_statement license].freeze
-
     def build_for_importer
       begin
         build_metadata
@@ -109,7 +107,7 @@ module Bulkrax
 
     # TODO: documentation
     def sanitize_qa_uri_values!
-      LOCAL_QA_FIELDS.each do |field|
+      Bulkrax.qa_controlled_properties.each do |field|
         next if parsed_metadata[field].blank?
 
         parsed_metadata[field].each_with_index do |value, i|

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -2,7 +2,7 @@
 
 module Bulkrax
   # Import Behavior for Entry classes
-  module ImportBehavior
+  module ImportBehavior # rubocop:disable Metrics/ModuleLength
     extend ActiveSupport::Concern
 
     def build_for_importer

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -12,6 +12,7 @@ module Bulkrax
                    :related_children_field_mapping,
                    :related_parents_field_mapping,
                    :reserved_properties,
+                   :qa_controlled_properties,
                    :field_mappings,
                    :import_path,
                    :export_path,
@@ -119,6 +120,11 @@ module Bulkrax
       original_url
       relative_path
     ]
+
+    # List of Questioning Authority properties that are controlled via YAML files in
+    # the config/authorities/ directory. For example, the :rights_statement property
+    # is controlled by the active terms in config/authorities/rights_statements.yml
+    self.qa_controlled_properties = %w[rights_statement license]
   end
 
   def self.api_definition

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -18,8 +18,7 @@ module Bulkrax
                    :export_path,
                    :removed_image_path,
                    :server_name,
-                   :api_definition,
-                   :removed_image_path
+                   :api_definition
 
     self.parsers = [
       { name: "OAI - Dublin Core", class_name: "Bulkrax::OaiDcParser", partial: "oai_fields" },
@@ -136,8 +135,6 @@ module Bulkrax
       )
     )
   end
-
-  self.removed_image_path = 'app/assets/images/bulkrax/removed.png'
 
   # this function maps the vars from your app into your engine
   def self.setup

--- a/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
+++ b/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
@@ -61,6 +61,12 @@ Bulkrax.setup do |config|
 
   # Properties that should not be used in imports/exports. They are reserved for use by Hyrax.
   # config.reserved_properties += ['my_field']
+
+  # List of Questioning Authority properties that are controlled via YAML files in
+  # the config/authorities/ directory. For example, the :rights_statement property
+  # is controlled by the active terms in config/authorities/rights_statements.yml
+  # Defaults: 'rights_statement' and 'license'
+  # config.qa_controlled_properties += ['my_field']
 end
 
 # Sidebar for hyrax 3+ support

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -68,8 +68,8 @@ module Bulkrax
           allow(subject).to receive(:raw_metadata).and_return('source_identifier' => 'qa_1', 'title' => 'some title')
         end
 
-        it 'calls #sanitize_qa_uri_values!' do
-          expect(subject).to receive(:sanitize_qa_uri_values!).once
+        it 'calls #sanitize_controlled_uri_values!' do
+          expect(subject).to receive(:sanitize_controlled_uri_values!).once
 
           subject.build_metadata
         end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -63,6 +63,70 @@ module Bulkrax
         end
       end
 
+      describe 'importing controlled questioning authority fields' do
+        before do
+          allow(subject).to receive(:raw_metadata).and_return('source_identifier' => 'qa_1', 'title' => 'some title')
+        end
+
+        it 'calls #sanitize_qa_uri_values' do
+          expect(subject).to receive(:sanitize_qa_uri_values).once
+
+          subject.build_metadata
+        end
+
+        describe 'importing :rights_statement' do
+          context 'when the value has https' do
+            before do
+              allow(subject).to receive(:raw_metadata).and_return('rights_statement' => 'https://rightsstatements.org/vocab/InC/1.0/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+            end
+
+            it 'replaces https with http' do
+              subject.build_metadata
+
+              expect(subject.parsed_metadata['rights_statement']).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+            end
+          end
+
+          context 'when the value does not have a forward slash at the end' do
+            before do
+              allow(subject).to receive(:raw_metadata).and_return('rights_statement' => 'http://rightsstatements.org/vocab/InC/1.0', 'source_identifier' => 'qa_1', 'title' => 'some title')
+            end
+
+            it 'adds a trailing forward slash' do
+              subject.build_metadata
+
+              expect(subject.parsed_metadata['rights_statement']).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+            end
+          end
+        end
+
+        describe 'importing :license' do
+          context 'when the value has https' do
+            before do
+              allow(subject).to receive(:raw_metadata).and_return('license' => 'https://creativecommons.org/licenses/by/3.0/us/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+            end
+
+            it 'replaces https with http' do
+              subject.build_metadata
+
+              expect(subject.parsed_metadata['license']).to eq(['http://creativecommons.org/licenses/by/3.0/us/'])
+            end
+          end
+
+          context 'when the value does not have a forward slash at the end' do
+            before do
+              allow(subject).to receive(:raw_metadata).and_return('license' => 'http://creativecommons.org/licenses/by/3.0/us', 'source_identifier' => 'qa_1', 'title' => 'some title')
+            end
+
+            it 'adds a trailing forward slash' do
+              subject.build_metadata
+
+              expect(subject.parsed_metadata['license']).to eq(['http://creativecommons.org/licenses/by/3.0/us/'])
+            end
+          end
+        end
+      end
+
       context 'with parent-child relationships' do
         let(:importer) { FactoryBot.create(:bulkrax_importer_csv, :with_relationships_mappings) }
         let(:required_data) do
@@ -231,7 +295,7 @@ module Bulkrax
           expect(metadata['single_object']['first_name']).to eq('Fake')
           expect(metadata['single_object']['last_name']).to eq('Fakerson')
           expect(metadata['single_object']['position']).to include('Leader', 'Jester', 'Queen')
-          expect(metadata['single_object']['language']).to eq('English')
+          expect(metadata['single_object']['language']).to eq(['English'])
         end
       end
 

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -75,15 +75,33 @@ module Bulkrax
         end
 
         describe 'importing :rights_statement' do
-          context 'when the value has https' do
-            before do
-              allow(subject).to receive(:raw_metadata).and_return('rights_statement' => 'https://rightsstatements.org/vocab/InC/1.0/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+          context 'when the http/https does not match' do
+            context 'when the authority ID has https' do
+              let(:auth_id) { 'https://rightsstatements.org/vocab/fake/1.0/' }
+
+              before do
+                allow(subject).to receive(:raw_metadata).and_return('rights_statement' => 'http://rightsstatements.org/vocab/fake/1.0/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+              end
+
+              it 'replaces http with https' do
+                subject.build_metadata
+
+                expect(subject.parsed_metadata['rights_statement']).to eq([auth_id])
+              end
             end
 
-            it 'replaces https with http' do
-              subject.build_metadata
+            context 'when the authority ID has http' do
+              let(:auth_id) { 'http://rightsstatements.org/vocab/InC/1.0/' }
 
-              expect(subject.parsed_metadata['rights_statement']).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+              before do
+                allow(subject).to receive(:raw_metadata).and_return('rights_statement' => 'https://rightsstatements.org/vocab/InC/1.0/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+              end
+
+              it 'replaces https with http' do
+                subject.build_metadata
+
+                expect(subject.parsed_metadata['rights_statement']).to eq([auth_id])
+              end
             end
           end
 
@@ -98,30 +116,70 @@ module Bulkrax
               expect(subject.parsed_metadata['rights_statement']).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
             end
           end
+
+          context 'when the value does not match an existing, active authority ID' do
+            before do
+              allow(subject).to receive(:raw_metadata).and_return('rights_statement' => 'hello world', 'source_identifier' => 'qa_1', 'title' => 'some title')
+            end
+
+            it 'raises a StandardError' do
+              expect { subject.build_metadata }
+                .to raise_error(StandardError, %("hello world" is not a valid and/or active authority ID for the :rights_statement field))
+            end
+          end
         end
 
         describe 'importing :license' do
-          context 'when the value has https' do
-            before do
-              allow(subject).to receive(:raw_metadata).and_return('license' => 'https://creativecommons.org/licenses/by/3.0/us/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+          context 'when the http/https does not match' do
+            context 'when the authority ID has https' do
+              let(:auth_id) { 'https://creativecommons.org/licenses/by/4.0/' }
+
+              before do
+                allow(subject).to receive(:raw_metadata).and_return('license' => 'http://creativecommons.org/licenses/by/4.0/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+              end
+
+              it 'replaces http with https' do
+                subject.build_metadata
+
+                expect(subject.parsed_metadata['license']).to eq([auth_id])
+              end
             end
 
-            it 'replaces https with http' do
-              subject.build_metadata
+            context 'when the authority ID has http' do
+              let(:auth_id) { 'http://creativecommons.org/publicdomain/mark/1.0/' }
 
-              expect(subject.parsed_metadata['license']).to eq(['http://creativecommons.org/licenses/by/3.0/us/'])
+              before do
+                allow(subject).to receive(:raw_metadata).and_return('license' => 'https://creativecommons.org/publicdomain/mark/1.0/', 'source_identifier' => 'qa_1', 'title' => 'some title')
+              end
+
+              it 'replaces https with http' do
+                subject.build_metadata
+
+                expect(subject.parsed_metadata['license']).to eq([auth_id])
+              end
             end
           end
 
           context 'when the value does not have a forward slash at the end' do
             before do
-              allow(subject).to receive(:raw_metadata).and_return('license' => 'http://creativecommons.org/licenses/by/3.0/us', 'source_identifier' => 'qa_1', 'title' => 'some title')
+              allow(subject).to receive(:raw_metadata).and_return('license' => 'https://creativecommons.org/licenses/by/4.0', 'source_identifier' => 'qa_1', 'title' => 'some title')
             end
 
             it 'adds a trailing forward slash' do
               subject.build_metadata
 
-              expect(subject.parsed_metadata['license']).to eq(['http://creativecommons.org/licenses/by/3.0/us/'])
+              expect(subject.parsed_metadata['license']).to eq(['https://creativecommons.org/licenses/by/4.0/'])
+            end
+          end
+
+          context 'when the value does not match an existing, active authority ID' do
+            before do
+              allow(subject).to receive(:raw_metadata).and_return('license' => 'hello world', 'source_identifier' => 'qa_1', 'title' => 'some title')
+            end
+
+            it 'raises a StandardError' do
+              expect { subject.build_metadata }
+                .to raise_error(StandardError, %("hello world" is not a valid and/or active authority ID for the :license field))
             end
           end
         end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -353,7 +353,7 @@ module Bulkrax
           expect(metadata['single_object']['first_name']).to eq('Fake')
           expect(metadata['single_object']['last_name']).to eq('Fakerson')
           expect(metadata['single_object']['position']).to include('Leader', 'Jester', 'Queen')
-          expect(metadata['single_object']['language']).to eq(['English'])
+          expect(metadata['single_object']['language']).to eq('English')
         end
       end
 

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -68,8 +68,8 @@ module Bulkrax
           allow(subject).to receive(:raw_metadata).and_return('source_identifier' => 'qa_1', 'title' => 'some title')
         end
 
-        it 'calls #sanitize_qa_uri_values' do
-          expect(subject).to receive(:sanitize_qa_uri_values).once
+        it 'calls #sanitize_qa_uri_values!' do
+          expect(subject).to receive(:sanitize_qa_uri_values!).once
 
           subject.build_metadata
         end

--- a/spec/test_app/app/models/work.rb
+++ b/spec/test_app/app/models/work.rb
@@ -5,4 +5,8 @@ class Work < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   property :single_object, predicate: ::RDF::Vocab::DC.creator, multiple: false
   property :multiple_objects, predicate: ::RDF::Vocab::DC.creator
+
+  # This must be included at the end, because it finalizes the metadata
+  # schema (by adding accepts_nested_attributes)
+  include ::Hyrax::BasicMetadata
 end

--- a/spec/test_app/app/models/work.rb
+++ b/spec/test_app/app/models/work.rb
@@ -6,7 +6,6 @@ class Work < ActiveFedora::Base
   property :single_object, predicate: ::RDF::Vocab::DC.creator, multiple: false
   property :multiple_objects, predicate: ::RDF::Vocab::DC.creator
 
-  # This must be included at the end, because it finalizes the metadata
-  # schema (by adding accepts_nested_attributes)
-  include ::Hyrax::BasicMetadata
+  property :license, predicate: ::RDF::Vocab::DC.rights
+  property :rights_statement, predicate: ::RDF::Vocab::EDM.rights
 end

--- a/spec/test_app/config/authorities/rights_statements.yml
+++ b/spec/test_app/config/authorities/rights_statements.yml
@@ -35,3 +35,6 @@ terms:
 - id: http://rightsstatements.org/vocab/NKC/1.0/
   term: "No Known Copyright"
   active: true
+- id: https://rightsstatements.org/vocab/fake/1.0/
+  term: "Fake Term for Testing"
+  active: true


### PR DESCRIPTION
# Summary

For default Hyrax local Questioning Authority controlled fields (`:rights_statement` and `:license`): 

- Use appropriate protocol (`https` or `http`) depending on IDs in `config/authorities/` YAML files 
- Add missing trailing slashes
- Remove duplicate `:removed_image_path` from `Bulkrax` config 