### PR TITLE
560 reimplement thumbnail export

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -114,9 +114,10 @@ module Bulkrax
     def build_files_metadata
       file_mapping = key_for_export('file')
       file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
-      filenames = file_sets.map { |fs| filename(fs).to_s if filename(fs).present? }.compact
+      filenames = map_file_sets(file_sets)
 
       handle_join_on_export(file_mapping, filenames, mapping['file']&.[]('join')&.present?)
+      build_thumbnail_files if hyrax_record.work?
     end
 
     def build_relationship_metadata
@@ -217,15 +218,6 @@ module Bulkrax
           end
         end
       end
-    end
-
-    def build_files
-      file_mapping = mapping['file']&.[]('from')&.first || 'file'
-      file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
-
-      filenames = map_file_sets(file_sets)
-      handle_join_on_export(file_mapping, filenames, mapping['file']&.[]('join')&.present?)
-      build_thumbnail_files if hyrax_record.work?
     end
 
     def build_thumbnail_files

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -1002,7 +1002,7 @@ module Bulkrax
 
         it 'calls #build_thumbnail_files' do
           expect(entry).to receive(:build_thumbnail_files).once
-          entry.build_files
+          entry.build_files_metadata
         end
 
         context 'when the parser has a file field mapping' do
@@ -1072,7 +1072,7 @@ module Bulkrax
 
         it 'gets called by #build_files' do
           expect(entry).to receive(:build_thumbnail_files).once
-          entry.build_files
+          entry.build_files_metadata
         end
 
         context 'when exporter does not include thumbnails' do


### PR DESCRIPTION
ref: #560

When selecting include_thumbnails? on a bulkrax exporter, the exported csv should have a "thumbnail_file" column. The zip's files directory should contain the thumbnail file, and its name will be referenced in the csv.

# Screenshot
<img width="1042" alt="Screen Shot 2022-06-10 at 12 23 35 PM" src="https://user-images.githubusercontent.com/10081604/173135947-7f9262ff-6bae-42f4-89ca-fd6cc25deff2.png">

