### PR TITLE
566-collections-metadata-only

### DIFF
--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -14,13 +14,15 @@ module Bulkrax
     validates :name, presence: true
     validates :parser_klass, presence: true
 
-    delegate :write, :create_from_collection, :create_from_importer, :create_from_worktype, :create_from_all, to: :parser
+    delegate :write, :create_from_collection, :create_from_collections_metadata, :create_from_importer, :create_from_worktype, :create_from_all, to: :parser
 
     def export
       current_run && setup_export_path
       case self.export_from
       when 'collection'
         create_from_collection
+      when 'collection metadata'
+        create_from_collections_metadata
       when 'importer'
         create_from_importer
       when 'worktype'
@@ -87,6 +89,7 @@ module Bulkrax
       [
         [I18n.t('bulkrax.exporter.labels.importer'), 'importer'],
         [I18n.t('bulkrax.exporter.labels.collection'), 'collection'],
+        [I18n.t('bulkrax.exporter.labels.collections_metadata'), 'collections metadata'],
         [I18n.t('bulkrax.exporter.labels.worktype'), 'worktype'],
         [I18n.t('bulkrax.exporter.labels.all'), 'all']
       ]

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -21,7 +21,7 @@ module Bulkrax
       case self.export_from
       when 'collection'
         create_from_collection
-      when 'collection metadata'
+      when 'collections metadata'
         create_from_collections_metadata
       when 'importer'
         create_from_importer

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -195,6 +195,7 @@ module Bulkrax
         @file_set_ids = ActiveFedora::SolrService.query("has_model_ssim:FileSet #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'collection'
         @work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source + extra_filters}", method: :post, rows: 2_000_000_000).map(&:id)
+        @collection_ids = ActiveFedora::SolrService.query("id:#{importerexporter.export_source} #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'collections metadata'
         @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:Collection #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'worktype'

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -195,6 +195,8 @@ module Bulkrax
         @file_set_ids = ActiveFedora::SolrService.query("has_model_ssim:FileSet #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'collection'
         @work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source + extra_filters}", method: :post, rows: 2_000_000_000).map(&:id)
+      when 'collections metadata'
+        @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:Collection #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'worktype'
         @work_ids = ActiveFedora::SolrService.query("has_model_ssim:#{importerexporter.export_source + extra_filters}", method: :post, rows: 2_000_000_000).map(&:id)
       when 'importer'
@@ -251,6 +253,7 @@ module Bulkrax
       end
     end
     alias create_from_collection create_new_entries
+    alias create_from_collections_metadata create_new_entries
     alias create_from_importer create_new_entries
     alias create_from_worktype create_new_entries
     alias create_from_all create_new_entries

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -15,15 +15,15 @@
 
   <%= form.hidden_field :user_id, value: current_user.id %>
 
-  <%= form.input :export_type, 
-    collection:  form.object.export_type_list, 
-    label: t('bulkrax.exporter.labels.export_type'), 
+  <%= form.input :export_type,
+    collection:  form.object.export_type_list,
+    label: t('bulkrax.exporter.labels.export_type'),
     required: true,
     prompt: 'Please select an export type' %>
 
-  <%= form.input :export_from, 
-    collection: form.object.export_from_list, 
-    label: t('bulkrax.exporter.labels.export_from'), 
+  <%= form.input :export_from,
+    collection: form.object.export_from_list,
+    label: t('bulkrax.exporter.labels.export_from'),
     required: true,
     prompt: 'Please select an export source' %>
 
@@ -55,8 +55,8 @@
     input_html: { class: 'worktype export-source-option hidden' },
     collection: Hyrax.config.curation_concerns.map {|cc| [cc.to_s, cc.to_s] } %>
 
-  <%= form.input :limit, 
-    as: :integer, 
+  <%= form.input :limit,
+    as: :integer,
     hint: 'leave blank or 0 for all records',
     label: t('bulkrax.exporter.labels.limit') %>
 
@@ -90,8 +90,8 @@
                  collection: form.object.workflow_status_list,
                  label: t('bulkrax.exporter.labels.status') %>
 
-  <%= form.input :parser_klass, 
-    collection: Bulkrax.parsers.map {|p| [p[:name], p[:class_name], {'data-partial' => p[:partial]}] if p[:class_name].constantize.export_supported? }.compact, 
+  <%= form.input :parser_klass,
+    collection: Bulkrax.parsers.map {|p| [p[:name], p[:class_name], {'data-partial' => p[:partial]}] if p[:class_name].constantize.export_supported? }.compact,
     label: t('bulkrax.exporter.labels.export_format') %>
 </div>
 

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -40,6 +40,9 @@
       <% when 'collection' %>
         <% collection = Collection.find(@exporter.export_source) %>
         <%= link_to collection&.title&.first, hyrax.dashboard_collection_path(collection.id) %>
+      <% when 'collections metadata' %>
+        <% collections = Collection.all %>
+        <%= collections.each { |c| link_to collection&.title&.first, hyrax.dashboard_collection_path(c.id)} %>
       <% when 'importer' %>
         <% importer = Bulkrax::Importer.find(@exporter.export_source) %>
         <%= link_to importer.name, bulkrax.importer_path(importer.id) %>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -42,7 +42,9 @@
         <%= link_to collection&.title&.first, hyrax.dashboard_collection_path(collection.id) %>
       <% when 'collections metadata' %>
         <% collections = Collection.all %>
-        <%= collections.each { |c| link_to collection&.title&.first, hyrax.dashboard_collection_path(c.id)} %>
+        <% collections.each_with_index do |c, i| %>
+          <%= link_to c&.title&.first, hyrax.dashboard_collection_path(c.id) %><%= ',' if i != collections.count - 1 %>
+        <% end %>
       <% when 'importer' %>
         <% importer = Bulkrax::Importer.find(@exporter.export_source) %>
         <%= link_to importer.name, bulkrax.importer_path(importer.id) %>

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -8,6 +8,7 @@ en:
       labels:
         all: All
         collection: Collection
+        collections_metadata: Collections Metadata
         export_format: Export Format
         export_from: Export From
         export_source: Export Source

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -8,7 +8,7 @@ en:
       labels:
         all: All
         collection: Collection
-        collections_metadata: Collections Metadata
+        collections_metadata: All Collections' Metadata (only)
         export_format: Export Format
         export_from: Export From
         export_source: Export Source

--- a/spec/models/bulkrax/exporter_spec.rb
+++ b/spec/models/bulkrax/exporter_spec.rb
@@ -8,6 +8,7 @@ module Bulkrax
     let(:importer) { FactoryBot.create(:bulkrax_importer) }
 
     describe 'export_from' do
+      # rubocop:disable RSpec/ExampleLength
       it 'defines a list of export from types' do
         expect(exporter.export_from_list).to eq(
           [
@@ -19,6 +20,7 @@ module Bulkrax
           ]
         )
       end
+      # rubocop:enable RSpec/ExampleLength
     end
 
     describe 'export_type' do

--- a/spec/models/bulkrax/exporter_spec.rb
+++ b/spec/models/bulkrax/exporter_spec.rb
@@ -52,6 +52,16 @@ module Bulkrax
         end
       end
 
+      context 'from collections metadata' do
+        # TODO(alishaevn): make this work
+        # let(:exporter) { FactoryBot.create(:bulkrax_exporter_collection) }
+
+        xit 'exports' do
+        #   expect(exporter).to receive(:create_from_collection)
+        #   exporter.export
+        end
+      end
+
       context 'from worktype' do
         let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype) }
 

--- a/spec/models/bulkrax/exporter_spec.rb
+++ b/spec/models/bulkrax/exporter_spec.rb
@@ -13,6 +13,7 @@ module Bulkrax
           [
             [I18n.t('bulkrax.exporter.labels.importer'), 'importer'],
             [I18n.t('bulkrax.exporter.labels.collection'), 'collection'],
+            [I18n.t('bulkrax.exporter.labels.collections_metadata'), 'collections metadata'],
             [I18n.t('bulkrax.exporter.labels.worktype'), 'worktype'],
             [I18n.t('bulkrax.exporter.labels.all'), 'all']
           ]
@@ -53,12 +54,11 @@ module Bulkrax
       end
 
       context 'from collections metadata' do
-        # TODO(alishaevn): make this work
-        # let(:exporter) { FactoryBot.create(:bulkrax_exporter_collection) }
+        let(:exporter) { FactoryBot.create(:bulkrax_exporter_collection, export_from: 'collections metadata') }
 
-        xit 'exports' do
-        #   expect(exporter).to receive(:create_from_collection)
-        #   exporter.export
+        it 'exports' do
+          expect(exporter).to receive(:create_from_collections_metadata)
+          exporter.export
         end
       end
 


### PR DESCRIPTION
ref: #566 

# expected behavior
- we can export the metadata of all collections in their own csv (does not apply to the bagit parser)
- we can export collection metadata along with the works in that collection when we choose the "collection" option (does not apply to the bagit parser)

# known gotchas
- this will not work for bagit parsing because bags require a file to be present and collections don't have files. this work is actually because of that fact though. exporting all work and fileset metadata is being worked on in #563 if a user wants checksum verification as they export their entire tenant. then they can export all collection metadata with this feature.
- the exporter show page only shows work ids, although the "total works" count is correct. this is being handled on #444 


# demo
|| new/edit page | show page | exported file |
| --- | --- | --- | --- |
| "collections metadata" | ![image](https://user-images.githubusercontent.com/29032869/173683874-661460bc-fd75-46d0-b6f0-965192b642f2.png) |  ![image](https://user-images.githubusercontent.com/29032869/173683937-8408d97f-3582-499d-ac77-97a2e7e3e994.png) |[export__from_collections metadata 3.csv](https://github.com/samvera-labs/bulkrax/files/8903798/export__from_collections.metadata.3.csv)  |
| collections | ![image](https://user-images.githubusercontent.com/29032869/173685698-76b7791a-4942-406c-a2ba-f4cad4664f62.png) | ![image](https://user-images.githubusercontent.com/29032869/173685475-79261dae-596c-4867-819e-5c68a69e5da7.png) |  [export_3_7.zip](https://github.com/samvera-labs/bulkrax/files/8903814/export_3_7.zip) |