### PR TITLE
reworked bagit write files to not create empty bags

### DIFF
--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -189,9 +189,9 @@ module Bulkrax
       require 'open-uri'
       require 'socket'
       importerexporter.entries.where(identifier: current_record_ids)[0..limit || total].each do |e|
-        bag = BagIt::Bag.new setup_bagit_folder(e.identifier)
         w = ActiveFedora::Base.find(e.identifier)
         next unless Hyrax.config.curation_concerns.include?(w.class)
+        bag = BagIt::Bag.new setup_bagit_folder(e.identifier)
 
         w.file_sets.each do |fs|
           file_name = filename(fs)


### PR DESCRIPTION
BagIt gem was creating empty/invalid bags so the line to instantiate a bag was moved after the `next unless` so this won't happen.