### PR TITLE
Remove willow_sword as a soft dependency, make rubyzip a full dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/**
 .DS_Store
 tmp/**
 .env.*
+*~undo-tree~

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'oai'
 gem 'rsolr', '>= 1.0'
 gem 'rspec-rails'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
-gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 
 group :development, :test do
   # To use a debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/notch8/willow_sword.git
-  revision: 0a669d78617c6003e4aa1a46a10447be92be27d5
-  specs:
-    willow_sword (0.2.0)
-      bagit (~> 0.4.1)
-      rails (>= 5.1.6)
-      rubyzip (>= 1.0.0)
-
 PATH
   remote: .
   specs:
@@ -22,6 +13,7 @@ PATH
       rack (>= 2.0.6)
       rails (>= 5.1.6)
       rdf (>= 2.0.2, < 4.0)
+      rubyzip
       simple_form
 
 GEM
@@ -925,7 +917,6 @@ DEPENDENCIES
   solr_wrapper (>= 0.3)
   sqlite3 (~> 1.3.13)
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
-  willow_sword!
 
 BUNDLED WITH
    2.3.8

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'zip'
 
 module Bulkrax
   class ApplicationParser # rubocop:disable Metrics/ClassLength
@@ -261,7 +262,6 @@ module Bulkrax
     end
 
     def zip
-      require 'zip'
       FileUtils.rm_rf(exporter_export_zip_path)
       Zip::File.open(exporter_export_zip_path, create: true) do |zip_file|
         Dir["#{exporter_export_path}/**/**"].each do |file|

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -18,18 +18,19 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 5.1.6"
-  s.add_dependency "loofah", ">= 2.2.3" # security issue, remove on rails upgrade
-  s.add_dependency "rack", ">= 2.0.6" # security issue, remove on rails upgrade
-  s.add_dependency "simple_form"
-  s.add_dependency 'iso8601', '~> 0.9.0'
-  s.add_dependency 'oai', '>= 0.4', '< 2.x'
-  s.add_dependency 'libxml-ruby', '~> 3.1.0'
-  s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'
-  s.add_dependency 'rdf', '>= 2.0.2', '< 4.0'
+  s.add_dependency 'rails', '>= 5.1.6'
   s.add_dependency 'bagit', '~> 0.4'
   s.add_dependency 'coderay'
+  s.add_dependency 'iso8601', '~> 0.9.0'
   s.add_dependency 'kaminari'
+  s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'
+  s.add_dependency 'libxml-ruby', '~> 3.1.0'
+  s.add_dependency 'loofah', '>= 2.2.3' # security issue, remove on rails upgrade
+  s.add_dependency 'oai', '>= 0.4', '< 2.x'
+  s.add_dependency 'rack', '>= 2.0.6' # security issue, remove on rails upgrade
+  s.add_dependency 'rdf', '>= 2.0.2', '< 4.0'
+  s.add_dependency 'rubyzip'
+  s.add_dependency 'simple_form'
 
   s.add_development_dependency 'sqlite3', '~> 1.3.13'
   s.add_development_dependency 'simplecov'

--- a/lib/generators/bulkrax/install_generator.rb
+++ b/lib/generators/bulkrax/install_generator.rb
@@ -10,7 +10,7 @@ class Bulkrax::InstallGenerator < Rails::Generators::Base
   end
 
   def add_to_gemfile
-    gem 'willow_sword', github: 'notch8/willow_sword'
+    gem 'bulkrax'
 
     Bundler.with_clean_env do
       run "bundle install"

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'bagit'
 
 module Bulkrax
   RSpec.describe BagitParser do


### PR DESCRIPTION
Export is a first class feature, so we should support its dependencies directly.