### PR TITLE
Do not spawn relationship jobs for FileSets

### DIFF
--- a/app/models/concerns/bulkrax/file_set_entry_behavior.rb
+++ b/app/models/concerns/bulkrax/file_set_entry_behavior.rb
@@ -28,5 +28,13 @@ module Bulkrax
 
       raise StandardError, 'File set must be related to at least one work'
     end
+
+    def parent_jobs
+      false # FileSet relationships are handled in ObjectFactory#create_file_set
+    end
+
+    def child_jobs
+      raise ::StandardError, 'A FileSet cannot be a parent of a Collection, Work, or other FileSet'
+    end
   end
 end


### PR DESCRIPTION
Don't spawn relationship jobs for FileSets; their parent work is set up in `ObjectFactory#create_file_set` 