### PR TITLE
handles bagit bag file exists error and prepends id to data filenames

### DIFF
--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -51,7 +51,7 @@ module Bulkrax
       fn = file_set.original_file.file_name.first
       mime = Mime::Type.lookup(file_set.original_file.mime_type)
       ext_mime = MIME::Types.of(file_set.original_file.file_name).first
-      if fn.include?(file_set.id) || importerexporter.metadata_only? || importerexporter.parser_klass.include?('Bagit')
+      if fn.include?(file_set.id) || importerexporter.metadata_only?
         filename = "#{fn}.#{mime.to_sym}"
         filename = fn if mime.to_s == ext_mime.to_s
       else

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -189,7 +189,7 @@ module Bulkrax
     alias create_from_worktype create_new_entries
     alias create_from_all create_new_entries
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def write_files
       require 'open-uri'
       require 'socket'
@@ -226,7 +226,7 @@ module Bulkrax
         bag.manifest!(algo: 'sha256')
       end
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def setup_csv_metadata_export_file(id)
       File.join(importerexporter.exporter_export_path, id, 'metadata.csv')


### PR DESCRIPTION
Prepending the id onto the filename to avoid duplication errors.  Though this changes the filename they are still coming out as valid bags so it should still satisfy requirements.  Added error handling just in case something really weird happens.

**Work with duplicate filesets**
<img width="1017" alt="Screen Shot 2022-06-15 at 10 09 23 PM" src="https://user-images.githubusercontent.com/19597776/173999447-d6eb3db8-342f-40c3-87c1-49bf00cb1bbd.png">

**Error in console**
<img width="813" alt="Screen Shot 2022-06-15 at 8 05 36 PM" src="https://user-images.githubusercontent.com/19597776/173999475-582609a0-7118-4fa6-81e8-984f77b296fe.png">

**Failed status on Export**
<img width="806" alt="Screen Shot 2022-06-15 at 10 08 04 PM" src="https://user-images.githubusercontent.com/19597776/173999472-bf4c46d6-b72f-445f-9a7d-af1d933750a3.png">

**Failed status on Entry**
<img width="1018" alt="Screen Shot 2022-06-15 at 10 08 52 PM" src="https://user-images.githubusercontent.com/19597776/173999459-25d42b75-0a04-404c-9104-e4013a69e1f0.png">

**Resulting bag**
<img width="428" alt="Screen Shot 2022-06-15 at 10 22 12 PM" src="https://user-images.githubusercontent.com/19597776/173999444-edea1d65-7e94-4c27-8f51-794d51b55e05.png">