### PR TITLE
GitHub PR Label action improvements

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,15 +6,12 @@ changelog:
     - title: Breaking Changes 🛠
       labels:
         - major-ver
-        - breaking-change
     - title: Exciting New Features 🎉
       labels:
         - minor-ver
-        - enhancement
     - title: Bug Fixes 🐞
       labels:
         - patch-ver
-        - bug-fix
     - title: Database Changes
       labels:
         - database-changes

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -17,8 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # https://github.com/marketplace/actions/label-checker-for-pull-requests
       - name: Check PR for Release Notes labels
         uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: patch-ver,minor-ver,major-ver,bug-fix,enhancement,breaking-change,database-changes,ignore-for-release
+          one_of: patch-ver,minor-ver,major-ver,ignore-for-release
+          any_of: bug-fix,enhancement,breaking-change,database-changes
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary 

Make PR label requirements more flexible.

Before, a PR could not have more than one of the required labels. This made it impossible for PRs that had database changes to use the `database-change` label while also describing what impact it will have on the next release (patch, minor, or major version bump). 

With this change, the `bug-fix`, `enhancement`, and `breaking-change` labels will no longer affect the auto-generated release notes, allowing them (and future labels) to be mixed and matched to be used as descriptors. One of the `major-ver`, `minor-ver`,`patch-ver`, or `ignore-for-release` labels is required, making a PRs impact on release notes more explicit. 