### PR TITLE
better entry lookup

### DIFF
--- a/app/models/concerns/bulkrax/dynamic_record_lookup.rb
+++ b/app/models/concerns/bulkrax/dynamic_record_lookup.rb
@@ -12,7 +12,7 @@ module Bulkrax
       # check for our entry in our current importer first
       importer_id = ImporterRun.find(importer_run_id).importer_id
       default_scope = { identifier: identifier, importerexporter_type: 'Bulkrax::Importer' }
-      record = Entry.find_by(default_scope, importerexporter_id: importer_id) || Entry.find_by(default_scope)
+      record = Entry.find_by(default_scope.merge({ importerexporter_id: importer_id })) || Entry.find_by(default_scope)
 
       # TODO(alishaevn): discuss whether we are only looking for Collection models here
       # use ActiveFedora::Base.find(identifier) instead?

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -18,8 +18,8 @@ module Bulkrax
 
     before do
       allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])
-      allow(Entry).to receive(:find_by).with({ identifier: child_entry.identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer.id }).and_return(child_entry)
-      allow(Entry).to receive(:find_by).with({ identifier: parent_entry.identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer.id }).and_return(parent_entry)
+      allow(Entry).to receive(:find_by).with({ identifier: child_entry.identifier, importerexporter_type: 'Bulkrax::Importer', importerexporter_id: importer.id }).and_return(child_entry)
+      allow(Entry).to receive(:find_by).with({ identifier: parent_entry.identifier, importerexporter_type: 'Bulkrax::Importer', importerexporter_id: importer.id }).and_return(parent_entry)
       allow(parent_entry).to receive(:factory).and_return(parent_factory)
       allow(child_entry).to receive(:factory).and_return(child_factory)
     end

--- a/spec/models/concerns/bulkrax/dynamic_record_lookup_spec.rb
+++ b/spec/models/concerns/bulkrax/dynamic_record_lookup_spec.rb
@@ -21,7 +21,7 @@ module Bulkrax
         let(:source_identifier) { 'bulkrax_identifier_1' }
 
         it 'looks through entries, collections, and all work types' do
-          expect(Entry).to receive(:find_by).with({ identifier: source_identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer_id }).once
+          expect(Entry).to receive(:find_by).with({ identifier: source_identifier, importerexporter_type: 'Bulkrax::Importer', importerexporter_id: importer_id }).once
           expect(::Collection).to receive(:where).with(id: source_identifier).once.and_return([])
           expect(::Work).to receive(:where).with(id: source_identifier).once.and_return([])
 
@@ -34,7 +34,7 @@ module Bulkrax
           let(:record) { instance_double(::Work, title: ["Found through Entry's factory"]) }
 
           before do
-            allow(Entry).to receive(:find_by).with({ identifier: source_identifier, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer_id }).and_return(entry)
+            allow(Entry).to receive(:find_by).with({ identifier: source_identifier, importerexporter_type: 'Bulkrax::Importer', importerexporter_id: importer_id }).and_return(entry)
             allow(entry).to receive(:factory).and_return(factory)
           end
 
@@ -64,7 +64,7 @@ module Bulkrax
         let(:id) { 'xyz6789' }
 
         it 'looks through entries, collections, and all work types' do
-          expect(Entry).to receive(:find_by).with({ identifier: id, importerexporter_type: 'Bulkrax::Importer' }, { importerexporter_id: importer_id }).once
+          expect(Entry).to receive(:find_by).with({ identifier: id, importerexporter_type: 'Bulkrax::Importer', importerexporter_id: importer_id }).once
           expect(::Collection).to receive(:where).with(id: id).once.and_return([])
           expect(::Work).to receive(:where).with(id: id).once.and_return([])
 


### PR DESCRIPTION
# summary
the `importer_id` wasn't actually being used in entry lookup. in my case, there were 2 entries with the same `parent_identifier`, but from 2 different importers. the first entry was exited from before completion so the `parsed_metadata`was nil. this meant that in "dynamic_record_lookup", the first invalid entry was being returned and when `entry.factory.find` was called...it came back nil. 

# demo
the before and after is demonstrated below. (look at the 4 red boxes)
![Screen Shot 2022-05-23 at 5 13 02 PM](https://user-images.githubusercontent.com/29032869/169914245-c90d613a-2060-4a01-a420-6c7a860a543f.png)