### PR TITLE
Use #key_for_export instead of always exporting model as "model"

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -97,7 +97,7 @@ module Bulkrax
       self.parsed_metadata = {}
       self.parsed_metadata['id'] = hyrax_record.id
       self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
-      self.parsed_metadata['model'] = hyrax_record.has_model.first
+      self.parsed_metadata[key_for_export('model')] = hyrax_record.has_model.first
       build_files_metadata unless hyrax_record.is_a?(Collection)
       build_relationship_metadata
       build_mapping_metadata
@@ -106,7 +106,7 @@ module Bulkrax
     end
 
     def build_files_metadata
-      file_mapping = mapping['file']&.[]('from')&.first || 'file'
+      file_mapping = key_for_export('file')
       file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
 
       filenames = file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -93,7 +93,6 @@ module Bulkrax
     end
 
     def build_export_metadata
-      # make_round_trippable
       self.parsed_metadata = {}
       self.parsed_metadata['id'] = hyrax_record.id
       self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
@@ -223,16 +222,6 @@ module Bulkrax
         end
         parsed_metadata.delete(key)
       end
-    end
-
-    # In order for the existing exported hyrax_record, to be updated by a re-import
-    # we need a unique value in system_identifier
-    # add the existing hyrax_record id to system_identifier
-    def make_round_trippable
-      values = hyrax_record.send(work_identifier.to_s).to_a
-      values << hyrax_record.id
-      hyrax_record.send("#{work_identifier}=", values)
-      hyrax_record.save
     end
 
     def record

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -94,14 +94,19 @@ module Bulkrax
 
     def build_export_metadata
       self.parsed_metadata = {}
-      self.parsed_metadata['id'] = hyrax_record.id
-      self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
-      self.parsed_metadata[key_for_export('model')] = hyrax_record.has_model.first
+      build_system_metadata
       build_files_metadata unless hyrax_record.is_a?(Collection)
       build_relationship_metadata
       build_mapping_metadata
 
       self.parsed_metadata
+    end
+
+    # Metadata required by Bulkrax for round-tripping
+    def build_system_metadata
+      self.parsed_metadata['id'] = hyrax_record.id
+      self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
+      self.parsed_metadata[key_for_export('model')] = hyrax_record.has_model.first
     end
 
     def build_files_metadata
@@ -136,7 +141,7 @@ module Bulkrax
     def build_mapping_metadata
       mapping.each do |key, value|
         next if Bulkrax.reserved_properties.include?(key) && !field_supported?(key)
-        next if key == "model"
+        next if key == 'model' # handled by #build_system_metadata
         # relationships handled by #build_relationship_metadata
         next if [related_parents_parsed_mapping, related_children_parsed_mapping].include?(key)
         next if key == 'file' # handled by #build_files_metadata

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -98,14 +98,14 @@ module Bulkrax
       self.parsed_metadata['id'] = hyrax_record.id
       self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
       self.parsed_metadata['model'] = hyrax_record.has_model.first
-      build_files unless hyrax_record.is_a?(Collection)
+      build_files_metadata unless hyrax_record.is_a?(Collection)
       build_relationship_metadata
       build_mapping_metadata
 
       self.parsed_metadata
     end
 
-    def build_files
+    def build_files_metadata
       file_mapping = mapping['file']&.[]('from')&.first || 'file'
       file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
 
@@ -140,7 +140,7 @@ module Bulkrax
         next if key == "model"
         # relationships handled by #build_relationship_metadata
         next if [related_parents_parsed_mapping, related_children_parsed_mapping].include?(key)
-        next if key == 'file' # handled by #build_files
+        next if key == 'file' # handled by #build_files_metadata
         next if value['excluded']
 
         object_key = key if value.key?('object')

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -94,6 +94,7 @@ module Bulkrax
 
     def build_export_metadata
       self.parsed_metadata = {}
+
       build_system_metadata
       build_files_metadata unless hyrax_record.is_a?(Collection)
       build_relationship_metadata
@@ -112,8 +113,8 @@ module Bulkrax
     def build_files_metadata
       file_mapping = key_for_export('file')
       file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
-
       filenames = file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
+
       handle_join_on_export(file_mapping, filenames, mapping['file']&.[]('join')&.present?)
     end
 
@@ -140,12 +141,10 @@ module Bulkrax
 
     def build_mapping_metadata
       mapping.each do |key, value|
-        next if Bulkrax.reserved_properties.include?(key) && !field_supported?(key)
-        next if key == 'model' # handled by #build_system_metadata
-        # relationships handled by #build_relationship_metadata
-        next if [related_parents_parsed_mapping, related_children_parsed_mapping].include?(key)
-        next if key == 'file' # handled by #build_files_metadata
+        # these keys are handled by other methods
+        next if ['model', 'file', related_parents_parsed_mapping, related_children_parsed_mapping].include?(key)
         next if value['excluded']
+        next if Bulkrax.reserved_properties.include?(key) && !field_supported?(key)
 
         object_key = key if value.key?('object')
         next unless hyrax_record.respond_to?(key.to_s) || object_key.present?

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -888,7 +888,7 @@ module Bulkrax
       end
     end
 
-    describe '#build_files' do
+    describe '#build_files_metadata' do
       subject(:entry) { described_class.new(importerexporter: exporter) }
       let(:exporter) { create(:bulkrax_exporter, :with_relationships_mappings) }
 
@@ -914,7 +914,7 @@ module Bulkrax
         end
 
         it 'does not get called by #build_export_metadata' do
-          expect(entry).not_to receive(:build_files)
+          expect(entry).not_to receive(:build_files_metadata)
           entry.build_export_metadata
         end
       end
@@ -935,7 +935,7 @@ module Bulkrax
         end
 
         it 'gets called by #build_export_metadata' do
-          expect(entry).to receive(:build_files).once
+          expect(entry).to receive(:build_files_metadata).once
           entry.build_export_metadata
         end
 
@@ -944,7 +944,7 @@ module Bulkrax
             let(:exporter) { create(:bulkrax_exporter, field_mapping: { 'file' => { from: ['filename'], join: true } }) }
 
             it "adds the file set's filename to the file mapping in parsed_metadata" do
-              entry.build_files
+              entry.build_files_metadata
 
               expect(entry.parsed_metadata['filename']).to eq('hello.png')
             end
@@ -953,7 +953,7 @@ module Bulkrax
 
         context 'when the parser does not have a file field mapping' do
           it "adds the file set's filename to the 'file' key in parsed_metadata" do
-            entry.build_files
+            entry.build_files_metadata
 
             expect(entry.parsed_metadata['file_1']).to eq('hello.png')
           end
@@ -995,7 +995,7 @@ module Bulkrax
         end
 
         it 'gets called by #build_export_metadata' do
-          expect(entry).to receive(:build_files).once
+          expect(entry).to receive(:build_files_metadata).once
           entry.build_export_metadata
         end
 
@@ -1004,7 +1004,7 @@ module Bulkrax
             let(:exporter) { create(:bulkrax_exporter, field_mapping: { 'file' => { from: ['filename'], join: true } }) }
 
             it "adds the work's file set's filenames to the file mapping in parsed_metadata" do
-              entry.build_files
+              entry.build_files_metadata
 
               expect(entry.parsed_metadata['filename']).to eq('hello.png | world.jpg')
             end
@@ -1013,7 +1013,7 @@ module Bulkrax
 
         context 'when the parser does not have a file field mapping' do
           it "adds the work's file set's filenames to the 'file' key in parsed_metadata" do
-            entry.build_files
+            entry.build_files_metadata
 
             expect(entry.parsed_metadata['file_1']).to eq('hello.png')
             expect(entry.parsed_metadata['file_2']).to eq('world.jpg')


### PR DESCRIPTION
# Summary 

Changes: 

- Use `#key_for_export` instead of always exporting model as `"model"` 
- Export files metadata closer to beginning of CSV instead of at the very end 
- Remove unused `#make_round_trippable` method 
- Move required export metadata into new `#build_system_metadata` method 
- Minor reorganization of `CsvEntry` class 