### PR TITLE
added required tag to form fields

### DIFF
--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -29,6 +29,7 @@
 
   <%= form.input :export_source_importer,
     label: t('bulkrax.exporter.labels.importer'),
+    required: true,
     prompt: 'Select from the list',
     label_html: { class: 'importer export-source-option hidden' },
     input_html: { class: 'importer export-source-option hidden' },
@@ -37,6 +38,7 @@
   <%= form.input :export_source_collection,
     prompt: 'Start typing ...',
     label: t('bulkrax.exporter.labels.collection'),
+    required: true,
     placeholder: @collection&.title&.first,
     label_html: { class: 'collection export-source-option hidden' },
     input_html: {
@@ -50,6 +52,7 @@
 
   <%= form.input :export_source_worktype,
     label: t('bulkrax.exporter.labels.worktype'),
+    required: true,
     prompt: 'Select from the list',
     label_html: { class: 'worktype export-source-option hidden' },
     input_html: { class: 'worktype export-source-option hidden' },


### PR DESCRIPTION
ref: #538 

Added `required: true` tag to each input field.  This would prevent the user from continuing if that field is left blank.

|Work Type|Collection|Importer|
|---|---|---|
|<img height="300" alt="Screen Shot 2022-06-24 at 8 30 23 AM" src="https://user-images.githubusercontent.com/19597776/175569896-3cbb8002-7b40-468e-945e-4e7e9e28a66a.png">|<img height="300" alt="Screen Shot 2022-06-24 at 8 30 12 AM" src="https://user-images.githubusercontent.com/19597776/175569907-e5f25638-749d-476d-9f62-1f803b0870d8.png">|<img height="300" alt="Screen Shot 2022-06-24 at 8 29 59 AM" src="https://user-images.githubusercontent.com/19597776/175569916-8bc14cf9-d76d-40c2-83cf-9ff065b61553.png">|

