### PR TITLE
563-bagit-export-fileset-metadata

### DIFF
--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -292,11 +292,11 @@ module Bulkrax
           let(:exporter) { FactoryBot.create(:bulkrax_exporter, :all) }
 
           before do
-            allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr, collection_ids_solr, file_set_ids_solr)
+            allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr, file_set_ids_solr)
           end
 
-          it 'exports works, collections, and file sets' do
-            expect(ExportWorkJob).to receive(:perform_now).exactly(6).times
+          it 'exports works, and file sets' do
+            expect(ExportWorkJob).to receive(:perform_now).exactly(3).times
 
             parser.create_new_entries
           end
@@ -329,7 +329,8 @@ module Bulkrax
           end
 
           it 'exported entries are given the correct class' do
-            expect { parser.create_new_entries }.to change(CsvEntry, :count).by(6)
+            expect { parser.create_new_entries }.to change(CsvEntry, :count).by(2)
+            expect { parser.create_new_entries }.to change(CsvFileSetEntry, :count).by(3)
           end
         end
       end

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -322,7 +322,7 @@ module Bulkrax
           it 'exported entries are given the correct class' do
             # Bulkrax::CsvFileSetEntry == Bulkrax::CsvEntry (false)
             # Bulkrax::CsvFileSetEntry.is_a? Bulkrax::CsvEntry (true)
-            # because of the above, although we only have 2 work id's, the 3 file set id's also create Bulkrax::CsvEntry's
+            # because of the above, although we only have 2 work id's, the 3 file set id's also increase the Bulkrax::CsvEntry count
             expect { parser.create_new_entries }
               .to change(CsvEntry, :count)
               .by(5)

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -296,7 +296,7 @@ module Bulkrax
           end
 
           it 'exports works, and file sets' do
-            expect(ExportWorkJob).to receive(:perform_now).exactly(3).times
+            expect(ExportWorkJob).to receive(:perform_now).exactly(5).times
 
             parser.create_new_entries
           end
@@ -304,15 +304,6 @@ module Bulkrax
           it 'exports all works' do
             work_entry_ids = Entry.where(identifier: work_ids_solr.map(&:id)).map(&:id)
             work_entry_ids.each do |id|
-              expect(ExportWorkJob).to receive(:perform_now).with(id, exporter.last_run.id).once
-            end
-
-            parser.create_new_entries
-          end
-
-          it 'exports all collections' do
-            collection_entry_ids = Entry.where(identifier: collection_ids_solr.map(&:id)).map(&:id)
-            collection_entry_ids.each do |id|
               expect(ExportWorkJob).to receive(:perform_now).with(id, exporter.last_run.id).once
             end
 
@@ -329,8 +320,14 @@ module Bulkrax
           end
 
           it 'exported entries are given the correct class' do
-            expect { parser.create_new_entries }.to change(CsvEntry, :count).by(2)
-            expect { parser.create_new_entries }.to change(CsvFileSetEntry, :count).by(3)
+            # Bulkrax::CsvFileSetEntry == Bulkrax::CsvEntry (false)
+            # Bulkrax::CsvFileSetEntry.is_a? Bulkrax::CsvEntry (true)
+            # because of the above, although we only have 2 work id's, the 3 file set id's also create Bulkrax::CsvEntry's
+            expect { parser.create_new_entries }
+              .to change(CsvEntry, :count)
+              .by(5)
+              .and change(CsvFileSetEntry, :count)
+              .by(3)
           end
         end
       end


### PR DESCRIPTION
ref #563 

# expected behavior
- exporting all now exports the file set metadata that's related to the work all on the same csv

# demo
[export_6_18.zip](https://github.com/samvera-labs/bulkrax/files/8905284/export_6_18.zip)

(the entire database consists of 2 collections, one work, with one fileset attached. we would expect one bag that has a work row and the related fileset row. no reference to the collections at all)
![image](https://user-images.githubusercontent.com/29032869/173727589-2a25acad-797b-4b88-9d74-5a9518e20545.png)


