### PR TITLE
Fix Collection-to-Work relationship assigning

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -108,7 +108,7 @@ module Bulkrax
       attrs = {
         work_members_attributes: records_hash
       }
-      parent_record.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX if parent_record.respond_to?(:reindex_extent)
+      parent_record.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
       env = Hyrax::Actors::Environment.new(parent_record, Ability.new(user), attrs)
       Hyrax::CurationConcern.actor.update(env)
       # TODO: add counters for :processed_parents and :failed_parents

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -84,18 +84,16 @@ module Bulkrax
     def collection_parent_work_child
       child_work_ids = child_records[:works].map(&:id)
       parent_record.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
-      parent_record.add_member_objects(child_work_ids)
 
-      # TODO: add counters for :processed_parents and :failed_parents
-      # FIXME: :processed_relationships should be incremented by the number of child_work_ids
-      ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
+      parent_record.add_member_objects(child_work_ids)
+      ImporterRun.find(importer_run_id).increment!(:processed_relationships, child_work_ids.count) # rubocop:disable Rails/SkipsModelValidations
     end
 
     # Collection-Collection membership is added to the as member_ids
     def collection_parent_collection_child
       child_records[:collections].each do |child_record|
         ::Hyrax::Collections::NestedCollectionPersistenceService.persist_nested_collection_for(parent: parent_record, child: child_record)
-        Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
+        ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
       end
     end
 
@@ -105,14 +103,12 @@ module Bulkrax
       child_records[:works].each_with_index do |child_record, i|
         records_hash[i] = { id: child_record.id }
       end
-      attrs = {
-        work_members_attributes: records_hash
-      }
+      attrs = { work_members_attributes: records_hash }
       parent_record.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
       env = Hyrax::Actors::Environment.new(parent_record, Ability.new(user), attrs)
+
       Hyrax::CurationConcern.actor.update(env)
-      # TODO: add counters for :processed_parents and :failed_parents
-      Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships) # rubocop:disable Rails/SkipsModelValidations
+      ImporterRun.find(importer_run_id).increment!(:processed_relationships, child_records[:works].count) # rubocop:disable Rails/SkipsModelValidations
     end
 
     def reschedule(parent_identifier:, importer_run_id:)

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -142,7 +142,7 @@ module Bulkrax
 
     def import_objects(types_array = nil)
       self.only_updates ||= false
-      types = types_array || %w[work collection file_set relationship]
+      types = types_array || %w[collection work file_set relationship]
       if parser.class == Bulkrax::CsvParser
         parser.create_objects(types)
       else

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -21,6 +21,8 @@ module Bulkrax
         status_info(e)
       else
         status_info
+      ensure
+        self.save!
       end
       return @item
     end

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -30,80 +30,76 @@ module Bulkrax
 
     describe '#perform' do
       context 'when adding a child work to a parent collection' do
-        let(:collection_work_attrs) do
-          {
-            parent: parent_record,
-            child: child_record
-          }
+        before do
+          allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
         end
 
         context 'with a Bulkrax::Entry source_identifier' do
           it 'calls #collection_parent_work_child' do
             expect(create_relationships_job).to receive(:collection_parent_work_child)
-            allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
+
             create_relationships_job.perform(
               parent_identifier: parent_entry.identifier, # source_identifier
               importer_run_id: importer.current_run.id
             )
           end
 
-          it 'runs NestedCollectionPersistenceService' do
-            expect(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs)
-            allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
+          it 'calls #add_member_objects on the parent record' do
+            expect(parent_record).to receive(:add_member_objects).with([child_record.id])
+
             create_relationships_job.perform(
               parent_identifier: parent_entry.identifier,
               importer_run_id: importer.current_run.id
             )
           end
 
-          context 'importer run' do
-            it 'increments processed relationships' do
-              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
-              allow(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs).and_return(true)
-              create_relationships_job.perform(
-                parent_identifier: parent_entry.identifier,
-                importer_run_id: importer.current_run.id
-              )
-              expect(importer.current_run.reload.processed_relationships).to eq(1)
-            end
+          it 'increments the processed relationships counter on the importer run' do
+            allow(parent_record).to receive(:add_member_objects)
+            create_relationships_job.perform(
+              parent_identifier: parent_entry.identifier,
+              importer_run_id: importer.current_run.id
+            )
+
+            expect(importer.reload.last_run.processed_relationships).to eq(1)
           end
         end
 
         context 'with an ID' do
+          let(:pending_rel) { build(:pending_relationship_collection_parent, parent_id: parent_record.id) }
+
           before do
-            allow(Entry).to receive(:find_by).with(identifier: parent_record.id).and_return(nil)
-            allow(::Collection).to receive(:where).with(id: parent_record.id).and_return([parent_record])
-            allow(::Work).to receive(:where).with(id: child_record.id).and_return([child_record])
-            allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
+            importer.current_run
+            allow(create_relationships_job)
+              .to receive(:find_record)
+              .and_return([nil, parent_record], [child_entry, child_record])
           end
 
           it 'calls #collection_parent_work_child' do
             expect(create_relationships_job).to receive(:collection_parent_work_child)
 
             create_relationships_job.perform(
-              parent_identifier: parent_entry.identifier,
+              parent_identifier: parent_record.id,
               importer_run_id: importer.current_run.id
             )
           end
 
-          it 'runs NestedCollectionPersistenceService' do
-            expect(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs)
+          it 'calls #add_member_objects on the parent record' do
+            expect(parent_record).to receive(:add_member_objects).with([child_record.id])
+
             create_relationships_job.perform(
-              parent_identifier: parent_entry.identifier,
+              parent_identifier: parent_record.id,
               importer_run_id: importer.current_run.id
             )
           end
 
-          context 'importer run' do
-            it 'increments processed relationships' do
-              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel])
-              allow(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_work_attrs).and_return(true)
-              create_relationships_job.perform(
-                parent_identifier: parent_entry.identifier,
-                importer_run_id: importer.current_run.id
-              )
-              expect(importer.current_run.reload.processed_relationships).to eq(1)
-            end
+          it 'increments the processed relationships counter on the importer run' do
+            allow(parent_record).to receive(:add_member_objects)
+            create_relationships_job.perform(
+              parent_identifier: parent_record.id,
+              importer_run_id: importer.current_run.id
+            )
+
+            expect(importer.reload.last_run.processed_relationships).to eq(1)
           end
         end
       end
@@ -156,18 +152,21 @@ module Bulkrax
         end
 
         context 'with an ID' do
+          let(:pending_rel_col) { build(:pending_relationship_collection_child, parent_id: parent_record.id) }
+
           before do
-            allow(Entry).to receive(:find_by).with(identifier: parent_record.id).and_return(nil)
-            allow(::Collection).to receive(:where).with(id: parent_record.id).and_return([parent_record])
-            allow(::Work).to receive(:where).with(id: child_record.id).and_return([child_record])
+            importer.current_run
             allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_col])
+            allow(create_relationships_job)
+              .to receive(:find_record)
+              .and_return([nil, parent_record], [child_entry, child_record])
           end
 
           it 'calls #collection_parent_collection_child' do
             expect(create_relationships_job).to receive(:collection_parent_collection_child)
 
             create_relationships_job.perform(
-              parent_identifier: parent_entry.identifier,
+              parent_identifier: parent_record.id,
               importer_run_id: importer.current_run.id
             )
           end
@@ -176,7 +175,7 @@ module Bulkrax
             expect(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_collection_attrs)
 
             create_relationships_job.perform(
-              parent_identifier: parent_entry.identifier,
+              parent_identifier: parent_record.id,
               importer_run_id: importer.current_run.id
             )
           end
@@ -186,7 +185,7 @@ module Bulkrax
               allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_col])
               allow(::Hyrax::Collections::NestedCollectionPersistenceService).to receive(:persist_nested_collection_for).with(collection_collection_attrs).and_return(true)
               create_relationships_job.perform(
-                parent_identifier: parent_entry.identifier,
+                parent_identifier: parent_record.id,
                 importer_run_id: importer.current_run.id
               )
               expect(importer.current_run.reload.processed_relationships).to eq(1)
@@ -238,10 +237,14 @@ module Bulkrax
         end
 
         context 'with an ID' do
+          let(:pending_rel_work) { build(:pending_relationship_collection_child, parent_id: parent_record.id) }
+
           before do
-            allow(Entry).to receive(:find_by).with(identifier: parent_record.id).and_return(nil)
-            allow(::Collection).to receive(:where).with(id: parent_record.id).and_return([parent_record])
-            allow(::Work).to receive(:where).with(id: child_record.id).and_return([child_record])
+            importer.current_run
+            allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
+            allow(create_relationships_job)
+              .to receive(:find_record)
+              .and_return([nil, parent_record], [child_entry, child_record])
           end
 
           it 'calls #work_parent_work_child' do
@@ -249,7 +252,7 @@ module Bulkrax
             allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
 
             create_relationships_job.perform(
-                parent_identifier: parent_entry.identifier,
+                parent_identifier: parent_record.id,
                 importer_run_id: importer.current_run.id
               )
           end
@@ -259,7 +262,7 @@ module Bulkrax
             allow(Ability).to receive(:new).with(importer.user)
             expect(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env))
             create_relationships_job.perform(
-                parent_identifier: parent_entry.identifier,
+                parent_identifier: parent_record.id,
                 importer_run_id: importer.current_run.id
               )
           end
@@ -270,7 +273,7 @@ module Bulkrax
               allow(Ability).to receive(:new).with(importer.user)
               allow(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env)).and_return(true)
               create_relationships_job.perform(
-                parent_identifier: parent_entry.identifier,
+                parent_identifier: parent_record.id,
                 importer_run_id: importer.current_run.id
               )
               expect(importer.current_run.reload.processed_relationships).to equal(1)


### PR DESCRIPTION
# Summary 

`Hyrax::Collections::NestedCollectionPersistenceService#persist_nested_collection_for` is only meant to be used for Collection-to-Collection relationships. Because of this, Collection-to-Work relationships were broken. 

Instead, use [Collection#add_member_objects](https://github.com/samvera/hyrax/blob/v2.9.6/app/controllers/hyrax/dashboard/collection_members_controller.rb#L29), which is used in the `Hyrax::Dashboard::CollectionMembersController` 