### PR TITLE
Do not render empty Error accordian on importers that succeed with failures

### DIFF
--- a/app/models/concerns/bulkrax/status_info.rb
+++ b/app/models/concerns/bulkrax/status_info.rb
@@ -18,7 +18,7 @@ module Bulkrax
     end
 
     def failed?
-      current_status&.status_message&.match(/fail/i)
+      current_status&.status_message&.eql?('Failed')
     end
 
     def succeeded?

--- a/spec/models/concerns/bulkrax/status_info_spec.rb
+++ b/spec/models/concerns/bulkrax/status_info_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Bulkrax
+  RSpec.describe StatusInfo do
+    subject(:status_info) { build(:bulkrax_status) }
+    let(:record) { status_info.statusable }
+
+    describe '#failed?' do
+      before do
+        allow(record).to receive(:current_status).and_return(status_info)
+      end
+
+      context 'when status_message is "Failed"' do
+        before do
+          status_info.status_message = 'Failed'
+        end
+
+        it 'returns true' do
+          expect(record.failed?).to eq(true)
+        end
+      end
+
+      context 'when status_message is "Complete (with failures)"' do
+        before do
+          status_info.status_message = 'Complete (with failures)'
+        end
+
+        it 'returns false' do
+          expect(record.failed?).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary

The `#failed?` method is used to determine whether the Error accordion should render in the UI. Before, it would match on the presence of the string "fail", meaning that `"Complete (with failures)"` would cause it to return true. This would render the Error accordion on the importer show page, even if the importer itself didn't have any errors on it. 

# Screenshots 

<details><summary>Before</summary>

![Show Importer Digital Collections Online 2022-06-10 at 11 41 32 AM](https://user-images.githubusercontent.com/32469930/173130854-a26a0848-128a-4df2-bcfe-8feb6842bc0c.jpg)


</details>

<details><summary>After</summary>

![Show Importer Digital Collections Online 2022-06-10 at 11 44 42 AM](https://user-images.githubusercontent.com/32469930/173130865-6539aaf8-e3cd-45c2-abb3-c363d5b49bb4.jpg)


</details>