### PR TITLE
Pending relationships do not cause errors when destroying Importers

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -33,7 +33,7 @@ module Bulkrax
     # is the child in the relationship, and vice versa if a child_identifier is passed.
     def perform(parent_identifier:, importer_run_id:) # rubocop:disable Metrics/AbcSize
       pending_relationships = Bulkrax::PendingRelationship.find_each.select do |rel|
-        rel.bulkrax_importer_run_id == importer_run_id && rel.parent_id == parent_identifier
+        rel.importer_run_id == importer_run_id && rel.parent_id == parent_identifier
       end.sort_by(&:order)
 
       @importer_run_id = importer_run_id

--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -7,7 +7,7 @@ module Bulkrax
     has_many :pending_relationships, dependent: :destroy
 
     def parents
-      PendingRelationship.where(bulkrax_importer_run_id: id).pluck(:parent_id).uniq
+      pending_relationships.pluck(:parent_id).uniq
     end
   end
 end

--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -4,6 +4,7 @@ module Bulkrax
   class ImporterRun < ApplicationRecord
     belongs_to :importer
     has_many :statuses, as: :runnable, dependent: :destroy
+    has_many :pending_relationships, dependent: :destroy
 
     def parents
       PendingRelationship.where(bulkrax_importer_run_id: id).pluck(:parent_id).uniq

--- a/app/models/bulkrax/pending_relationship.rb
+++ b/app/models/bulkrax/pending_relationship.rb
@@ -2,6 +2,6 @@
 
 module Bulkrax
   class PendingRelationship < ApplicationRecord
-    belongs_to :bulkrax_importer_run, class_name: "::Bulkrax::ImporterRun"
+    belongs_to :importer_run
   end
 end

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -50,7 +50,7 @@ module Bulkrax
       self.parsed_metadata[related_parents_parsed_mapping].each do |parent_identifier|
         next if parent_identifier.blank?
 
-        PendingRelationship.create!(child_id: self.identifier, parent_id: parent_identifier, bulkrax_importer_run_id: importerexporter.last_run.id, order: self.id)
+        PendingRelationship.create!(child_id: self.identifier, parent_id: parent_identifier, importer_run_id: importerexporter.last_run.id, order: self.id)
       end
     end
 
@@ -58,7 +58,7 @@ module Bulkrax
       self.parsed_metadata[related_children_parsed_mapping].each do |child_identifier|
         next if child_identifier.blank?
 
-        PendingRelationship.create!(parent_id: self.identifier, child_id: child_identifier, bulkrax_importer_run_id: importerexporter.last_run.id, order: self.id)
+        PendingRelationship.create!(parent_id: self.identifier, child_id: child_identifier, importer_run_id: importerexporter.last_run.id, order: self.id)
       end
     end
 

--- a/db/migrate/20220609001128_rename_bulkrax_importer_run_to_importer_run.rb
+++ b/db/migrate/20220609001128_rename_bulkrax_importer_run_to_importer_run.rb
@@ -1,0 +1,7 @@
+class RenameBulkraxImporterRunToImporterRun < ActiveRecord::Migration[5.2]
+  def change
+    if column_exists?(:bulkrax_pending_relationships, :bulkrax_importer_run_id)
+      rename_column :bulkrax_pending_relationships, :bulkrax_importer_run_id, :importer_run_id
+    end
+  end
+end

--- a/spec/factories/bulkrax/pending_relationships.rb
+++ b/spec/factories/bulkrax/pending_relationships.rb
@@ -2,25 +2,25 @@
 
 FactoryBot.define do
   factory :pending_relationship_collection_parent, class: 'Bulkrax::PendingRelationship' do
-    bulkrax_importer_run_id { 1 }
+    importer_run_id { 1 }
     parent_id { 'entry_collection' }
     child_id { 'entry_work' }
   end
 
   factory :pending_relationship_collection_child, class: 'Bulkrax::PendingRelationship' do
-    bulkrax_importer_run_id { 1 }
+    importer_run_id { 1 }
     parent_id { 'parent_entry_collection' }
     child_id { 'child_entry_collection' }
   end
 
   factory :pending_relationship_work_parent, class: 'Bulkrax::PendingRelationship' do
-    bulkrax_importer_run_id { 1 }
+    importer_run_id { 1 }
     parent_id { 'parent_entry_work' }
     child_id { 'child_entry_work' }
   end
 
   factory :bad_pending_relationship, class: 'Bulkrax::PendingRelationship' do
-    bulkrax_importer_run_id { 1 }
+    importer_run_id { 1 }
     parent_id { 'entry_work' }
     child_id { 'entry_collection' }
   end

--- a/spec/models/bulkrax/importer_run_spec.rb
+++ b/spec/models/bulkrax/importer_run_spec.rb
@@ -11,5 +11,17 @@ module Bulkrax
         expect(importer_run.parents).to be_an(Array)
       end
     end
+
+    context 'when being destroyed' do
+      before do
+        importer_run.save
+        create(:pending_relationship_collection_parent, importer_run_id: importer_run.id)
+        create(:pending_relationship_work_parent, importer_run_id: importer_run.id)
+      end
+
+      it 'destroys all of its associated pending relationships' do
+        expect { importer_run.destroy }.to change(PendingRelationship, :count).by(-2)
+      end
+    end
   end
 end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_180915) do
+ActiveRecord::Schema.define(version: 2022_06_09_001128) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -115,13 +115,13 @@ ActiveRecord::Schema.define(version: 2022_04_13_180915) do
   end
 
   create_table "bulkrax_pending_relationships", force: :cascade do |t|
-    t.integer "bulkrax_importer_run_id", null: false
+    t.integer "importer_run_id", null: false
     t.string "parent_id", null: false
     t.string "child_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order", default: 0
-    t.index ["bulkrax_importer_run_id"], name: "index_bulkrax_pending_relationships_on_bulkrax_importer_run_id"
+    t.index ["importer_run_id"], name: "index_bulkrax_pending_relationships_on_importer_run_id"
   end
 
   create_table "bulkrax_statuses", force: :cascade do |t|


### PR DESCRIPTION
# Summary 

Let Rails handle database table prefixes with its magic.

An Importer's `PendingRelationship`s (through `ImporterRun`) will no longer cause attempting to destroy the Importer to throw an error. Instead, the Importer's pending relationships will be destroyed alongside it automatically 