### PR TITLE
Erroneous pending status on import

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -52,12 +52,13 @@ module Bulkrax
         )
         return false # stop current job from continuing to run after rescheduling
       end
-
+      importer_id = ImporterRun.find(importer_run_id).importer_id
       @parent_entry ||= Bulkrax::Entry.where(identifier: parent_identifier,
-                                             importerexporter_id: ImporterRun.find(importer_run_id).importer_id,
+                                             importerexporter_id: importer_id,
                                              importerexporter_type: "Bulkrax::Importer").first
       create_relationships
       pending_relationships.each(&:destroy)
+      Bulkrax::Importer.find(importer_id).record_status
     rescue ::StandardError => e
       parent_entry ? parent_entry.status_info(e) : child_entry.status_info(e)
       Bulkrax::ImporterRun.find(importer_run_id).increment!(:failed_relationships) # rubocop:disable Rails/SkipsModelValidations

--- a/app/jobs/bulkrax/import_collection_job.rb
+++ b/app/jobs/bulkrax/import_collection_job.rb
@@ -9,16 +9,18 @@ module Bulkrax
       entry = Entry.find(args[0])
       begin
         entry.build
-        entry.save
+        entry.save!
         ImporterRun.find(args[1]).increment!(:processed_records)
         ImporterRun.find(args[1]).increment!(:processed_collections)
-        ImporterRun.find(args[1]).decrement!(:enqueued_records)
+        ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
       rescue => e
         ImporterRun.find(args[1]).increment!(:failed_records)
         ImporterRun.find(args[1]).increment!(:failed_collections)
-        ImporterRun.find(args[1]).decrement!(:enqueued_records)
+        ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
         raise e
       end
+      entry.importer.current_run = ImporterRun.find(args[1])
+      entry.importer.record_status
     end
     # rubocop:enable Rails/SkipsModelValidations
   end

--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -26,8 +26,10 @@ module Bulkrax
         ImporterRun.find(importer_run_id).increment!(:failed_file_sets)
         # rubocop:enable Rails/SkipsModelValidations
       end
-      ImporterRun.find(importer_run_id).decrement!(:enqueued_records) # rubocop:disable Rails/SkipsModelValidations
+      ImporterRun.find(importer_run_id).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Rails/SkipsModelValidations
       entry.save!
+      entry.importer.current_run = ImporterRun.find(args[1])
+      entry.importer.record_status
 
     rescue MissingParentError => e
       # try waiting for the parent record to be created

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -38,7 +38,7 @@
             <% @importers.each do |importer| %>
               <tr>
                 <th scope="row"><%= link_to importer.name, importer_path(importer) %></th>
-                <td><%= importer.status %></td>
+                <td><%= importer.last_run&.enqueued_records&.zero? ? 'Complete' : importer.status %></td>
                 <td><%= importer.last_imported_at.strftime("%b %d, %Y") if importer.last_imported_at %></td>
                 <td><%= importer.next_import_at.strftime("%b %d, %Y") if importer.next_import_at %></td>
                 <td><%= importer.last_run&.enqueued_records %></td>


### PR DESCRIPTION
`#record_status` which updates the status wasn't being called when a collection finishes however it was called when a work was completed.

This seemingly meant that if the works finish faster than the collections the status gets stuck on "Pending".