### PR TITLE
Bagit export status and total fix

### DIFF
--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -51,7 +51,7 @@ module Bulkrax
       fn = file_set.original_file.file_name.first
       mime = Mime::Type.lookup(file_set.original_file.mime_type)
       ext_mime = MIME::Types.of(file_set.original_file.file_name).first
-      if fn.include?(file_set.id) || importerexporter.metadata_only? || importerexporter.parser_klass.include?('Bagit')
+      if fn.include?(file_set.id) || importerexporter.metadata_only?
         filename = "#{fn}.#{mime.to_sym}"
         filename = fn if mime.to_s == ext_mime.to_s
       else

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -100,8 +100,17 @@ module Bulkrax
       total
     end
 
+    # TODO @kirkkwang: look into if CsvParser#total needs this same logic
     def total
-      importerexporter.entries.count
+      @total = importer.parser_fields['total'] || 0 if importer?
+
+      @total = if exporter?
+                 limit.nil? || limit.zero? ? current_record_ids.count : limit
+               end
+
+      return @total || 0
+    rescue StandardError
+      @total = 0
     end
 
     def extra_filters
@@ -132,7 +141,6 @@ module Bulkrax
       when 'importer'
         set_ids_for_exporting_from_importer
       end
-
       @work_ids + @collection_ids + @file_set_ids
     end
 

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -100,7 +100,6 @@ module Bulkrax
       total
     end
 
-    # TODO: look into if CsvParser#total needs this same logic
     def total
       @total = importer.parser_fields['total'] || 0 if importer?
 

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -189,7 +189,7 @@ module Bulkrax
     alias create_from_worktype create_new_entries
     alias create_from_all create_new_entries
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def write_files
       require 'open-uri'
       require 'socket'
@@ -226,7 +226,7 @@ module Bulkrax
         bag.manifest!(algo: 'sha256')
       end
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
     def setup_csv_metadata_export_file(id)
       File.join(importerexporter.exporter_export_path, id, 'metadata.csv')

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -100,7 +100,7 @@ module Bulkrax
       total
     end
 
-    # TODO @kirkkwang: look into if CsvParser#total needs this same logic
+    # TODO: look into if CsvParser#total needs this same logic
     def total
       @total = importer.parser_fields['total'] || 0 if importer?
 

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -5,6 +5,34 @@ require 'bagit'
 
 module Bulkrax
   RSpec.describe BagitParser do
+    describe '#total' do
+      context 'while exporting' do
+        subject { described_class.new(exporter) }
+        let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype_bagit) }
+        let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
+        let(:work_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
+        let(:collection_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
+        let(:file_set_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
+
+        before do
+          allow(subject).to receive(:current_record_ids).and_return(work_ids_solr + collection_ids_solr + file_set_ids_solr)
+        end
+
+        context 'when there is no limit' do
+          it 'counts the correct number of works, collections, and filesets' do
+            expect(subject.total).to eq(6)
+          end
+        end
+
+        context 'when there is a limit' do
+          let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype_bagit, limit: 1) }
+          it 'counts the correct number of works, collections, and filesets' do
+            expect(subject.total).to eq(1)
+          end
+        end
+      end
+    end
+
     context 'when importing a bagit file' do
       let(:rdf_importer) { FactoryBot.create(:bulkrax_importer_bagit_rdf) }
       let(:csv_importer) { FactoryBot.create(:bulkrax_importer_bagit_csv) }

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -5,7 +5,6 @@ require 'bagit'
 
 module Bulkrax
   RSpec.describe BagitParser do
-
     context 'when importing a bagit file' do
       let(:rdf_importer) { FactoryBot.create(:bulkrax_importer_bagit_rdf) }
       let(:csv_importer) { FactoryBot.create(:bulkrax_importer_bagit_csv) }
@@ -335,7 +334,6 @@ module Bulkrax
       end
 
       describe '#total' do
-
         before do
           allow(subject).to receive(:current_record_ids).and_return(work_ids_solr + file_set_ids_solr)
         end


### PR DESCRIPTION
Bagit exports were erroneously updating the status to 'Complete' when it was not.  That was because the enqueued records were never set correctly and was stuck on zero.  Pulled in `CsvParser#total` to `BagitParser` and found when `limit` is 0, it did not respect it as the same as nil.

<img width="212" alt="image" src="https://user-images.githubusercontent.com/19597776/174121730-b4deeab0-a93e-4a38-b08a-6790233d363b.png">

This change might need to be reflected in `CsvParser` or better yet, move all duplicate code from each individual parser up to `ApplicationParser`.

