### PR TITLE
Issue-544 - verify depositor presence on imported works

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -61,6 +61,7 @@ module Bulkrax
           work_actor.update(environment(attrs))
         end
       end
+      object.apply_depositor_metadata(@user) && object.save! if object.depositor.nil?
       log_updated(object)
     end
 
@@ -107,6 +108,7 @@ module Bulkrax
           end
         end
       end
+      object.apply_depositor_metadata(@user) && object.save! if object.depositor.nil?
       log_created(object)
     end
 
@@ -141,7 +143,6 @@ module Bulkrax
       attrs = clean_attrs(attrs)
       attrs = collection_type(attrs)
       object.attributes = attrs
-      object.apply_depositor_metadata(@user)
       object.save!
     end
 


### PR DESCRIPTION
# Summary

ref: [i544](https://github.com/samvera-labs/bulkrax/issues/544)
There have been reported incidences imports and round trips resulted in nil valued depositors. 

This is because #apply_depositor_metadata used to only be called for certain object types. Additionally, it was never called during the update method (aka round trip). The object would get updated to whatever attrs were passed to it. If there is a nil depositor in the data, it would get reset to nil even if the object previously had a depositor. 

I am also noticing that depositor gets exported as nil for Collection and FileSet even when their objects have a value. Looking into that.

row 1 = Work 
row 2 = Collection
row 3 = FileSet
<img width="372" alt="Screen Shot 2022-06-08 at 3 03 40 PM" src="https://user-images.githubusercontent.com/10081604/172725756-8e927598-f78d-4e7c-a147-1d5099164df4.png">

Debugging exporter. Find the collection. Does it have a depositor? => YES
<img width="689" alt="Screen Shot 2022-06-08 at 2 58 50 PM" src="https://user-images.githubusercontent.com/10081604/172724680-e0cb1bc1-c5f5-478c-b8e7-18ba1ed8e6d6.png">
How come it doesn't get exported with a value then? Check the parsed metadata:
<img width="653" alt="Screen Shot 2022-06-08 at 2 58 02 PM" src="https://user-images.githubusercontent.com/10081604/172724606-0e4283eb-3a9e-48ee-abe5-fb67002d6d72.png">

**UPDATE**: The above concerns about not exporting all of the collection data may be an issue specific to the client. I am seeing errors about "current_he_institution"  being undefined for a Collection. It quits before all of the parsed_metadata fields are assigned. 




sample files: 

[book_with_fileset_row_in_collection.zip](https://github.com/samvera-labs/bulkrax/files/8865298/book_with_fileset_row_in_collection.zip)
[article_with_one_local_file-1.zip](https://github.com/samvera-labs/bulkrax/files/8865300/article_with_one_local_file-1.zip)


