### PR TITLE
Split downloads by size

### DIFF
--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -127,7 +127,7 @@ module Bulkrax
     # Download methods
 
     def file_path
-      @exporter.exporter_export_zip_path
+      "#{@exporter.exporter_export_zip_path}/#{params['exporter']['exporter_export_zip_files']}"
     end
   end
 end

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -124,9 +124,9 @@ module Bulkrax
     end
 
     def exporter_export_zip_path
-      @exporter_export_zip_path ||= FileUtils.mkdir_p(File.join(parser.base_path('export'), "export_#{self.id}_#{self.exporter_runs.last.id}")).first
+      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_#{self.exporter_runs.last.id}")
     rescue
-      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_#{self.exporter_runs.last.id}.zip") || File.join(parser.base_path('export'), "export_#{self.id}_0.zip")
+      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_0")
     end
 
     def export_properties

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -141,5 +141,14 @@ module Bulkrax
     def metadata_only?
       export_type == 'metadata'
     end
+
+    def sort_zip_files(zip_files)
+      zip_files.sort_by do |item|
+        number = item.split('_').last.match(/\d+/)&.[](0) || 0.to_s
+        sort_number = number.rjust(4, "0")
+
+        sort_number
+      end
+    end
   end
 end

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -124,9 +124,9 @@ module Bulkrax
     end
 
     def exporter_export_zip_path
-      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_#{self.exporter_runs.last.id}.zip")
+      @exporter_export_zip_path ||= FileUtils.mkdir_p(File.join(parser.base_path('export'), "export_#{self.id}_#{self.exporter_runs.last.id}")).first
     rescue
-      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_0.zip")
+      @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_#{self.exporter_runs.last.id}.zip") || File.join(parser.base_path('export'), "export_#{self.id}_0.zip")
     end
 
     def export_properties

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -129,6 +129,10 @@ module Bulkrax
       @exporter_export_zip_path ||= File.join(parser.base_path('export'), "export_#{self.id}_0")
     end
 
+    def exporter_export_zip_files
+      @exporter_export_zip_files ||= Dir["#{exporter_export_zip_path}/**"].map { |zip| Array(zip.split('/').last) }
+    end
+
     def export_properties
       properties = Hyrax.config.registered_curation_concern_types.map { |work| work.constantize.properties.keys }.flatten.uniq.sort
       properties.reject { |prop| Bulkrax.reserved_properties.include?(prop) }

--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -7,9 +7,6 @@ module Bulkrax
 
     def build_for_exporter
       build_export_metadata
-      # TODO(alishaevn): determine if the line below is still necessary
-      # the csv and bagit parsers also have write_files methods
-      write_files if export_type == 'full' && !importerexporter.parser_klass.include?('Bagit')
     rescue RSolr::Error::Http, CollectionsCreatedError => e
       raise e
     rescue StandardError => e
@@ -24,25 +21,6 @@ module Bulkrax
 
     def hyrax_record
       @hyrax_record ||= ActiveFedora::Base.find(self.identifier)
-    end
-
-    def write_files
-      return if hyrax_record.is_a?(Collection)
-
-      file_sets = hyrax_record.file_set? ? Array.wrap(hyrax_record) : hyrax_record.file_sets
-      file_sets << hyrax_record.thumbnail if hyrax_record.thumbnail.present? && hyrax_record.work? && exporter.include_thumbnails
-      file_sets.each do |fs|
-        path = File.join(exporter_export_path, 'files')
-        FileUtils.mkdir_p(path)
-        file = filename(fs)
-        require 'open-uri'
-        io = open(fs.original_file.uri)
-        next if file.blank?
-        File.open(File.join(path, file), 'wb') do |f|
-          f.write(io.read)
-          f.close
-        end
-      end
     end
 
     # Prepend the file_set id to ensure a unique filename and also one that is not longer than 255 characters

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -262,10 +262,20 @@ module Bulkrax
     end
 
     def zip
-      FileUtils.rm_rf(exporter_export_zip_path)
-      Zip::File.open(exporter_export_zip_path, create: true) do |zip_file|
-        Dir["#{exporter_export_path}/**/**"].each do |file|
-          zip_file.add(file.sub("#{exporter_export_path}/", ''), file)
+      if exporter_export_zip_path.exclude?('zip')
+        Dir["#{exporter_export_path}/**"].each do |folder|
+          zip_path = "#{exporter_export_zip_path.split('/').last}_#{folder.split('/').last}.zip"
+          Zip::File.open(File.join("#{exporter_export_zip_path}/#{zip_path}"), create: true) do |zip_file|
+            Dir["#{folder}/**/**"].each do |file|
+              zip_file.add(file.sub("#{folder}/", ''), file)
+            end
+          end
+        end
+      else
+        FileUtils.rm_rf(exporter_export_zip_path)
+        Zip::File.open(exporter_export_zip_path, create: true) do |zip_file|
+          Dir["#{exporter_export_path}/**/**"].each do |file|
+            zip_file.add(file.sub("#{exporter_export_path}/", ''), file)
         end
       end
     end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -262,20 +262,13 @@ module Bulkrax
     end
 
     def zip
-      if exporter_export_zip_path.exclude?('zip')
-        Dir["#{exporter_export_path}/**"].each do |folder|
-          zip_path = "#{exporter_export_zip_path.split('/').last}_#{folder.split('/').last}.zip"
-          Zip::File.open(File.join("#{exporter_export_zip_path}/#{zip_path}"), create: true) do |zip_file|
-            Dir["#{folder}/**/**"].each do |file|
-              zip_file.add(file.sub("#{folder}/", ''), file)
-            end
-          end
-        end
-      else
-        FileUtils.rm_rf(exporter_export_zip_path)
-        Zip::File.open(exporter_export_zip_path, create: true) do |zip_file|
-          Dir["#{exporter_export_path}/**/**"].each do |file|
-            zip_file.add(file.sub("#{exporter_export_path}/", ''), file)
+      FileUtils.mkdir_p(exporter_export_zip_path)
+
+      Dir["#{exporter_export_path}/**"].each do |folder|
+        zip_path = "#{exporter_export_zip_path.split('/').last}_#{folder.split('/').last}.zip"
+        Zip::File.open(File.join("#{exporter_export_zip_path}/#{zip_path}"), create: true) do |zip_file|
+          Dir["#{folder}/**/**"].each do |file|
+            zip_file.add(file.sub("#{folder}/", ''), file)
           end
         end
       end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -276,6 +276,7 @@ module Bulkrax
         Zip::File.open(exporter_export_zip_path, create: true) do |zip_file|
           Dir["#{exporter_export_path}/**/**"].each do |file|
             zip_file.add(file.sub("#{exporter_export_path}/", ''), file)
+          end
         end
       end
     end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -134,11 +134,12 @@ module Bulkrax
         bag_entries = [entry]
         file_set_entry = Bulkrax::CsvFileSetEntry.where("parsed_metadata LIKE '%#{record.id}%'").first
         bag_entries << file_set_entry unless file_set_entry.nil?
+        work_count = bag_entries.select { |entry| entry.class == CsvEntry }.count
 
-        records_in_folder += bag_entries.count
+        records_in_folder += work_count
         if records_in_folder > 1000
           folder_count += 1
-          records_in_folder = bag_entries.count
+          records_in_folder = work_count
         end
 
         bag ||= BagIt::Bag.new setup_bagit_folder(folder_count, entry.identifier)

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -132,12 +132,20 @@ module Bulkrax
         next unless Hyrax.config.curation_concerns.include?(record.class)
 
         bag_entries = [entry]
-        file_set_entry = Bulkrax::CsvFileSetEntry.where("parsed_metadata LIKE '%#{record.id}%'").first
-        bag_entries << file_set_entry unless file_set_entry.nil?
+        file_set_entries = Bulkrax::CsvFileSetEntry.where("parsed_metadata LIKE '%#{record.id}%'")
+        items = []
+        file_set_entries.each do |fse|
+          item = fse.attributes['parsed_metadata']['item_1']
+          unless items.include?(item) || file_set_entries.nil?
+            items << item
+            bag_entries << fse
+          end
+        end
+
         work_count = bag_entries.select { |entry| entry.class == CsvEntry }.count
 
         records_in_folder += work_count
-        if records_in_folder > 1000
+        if records_in_folder > works_split_count
           folder_count += 1
           records_in_folder = work_count
         end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -211,7 +211,11 @@ module Bulkrax
     # find the related file set ids so entries can be made for export
     def find_child_file_sets(work_ids)
       work_ids.each do |id|
-        ActiveFedora::Base.find(id).file_set_ids.each { |fs_id| @file_set_ids << fs_id }
+        begin
+          ActiveFedora::Base.find(id).file_set_ids.each { |fs_id| @file_set_ids << fs_id }
+        rescue NameError, ActiveFedora::ObjectNotFoundError
+          return
+        end
       end
     end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -208,6 +208,13 @@ module Bulkrax
       @work_ids + @collection_ids + @file_set_ids
     end
 
+    # find the related file set ids so entries can be made for export
+    def find_child_file_sets(work_ids)
+      work_ids.each do |id|
+        ActiveFedora::Base.find(id).file_set_ids.each { |fs_id| @file_set_ids << fs_id }
+      end
+    end
+
     # Set the following instance variables: @work_ids, @collection_ids, @file_set_ids
     # @see #current_record_ids
     def set_ids_for_exporting_from_importer
@@ -284,7 +291,7 @@ module Bulkrax
       @total = 0
     end
 
-    def works_split_count
+    def records_split_count
       1000
     end
 
@@ -315,7 +322,7 @@ module Bulkrax
       require 'open-uri'
       folder_count = 0
 
-      importerexporter.entries.where(identifier: current_record_ids)[0..limit || total].in_groups_of(works_split_count, false) do |group|
+      importerexporter.entries.where(identifier: current_record_ids)[0..limit || total].in_groups_of(records_split_count, false) do |group|
         folder_count += 1
 
         CSV.open(setup_export_file(folder_count), "w", headers: export_headers, write_headers: true) do |csv|

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -389,7 +389,7 @@ module Bulkrax
       path = File.join(importerexporter.exporter_export_path, folder_count.to_s)
       FileUtils.mkdir_p(path) unless File.exist?(path)
 
-      File.join(path, "export_#{importerexporter.export_source}_from_#{importerexporter.export_from}_#{folder_count.to_s}.csv")
+      File.join(path, "export_#{importerexporter.export_source}_from_#{importerexporter.export_from}_#{folder_count}.csv")
     end
 
     # Retrieve file paths for [:file] mapping in records

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -284,6 +284,10 @@ module Bulkrax
       @total = 0
     end
 
+    def works_split_count
+      1000
+    end
+
     # @todo - investigate getting directory structure
     # @todo - investigate using perform_later, and having the importer check for
     #   DownloadCloudFileJob before it starts
@@ -311,7 +315,7 @@ module Bulkrax
       require 'open-uri'
       folder_count = 0
 
-      importerexporter.entries.where(identifier: current_record_ids)[0..limit || total].in_groups_of(1000, false) do |group|
+      importerexporter.entries.where(identifier: current_record_ids)[0..limit || total].in_groups_of(works_split_count, false) do |group|
         folder_count += 1
 
         CSV.open(setup_export_file(folder_count), "w", headers: export_headers, write_headers: true) do |csv|

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -211,11 +211,7 @@ module Bulkrax
     # find the related file set ids so entries can be made for export
     def find_child_file_sets(work_ids)
       work_ids.each do |id|
-        begin
-          ActiveFedora::Base.find(id).file_set_ids.each { |fs_id| @file_set_ids << fs_id }
-        rescue NameError, ActiveFedora::ObjectNotFoundError
-          return
-        end
+        ActiveFedora::Base.find(id).file_set_ids.each { |fs_id| @file_set_ids << fs_id }
       end
     end
 

--- a/app/views/bulkrax/exporters/_downloads.html.erb
+++ b/app/views/bulkrax/exporters/_downloads.html.erb
@@ -1,7 +1,6 @@
-<%= form.input :exporter_export_zip_files,
-  prompt: 'Select a file to download',
-  label_html: { class: 'hidden' },
-  collection: form.object.exporter_export_zip_files
-%>
-<%# link_to raw('<span class="glyphicon glyphicon-download"></span>'), exporter_download_path(exporter), :html => {:onclick => raise 'your hands'} %>
-<%= form.button :submit, 'Download' %>
+<%= form.input :exporter_export_zip_files, label: false do %>
+  <%= form.select :exporter_export_zip_files,
+    form.object.exporter_export_zip_files,
+    action: :download
+  %>
+<% end%>

--- a/app/views/bulkrax/exporters/_downloads.html.erb
+++ b/app/views/bulkrax/exporters/_downloads.html.erb
@@ -1,0 +1,6 @@
+<%= form.input :exporter_export_zip_files,
+  prompt: 'Select a file to download',
+  label_html: { class: 'hidden' },
+  collection: form.object.exporter_export_zip_files
+%>
+

--- a/app/views/bulkrax/exporters/_downloads.html.erb
+++ b/app/views/bulkrax/exporters/_downloads.html.erb
@@ -1,5 +1,5 @@
 <%= form.select :exporter_export_zip_files,
-  form.object.exporter_export_zip_files,
+  form.object.exporter_export_zip_files.sort,
   {},
   {
     class: 'btn btn-default form-control',

--- a/app/views/bulkrax/exporters/_downloads.html.erb
+++ b/app/views/bulkrax/exporters/_downloads.html.erb
@@ -3,4 +3,5 @@
   label_html: { class: 'hidden' },
   collection: form.object.exporter_export_zip_files
 %>
-
+<%# link_to raw('<span class="glyphicon glyphicon-download"></span>'), exporter_download_path(exporter), :html => {:onclick => raise 'your hands'} %>
+<%= form.button :submit, 'Download' %>

--- a/app/views/bulkrax/exporters/_downloads.html.erb
+++ b/app/views/bulkrax/exporters/_downloads.html.erb
@@ -1,6 +1,8 @@
-<%= form.input :exporter_export_zip_files, label: false do %>
-  <%= form.select :exporter_export_zip_files,
-    form.object.exporter_export_zip_files,
-    action: :download
-  %>
-<% end%>
+<%= form.select :exporter_export_zip_files,
+  form.object.exporter_export_zip_files,
+  {},
+  {
+    class: 'btn btn-default form-control',
+    style: 'width: 200px'
+  }
+%>

--- a/app/views/bulkrax/exporters/_downloads.html.erb
+++ b/app/views/bulkrax/exporters/_downloads.html.erb
@@ -1,5 +1,5 @@
 <%= form.select :exporter_export_zip_files,
-  form.object.exporter_export_zip_files.sort,
+  exporter.sort_zip_files(form.object.exporter_export_zip_files.flatten),
   {},
   {
     class: 'btn btn-default form-control',

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -35,8 +35,9 @@
                 <td><%= exporter.created_at %></td>
                 <td>
                   <% if File.exist?(exporter.exporter_export_zip_path) %>
-                    <%= simple_form_for exporter do |form| %>
+                    <%= simple_form_for(exporter, method: :get, url: exporter_download_path(exporter)) do |form| %>
                       <%= render 'downloads', exporter: exporter, form: form %>
+                      <%= form.button :submit, value: 'Download', data: { disable_with: false } %>
                     <% end %>
                   <% end%>
                 </td>

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -39,8 +39,6 @@
                       <%= render 'downloads', exporter: exporter, form: form %>
                     <% end %>
                   <% end%>
-                    <%= link_to raw('<span class="glyphicon glyphicon-download"></span>'), exporter_download_path(exporter) %>
-                  <% end%>
                 </td>
                 <td><%= link_to raw('<span class="glyphicon glyphicon-info-sign"></span>'), exporter_path(exporter) %></td>
                 <td><%= link_to raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(exporter) %></td>

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -21,7 +21,7 @@
               <th scope="col">Name</th>
               <th scope="col">Status</th>
               <th scope="col">Date Exported</th>
-              <th scope="col"></th>
+              <th scope="col">Downloadable Files</th>
               <th scope="col"></th>
               <th scope="col"></th>
               <th scope="col"></th>
@@ -35,6 +35,10 @@
                 <td><%= exporter.created_at %></td>
                 <td>
                   <% if File.exist?(exporter.exporter_export_zip_path) %>
+                    <%= simple_form_for exporter do |form| %>
+                      <%= render 'downloads', exporter: exporter, form: form %>
+                    <% end %>
+                  <% end%>
                     <%= link_to raw('<span class="glyphicon glyphicon-download"></span>'), exporter_download_path(exporter) %>
                   <% end%>
                 </td>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -8,10 +8,11 @@
   <div class='panel-body'>
 
     <% if File.exist?(@exporter.exporter_export_zip_path) %>
-      <p class='bulkrax-p-align'>
+      <%= simple_form_for @exporter, method: :get, url: exporter_download_path(@exporter), html: { class: 'form-inline bulkrax-p-align' } do |form| %>
         <strong>Download:</strong>
-        <%= link_to raw('<span class="glyphicon glyphicon-download"></span>'), exporter_download_path(@exporter) %>
-      </p>
+        <%= render 'downloads', exporter: @exporter, form: form %>
+        <%= form.button :submit, value: 'Download', data: { disable_with: false } %>
+      <% end %>
     <% end %>
 
     <p class='bulkrax-p-align'>
@@ -135,10 +136,6 @@
       <%= page_entries_info(@work_entries) %><br>
       <%= paginate(@work_entries, param_name: :work_entries_page) %>
       <br>
-      <% if File.exist?(@exporter.exporter_export_zip_path) %>
-        <%= link_to 'Download', exporter_download_path(@exporter) %>
-        |
-      <% end %>
       <%= link_to 'Edit', edit_exporter_path(@exporter) %>
       |
       <%= link_to 'Back', exporters_path %>

--- a/lib/tasks/bulkrax_tasks.rake
+++ b/lib/tasks/bulkrax_tasks.rake
@@ -1,6 +1,29 @@
 # frozen_string_literal: true
 
-# desc "Explaining what the task does"
-# task :bulkrax do
-#   # Task goes here
-# end
+namespace :bulkrax do
+  desc "Remove old exported zips and create new ones with the new file structure"
+  task rerun_all_exporters: :environment do
+    if defined?(::Hyku)
+      Account.find_each do |account|
+        puts "=============== updating #{account.name} ============"
+        next if account.name == "search"
+        switch!(account)
+
+        rerun_exporters_and_delete_zips
+      end
+    else
+      rerun_exporters_and_delete_zips
+    end
+  end
+
+  def rerun_exporters_and_delete_zips
+    begin
+      Bulkrax::Exporter.all.each { |e| Bulkrax::ExporterJob.perform_later(e.id) }
+      puts "=============== finished updating #{account.name} ============"
+    rescue => e
+      puts "(#{e.message})"
+    end
+
+    Dir["tmp/exports/**.zip"].each { |zip_path| FileUtils.rm_rf(zip_path) }
+  end
+end

--- a/lib/tasks/bulkrax_tasks.rake
+++ b/lib/tasks/bulkrax_tasks.rake
@@ -10,6 +10,8 @@ namespace :bulkrax do
         switch!(account)
 
         rerun_exporters_and_delete_zips
+
+        puts "=============== finished updating #{account.name} ============"
       end
     else
       rerun_exporters_and_delete_zips
@@ -19,7 +21,6 @@ namespace :bulkrax do
   def rerun_exporters_and_delete_zips
     begin
       Bulkrax::Exporter.all.each { |e| Bulkrax::ExporterJob.perform_later(e.id) }
-      puts "=============== finished updating #{account.name} ============"
     rescue => e
       puts "(#{e.message})"
     end

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -30,7 +30,7 @@ module Bulkrax
         importer_job.perform(importer.id)
 
         expect(importer.current_run.total_work_entries).to eq(10)
-        expect(importer.current_run.total_collection_entries).to eq(427)
+        expect(importer.current_run.total_collection_entries).to eq(428)
       end
     end
 

--- a/spec/models/bulkrax/exporter_spec.rb
+++ b/spec/models/bulkrax/exporter_spec.rb
@@ -6,6 +6,11 @@ module Bulkrax
   RSpec.describe Exporter, type: :model do
     let(:exporter) { FactoryBot.create(:bulkrax_exporter, limit: 7) }
     let(:importer) { FactoryBot.create(:bulkrax_importer) }
+    let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
+
+    before do
+      allow(exporter).to receive(:exporter_runs).and_return([bulkrax_exporter_run])
+    end
 
     describe 'export_from' do
       # rubocop:disable RSpec/ExampleLength
@@ -123,6 +128,22 @@ module Bulkrax
           expect(exporter.export_source_importer).to be_nil
           expect(exporter.export_source_collection).to be_nil
         end
+      end
+    end
+
+    describe '#setup_export_path' do
+      it 'returns a path to the exported zip files' do
+        expect(exporter.exporter_export_zip_path).to eq('tmp/exports/export_1_1')
+      end
+    end
+
+    describe '#sort_zip_files' do
+      it 'orders the zip files numerically' do
+        zip_files = ['export_1_10.zip', 'export_1_2.zip']
+        sorted = exporter.sort_zip_files(zip_files)
+
+        expect(sorted[0]).to eq('export_1_2.zip')
+        expect(sorted[1]).to eq('export_1_10.zip')
       end
     end
   end

--- a/spec/models/bulkrax/exporter_spec.rb
+++ b/spec/models/bulkrax/exporter_spec.rb
@@ -6,11 +6,6 @@ module Bulkrax
   RSpec.describe Exporter, type: :model do
     let(:exporter) { FactoryBot.create(:bulkrax_exporter, limit: 7) }
     let(:importer) { FactoryBot.create(:bulkrax_importer) }
-    let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
-
-    before do
-      allow(exporter).to receive(:exporter_runs).and_return([bulkrax_exporter_run])
-    end
 
     describe 'export_from' do
       # rubocop:disable RSpec/ExampleLength
@@ -131,9 +126,23 @@ module Bulkrax
       end
     end
 
-    describe '#setup_export_path' do
-      it 'returns a path to the exported zip files' do
-        expect(exporter.exporter_export_zip_path).to eq('tmp/exports/export_1_1')
+    context '#exporter_export_zip_path' do
+      describe 'without an exporter run' do
+        it 'returns a path to the exported zip files' do
+          expect(exporter.exporter_export_zip_path).to eq('tmp/exports/export_1_0')
+        end
+      end
+
+      describe 'with an exporter run' do
+        let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
+
+        before do
+          allow(exporter).to receive(:exporter_runs).and_return([bulkrax_exporter_run])
+        end
+
+        it 'returns a path to the exported zip files' do
+          expect(exporter.exporter_export_zip_path).to eq('tmp/exports/export_1_1')
+        end
       end
     end
 

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -290,8 +290,6 @@ module Bulkrax
       end
 
       describe '#find_child_file_sets' do
-        subject(:parser) { described_class.new(exporter) }
-
         before do
           parser.instance_variable_set(:@file_set_ids, [])
           allow(ActiveFedora::Base).to receive(:find).with('123').and_return(ActiveFedora::ObjectNotFoundError)
@@ -309,7 +307,6 @@ module Bulkrax
       end
 
       describe '#create_new_entries' do
-        subject(:parser) { described_class.new(exporter) }
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
 
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
@@ -383,6 +380,32 @@ module Bulkrax
         end
       end
 
+      context 'folders and files for export' do
+        let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
+
+        before do
+          allow(exporter).to receive(:exporter_runs).and_return([bulkrax_exporter_run])
+        end
+
+        describe '#setup_csv_metadata_export_file' do
+          it 'creates the csv metadata file' do
+            expect(subject.setup_csv_metadata_export_file(2, '3')).to eq('tmp/exports/1/1/2/3/metadata.csv')
+          end
+        end
+
+        describe '#setup_triple_metadata_export_file' do
+          it 'creates the csv metadata file' do
+            expect(subject.setup_triple_metadata_export_file(2, '3')).to eq('tmp/exports/1/1/2/3/metadata.nt')
+          end
+        end
+
+        describe '#setup_bagit_folder' do
+          it 'creates the csv metadata file' do
+            expect(subject.setup_bagit_folder(2, '3')).to eq('tmp/exports/1/1/2/3')
+          end
+        end
+      end
+
       describe '#total' do
         before do
           allow(subject).to receive(:current_record_ids).and_return(work_ids_solr + file_set_ids_solr)
@@ -403,7 +426,6 @@ module Bulkrax
       end
 
       describe '#export_headers' do
-        subject(:parser) { described_class.new(exporter) }
         let(:work_id) { SecureRandom.alphanumeric(9) }
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype_bagit, field_mapping: {

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -291,18 +291,18 @@ module Bulkrax
 
       describe '#find_child_file_sets' do
         before do
-          parser.instance_variable_set(:@file_set_ids, [])
+          subject.instance_variable_set(:@file_set_ids, [])
           allow(ActiveFedora::Base).to receive(:find).with('123').and_return(ActiveFedora::ObjectNotFoundError)
         end
 
         it 'returns the ids when child file sets are present' do
-          parser.find_child_file_sets(work_ids_solr.pluck(:id))
-          expect(parser.instance_variable_get(:@file_set_ids)).to eq([file_set_ids_solr.pluck(:id).first])
+          subject.find_child_file_sets(work_ids_solr.pluck(:id))
+          expect(subject.instance_variable_get(:@file_set_ids)).to eq([file_set_ids_solr.pluck(:id).first])
         end
 
         it 'returns nothing when no child file sets are present' do
-          parser.find_child_file_sets(['123'])
-          expect(parser.instance_variable_get(:@file_set_ids)).to eq([])
+          subject.find_child_file_sets(['123'])
+          expect(subject.instance_variable_get(:@file_set_ids)).to eq([])
         end
       end
 
@@ -312,7 +312,7 @@ module Bulkrax
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
           expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
           expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(3).times
-          parser.create_new_entries
+          subject.create_new_entries
         end
 
         context 'with an export limit of 1' do
@@ -321,7 +321,7 @@ module Bulkrax
           it 'invokes Bulkrax::ExportWorkJob once' do
             expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
             expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
-            parser.create_new_entries
+            subject.create_new_entries
           end
         end
 
@@ -331,7 +331,7 @@ module Bulkrax
           it 'invokes Bulkrax::ExportWorkJob once per Entry' do
             expect(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
             expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(3).times
-            parser.create_new_entries
+            subject.create_new_entries
           end
         end
 
@@ -346,7 +346,7 @@ module Bulkrax
           it 'exports works, and file sets' do
             expect(ExportWorkJob).to receive(:perform_now).exactly(5).times
 
-            parser.create_new_entries
+            subject.create_new_entries
           end
 
           it 'exports all works' do
@@ -355,7 +355,7 @@ module Bulkrax
               expect(ExportWorkJob).to receive(:perform_now).with(id, exporter.last_run.id).once
             end
 
-            parser.create_new_entries
+            subject.create_new_entries
           end
 
           it 'exports all file sets' do
@@ -364,14 +364,14 @@ module Bulkrax
               expect(ExportWorkJob).to receive(:perform_now).with(id, exporter.last_run.id).once
             end
 
-            parser.create_new_entries
+            subject.create_new_entries
           end
 
           it 'exported entries are given the correct class' do
             # Bulkrax::CsvFileSetEntry == Bulkrax::CsvEntry (false)
             # Bulkrax::CsvFileSetEntry.is_a? Bulkrax::CsvEntry (true)
             # because of the above, although we only have 2 work id's, the 3 file set id's also increase the Bulkrax::CsvEntry count
-            expect { parser.create_new_entries }
+            expect { subject.create_new_entries }
               .to change(CsvEntry, :count)
               .by(5)
               .and change(CsvFileSetEntry, :count)
@@ -452,12 +452,12 @@ module Bulkrax
         before do
           allow(ActiveFedora::SolrService).to receive(:query).and_return(OpenStruct.new(id: work_id))
           allow(exporter.entries).to receive(:where).and_return([entry])
-          allow(parser).to receive(:headers).and_return(entry.parsed_metadata.keys)
+          allow(subject).to receive(:headers).and_return(entry.parsed_metadata.keys)
         end
 
         # rubocop:disable RSpec/ExampleLength
         it 'returns an array of single, numerated and double numerated header values' do
-          headers = parser.export_headers
+          headers = subject.export_headers
           expect(headers).to include('id')
           expect(headers).to include('model')
           expect(headers).to include('display_title')

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -292,17 +292,11 @@ module Bulkrax
       describe '#find_child_file_sets' do
         before do
           subject.instance_variable_set(:@file_set_ids, [])
-          allow(ActiveFedora::Base).to receive(:find).with('123').and_return(ActiveFedora::ObjectNotFoundError)
         end
 
         it 'returns the ids when child file sets are present' do
           subject.find_child_file_sets(work_ids_solr.pluck(:id))
           expect(subject.instance_variable_get(:@file_set_ids)).to eq([file_set_ids_solr.pluck(:id).first])
-        end
-
-        it 'returns nothing when no child file sets are present' do
-          subject.find_child_file_sets(['123'])
-          expect(subject.instance_variable_get(:@file_set_ids)).to eq([])
         end
       end
 

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -380,6 +380,24 @@ module Bulkrax
         end
       end
 
+      describe '#write_files' do
+        let(:work_entry_1) { FactoryBot.create(:bulkrax_csv_entry, importerexporter: exporter) }
+        let(:work_entry_2) { FactoryBot.create(:bulkrax_csv_entry, importerexporter: exporter) }
+        let(:fileset_entry_1) { FactoryBot.create(:bulkrax_csv_entry_file_set, importerexporter: exporter) }
+        let(:fileset_entry_2) { FactoryBot.create(:bulkrax_csv_entry_file_set, importerexporter: exporter) }
+
+        before do
+          allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
+          allow(exporter.entries).to receive(:where).and_return([work_entry_1, work_entry_2, fileset_entry_1, fileset_entry_2])
+        end
+
+        it 'attempts to find the related record' do
+          expect(ActiveFedora::Base).to receive(:find).with('csv_entry').and_return(nil)
+
+          subject.write_files
+        end
+      end
+
       context 'folders and files for export' do
         let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
 

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -292,12 +292,20 @@ module Bulkrax
       describe '#find_child_file_sets' do
         subject(:parser) { described_class.new(exporter) }
 
-        it 'returns the file sets attached to the parent works' do
+        before do
           parser.instance_variable_set(:@file_set_ids, [])
+          allow(ActiveFedora::Base).to receive(:find).with('123').and_return(ActiveFedora::ObjectNotFoundError)
+        end
 
+        it 'returns the ids when child file sets are present' do
           parser.find_child_file_sets(work_ids_solr.pluck(:id))
-
           expect(parser.instance_variable_get(:@file_set_ids)).to eq([file_set_ids_solr.pluck(:id).first])
+        end
+
+        it 'returns nothing when no child file sets are present' do
+          # byebug
+          parser.find_child_file_sets(['123'])
+          expect(parser.instance_variable_get(:@file_set_ids)).to eq([])
         end
       end
 

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -303,7 +303,6 @@ module Bulkrax
         end
 
         it 'returns nothing when no child file sets are present' do
-          # byebug
           parser.find_child_file_sets(['123'])
           expect(parser.instance_variable_get(:@file_set_ids)).to eq([])
         end

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -289,6 +289,18 @@ module Bulkrax
         allow(ActiveFedora::Base).to receive(:find).with(work_ids_solr.last.id).and_return(parent_record_2)
       end
 
+      describe '#find_child_file_sets' do
+        subject(:parser) { described_class.new(exporter) }
+
+        it 'returns the file sets attached to the parent works' do
+          parser.instance_variable_set(:@file_set_ids, [])
+
+          parser.find_child_file_sets(work_ids_solr.pluck(:id))
+
+          expect(parser.instance_variable_get(:@file_set_ids)).to eq([file_set_ids_solr.pluck(:id).first])
+        end
+      end
+
       describe '#create_new_entries' do
         subject(:parser) { described_class.new(exporter) }
         # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -475,6 +475,20 @@ module Bulkrax
       end
     end
 
+    describe '#setup_export_file' do
+      subject(:parser) { described_class.new(exporter) }
+      let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
+      let(:exporter)   { FactoryBot.create(:bulkrax_exporter_worktype) }
+
+      before do
+        allow(exporter).to receive(:exporter_runs).and_return([bulkrax_exporter_run])
+      end
+
+      it 'creates the csv metadata file' do
+        expect(subject.setup_export_file(2)).to eq('tmp/exports/1/1/2/export_Generic_from_worktype_2.csv')
+      end
+    end
+
     describe '#total' do
       context 'on import' do
         subject { described_class.new(importer) }

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -505,6 +505,12 @@ module Bulkrax
       end
     end
 
+    describe '#records_split_count' do
+      it 'defaults to 1000' do
+        expect(subject.records_split_count).to eq(1000)
+      end
+    end
+
     describe '#path_to_files' do
       context 'when an argument is passed' do
         it 'returns the correct path' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -478,7 +478,7 @@ module Bulkrax
     describe '#setup_export_file' do
       subject(:parser) { described_class.new(exporter) }
       let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
-      let(:exporter)   { FactoryBot.create(:bulkrax_exporter_worktype) }
+      let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype) }
 
       before do
         allow(exporter).to receive(:exporter_runs).and_return([bulkrax_exporter_run])


### PR DESCRIPTION
ref: https://gitlab.com/notch8/palni-palci/-/issues/466

# expected behavior
### csv
- csv formatted exports will have a maximum of 1000 records per csv
- if there are multiple csv's, each one along with its related "files" folder, will be in its own zip file

### bagit
- bagit formatted exports will have a maximum of 1000 records per zip. 
  - there will still only be 1 work per csv, along with its child file sets
  - a single zip will contain multiple bags

### ui
- now that there are potentially several zip files created from a single export, there is a drop down of files on the index page
- selecting a zip file and then pressing "download" will download that particular zip file
- the same applies to the exporter show page

# demo
<details>
<summary> exporter index page </summary>

![image](https://user-images.githubusercontent.com/29032869/177658333-86c264b7-3b6b-40f3-babe-c07ff3068a83.png)
</details>

<details>
<summary> exporter show page </summary>

![image](https://user-images.githubusercontent.com/29032869/177658430-793b3f3b-3223-477f-9015-d0a3cea6ad82.png)
</details>

<details>
<summary> new file structure </summary>

![image](https://user-images.githubusercontent.com/29032869/177658537-c20d13f5-092f-46b8-a326-9972d68725bf.png)
</details>