### PR TITLE
Fix error when migrating MySQL db (ref #393)

### DIFF
--- a/db/migrate/20220609001128_rename_bulkrax_importer_run_to_importer_run.rb
+++ b/db/migrate/20220609001128_rename_bulkrax_importer_run_to_importer_run.rb
@@ -1,7 +1,17 @@
 class RenameBulkraxImporterRunToImporterRun < ActiveRecord::Migration[5.2]
-  def change
+  def up
     if column_exists?(:bulkrax_pending_relationships, :bulkrax_importer_run_id)
+      remove_foreign_key :bulkrax_pending_relationships, :bulkrax_importer_runs
+      remove_index :bulkrax_pending_relationships, column: :bulkrax_importer_run_id
+
       rename_column :bulkrax_pending_relationships, :bulkrax_importer_run_id, :importer_run_id
+
+      add_foreign_key :bulkrax_pending_relationships, :bulkrax_importer_runs, column: :importer_run_id
+      add_index :bulkrax_pending_relationships, :importer_run_id, name: 'index_bulkrax_pending_relationships_on_importer_run_id'
     end
+  end
+
+  def down
+    rename_column :bulkrax_pending_relationships, :importer_run_id, :bulkrax_importer_run_id
   end
 end


### PR DESCRIPTION
# Summary 

Some MySQL databases were not properly migrating the foreign key with the most recent migration change (`RenameBulkraxImporterRunToImporterRun`), while Postgres ones were. This change makes the migration more universal by manually removing / re-adding the foreign key (and index) manually around the column name change 

#393 fixed a similar issue 

<details><summary>Archive (no longer applicable)</summary>

# ⚠️ Add the following section the the next release notes ⚠️ 

## If using a MySQL database, follow these steps to repair the migrations: 

1. `rails db:migrate:down VERSION=20220609001128`
2. `rails db:migrate`
3. Verify the changes to `db/schema.rb` 
  a. `bulkrax_pending_relationships` table<sup>1</sup>
  b. `bulkrax_pending_relationships` foreign key<sup>2</sup> 

<sup>1</sup> `bulkrax_pending_relationships` table

```ruby
  create_table "bulkrax_pending_relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
    t.bigint "importer_run_id", null: false
    ...
    t.index ["importer_run_id"], name: "index_bulkrax_pending_relationships_on_importer_run_id"
  end
```

<sup>2</sup> `bulkrax_pending_relationships` foreign key

```ruby
  add_foreign_key "bulkrax_pending_relationships", "bulkrax_importer_runs", column: "importer_run_id"
```

</details>