### PR TITLE
erroneous pending status on import

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -55,7 +55,6 @@ module Bulkrax
                                              importerexporter_type: "Bulkrax::Importer").first
       create_relationships
       pending_relationships.each(&:destroy)
-      Bulkrax::Importer.find(importer_id).record_status
     rescue ::StandardError => e
       parent_entry ? parent_entry.status_info(e) : child_entry.status_info(e)
       Bulkrax::ImporterRun.find(importer_run_id).increment!(:failed_relationships) # rubocop:disable Rails/SkipsModelValidations

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -49,9 +49,8 @@ module Bulkrax
         reschedule({ parent_identifier: parent_identifier, importer_run_id: importer_run_id })
         return false # stop current job from continuing to run after rescheduling
       end
-      importer_id = ImporterRun.find(importer_run_id).importer_id
       @parent_entry ||= Bulkrax::Entry.where(identifier: parent_identifier,
-                                             importerexporter_id: importer_id,
+                                             importerexporter_id: ImporterRun.find(importer_run_id).importer_id,
                                              importerexporter_type: "Bulkrax::Importer").first
       create_relationships
       pending_relationships.each(&:destroy)


### PR DESCRIPTION
Fixed a previous change that resulted in an interesting unintended behavior.

`Bulkrax::Importer.find(importer_id).record_status` was removing all `Entries Processed` and adding `Pending` status to all entries even after they are processed.  It seems that since `#record_status` is being called after `ImportWorkJob`, `ImportCollectionJob`, and `ImportFileSetJob`, it is not needed after `CreateRelationshipJob` as the statuses should already set before this job runs.

Before:
<img width="1455" alt="Screen Shot 2022-05-23 at 5 34 39 PM" src="https://user-images.githubusercontent.com/19597776/169926118-84ef0ab4-5c15-4486-867f-9ed29b0f1e51.png">

<img width="1325" alt="Screen Shot 2022-05-23 at 5 35 23 PM" src="https://user-images.githubusercontent.com/19597776/169926171-8cea2bda-a21e-4a54-8389-5f2ec92f3328.png">

After:
<img width="1452" alt="Screen Shot 2022-05-23 at 5 36 08 PM" src="https://user-images.githubusercontent.com/19597776/169926201-3e2d346e-6123-40cd-8d61-111f516566fd.png">

<img width="1334" alt="Screen Shot 2022-05-23 at 5 37 10 PM" src="https://user-images.githubusercontent.com/19597776/169926215-4b196f81-7328-43e9-8bea-eae8c17e400f.png">


