### PR TITLE
export-child-collections

### DIFF
--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -14,15 +14,13 @@ module Bulkrax
     validates :name, presence: true
     validates :parser_klass, presence: true
 
-    delegate :write, :create_from_collection, :create_from_collections_metadata, :create_from_importer, :create_from_worktype, :create_from_all, to: :parser
+    delegate :write, :create_from_collection, :create_from_importer, :create_from_worktype, :create_from_all, to: :parser
 
     def export
       current_run && setup_export_path
       case self.export_from
       when 'collection'
         create_from_collection
-      when 'collections metadata'
-        create_from_collections_metadata
       when 'importer'
         create_from_importer
       when 'worktype'

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -140,7 +140,7 @@ module Bulkrax
           file.write(io.read)
           file.close
           begin
-            bag.add_file(file_name, file.path) unless bag.bag_files.select { |b| b.include?(file_name) }.present?
+            bag.add_file(file_name, file.path) if bag.bag_files.select { |b| b.include?(file_name) }.blank?
           rescue => e
             entry.status_info(e)
             status_info(e)

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -140,7 +140,7 @@ module Bulkrax
           file.write(io.read)
           file.close
           begin
-            bag.add_file(file_name, file.path)
+            bag.add_file(file_name, file.path) unless bag.bag_files.select { |b| b.include?(file_name) }.present?
           rescue => e
             entry.status_info(e)
             status_info(e)

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -196,7 +196,8 @@ module Bulkrax
         @file_set_ids = ActiveFedora::SolrService.query("has_model_ssim:FileSet #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'collection'
         @work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source + extra_filters} AND has_model_ssim:(#{Hyrax.config.curation_concerns.join(' OR ')})", method: :post, rows: 2_000_000_000).map(&:id)
-        @collection_ids = ActiveFedora::SolrService.query("id:#{importerexporter.export_source} #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
+        # TODO: get this working properly
+        @collection_ids = ActiveFedora::SolrService.query("id:#{importerexporter.export_source} #{extra_filters} OR member_of_collection_ids_ssim:#{importerexporter.export_source}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'collections metadata'
         @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:Collection #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'worktype'

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -200,8 +200,6 @@ module Bulkrax
         # get the parent collection and child collections
         @collection_ids = ActiveFedora::SolrService.query("id:#{importerexporter.export_source} #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
         @collection_ids += ActiveFedora::SolrService.query("has_model_ssim:Collection AND member_of_collection_ids_ssim:#{importerexporter.export_source}", method: :post, rows: 2_147_483_647).map(&:id)
-      when 'collections metadata'
-        @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:Collection #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'worktype'
         @work_ids = ActiveFedora::SolrService.query("has_model_ssim:#{importerexporter.export_source + extra_filters}", method: :post, rows: 2_000_000_000).map(&:id)
       when 'importer'
@@ -268,7 +266,6 @@ module Bulkrax
       end
     end
     alias create_from_collection create_new_entries
-    alias create_from_collections_metadata create_new_entries
     alias create_from_importer create_new_entries
     alias create_from_worktype create_new_entries
     alias create_from_all create_new_entries

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -195,7 +195,7 @@ module Bulkrax
         @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:Collection #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
         @file_set_ids = ActiveFedora::SolrService.query("has_model_ssim:FileSet #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'collection'
-        @work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source + extra_filters}", method: :post, rows: 2_000_000_000).map(&:id)
+        @work_ids = ActiveFedora::SolrService.query("member_of_collection_ids_ssim:#{importerexporter.export_source + extra_filters} AND has_model_ssim:(#{Hyrax.config.curation_concerns.join(' OR ')})", method: :post, rows: 2_000_000_000).map(&:id)
         @collection_ids = ActiveFedora::SolrService.query("id:#{importerexporter.export_source} #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)
       when 'collections metadata'
         @collection_ids = ActiveFedora::SolrService.query("has_model_ssim:Collection #{extra_filters}", method: :post, rows: 2_147_483_647).map(&:id)

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -41,11 +41,6 @@
       <% when 'collection' %>
         <% collection = Collection.find(@exporter.export_source) %>
         <%= link_to collection&.title&.first, hyrax.dashboard_collection_path(collection.id) %>
-      <% when 'collections metadata' %>
-        <% collections = Collection.all %>
-        <% collections.each_with_index do |c, i| %>
-          <%= link_to c&.title&.first, hyrax.dashboard_collection_path(c.id) %><%= ',' if i != collections.count - 1 %>
-        <% end %>
       <% when 'importer' %>
         <% importer = Bulkrax::Importer.find(@exporter.export_source) %>
         <%= link_to importer.name, bulkrax.importer_path(importer.id) %>

--- a/spec/models/bulkrax/exporter_spec.rb
+++ b/spec/models/bulkrax/exporter_spec.rb
@@ -54,15 +54,6 @@ module Bulkrax
         end
       end
 
-      context 'from collections metadata' do
-        let(:exporter) { FactoryBot.create(:bulkrax_exporter_collection, export_from: 'collections metadata') }
-
-        it 'exports' do
-          expect(exporter).to receive(:create_from_collections_metadata)
-          exporter.export
-        end
-      end
-
       context 'from worktype' do
         let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype) }
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -476,15 +476,15 @@ module Bulkrax
 
       context 'when exporting by collection' do
         let(:exporter) { FactoryBot.create(:bulkrax_exporter_collection) }
+        let(:parent_record_1) { build(:work, id: work_ids_solr.first.id) }
 
         before do
-          allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr.first, collection_ids_solr, file_set_ids_solr.first)
-          parser.instance_variable_set(:@work_ids, [work_ids_solr.first.id])
-          parser.instance_variable_set(:@collection_ids, collection_ids_solr.map(&:id))
-          parser.instance_variable_set(:@file_set_ids, [file_set_ids_solr.first.id])
+          allow(parent_record_1).to receive(:file_set_ids).and_return([file_set_ids_solr.pluck(:id).first])
+          allow(ActiveFedora::SolrService).to receive(:query).and_return([work_ids_solr.first], [collection_ids_solr.first], [collection_ids_solr.last])
+          allow(ActiveFedora::Base).to receive(:find).with(work_ids_solr.first.id).and_return(parent_record_1)
         end
 
-        xit 'exports the collection, child works, child collections, and file sets related to the child works' do
+        it 'exports the collection, child works, child collections, and file sets related to the child works' do
           expect(ExportWorkJob).to receive(:perform_now).exactly(4).times
 
           parser.create_new_entries

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -480,9 +480,8 @@ module Bulkrax
         before do
           allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr.first, collection_ids_solr, file_set_ids_solr.first)
           parser.instance_variable_set(:@work_ids, [work_ids_solr.first.id])
-          parser.instance_variable_set(:@collection_ids, collection_ids_solr.map { |solr| solr.id })
+          parser.instance_variable_set(:@collection_ids, collection_ids_solr.map(&:id))
           parser.instance_variable_set(:@file_set_ids, [file_set_ids_solr.first.id])
-
         end
 
         xit 'exports the collection, child works, child collections, and file sets related to the child works' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -394,7 +394,7 @@ module Bulkrax
       let(:exporter)   { FactoryBot.create(:bulkrax_exporter_worktype) }
       # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
       let(:work_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
-      let(:collection_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
+      let(:collection_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
       let(:file_set_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
 
       it 'invokes Bulkrax::ExportWorkJob once per Entry' do
@@ -431,7 +431,7 @@ module Bulkrax
         end
 
         it 'exports works, collections, and file sets' do
-          expect(ExportWorkJob).to receive(:perform_now).exactly(6).times
+          expect(ExportWorkJob).to receive(:perform_now).exactly(7).times
 
           parser.create_new_entries
         end
@@ -468,9 +468,27 @@ module Bulkrax
             .to change(CsvFileSetEntry, :count)
             .by(3)
             .and change(CsvCollectionEntry, :count)
-            .by(1)
+            .by(2)
             .and change(CsvEntry, :count)
-            .by(6) # 6 csv entries minus 3 file set entries minus 1 collection entry equals 2 work entries
+            .by(7) # 6 csv entries minus 3 file set entries minus 2 collection entries equals 2 work entries
+        end
+      end
+
+      context 'when exporting by collection' do
+        let(:exporter) { FactoryBot.create(:bulkrax_exporter_collection) }
+
+        before do
+          allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr.first, collection_ids_solr, file_set_ids_solr.first)
+          parser.instance_variable_set(:@work_ids, [work_ids_solr.first.id])
+          parser.instance_variable_set(:@collection_ids, collection_ids_solr.map { |solr| solr.id })
+          parser.instance_variable_set(:@file_set_ids, [file_set_ids_solr.first.id])
+
+        end
+
+        xit 'exports the collection, child works, child collections, and file sets related to the child works' do
+          expect(ExportWorkJob).to receive(:perform_now).exactly(4).times
+
+          parser.create_new_entries
         end
       end
     end


### PR DESCRIPTION
# expected behavior
- do not include child collections as part of the @work_ids
- include child collections as part of the @collection_ids
- remove remaining/returned references to "collections metadata"
- return guard clause for bagit files on export

# demo
- 1 parent collection
- 1 child collection
- 2 child works, with 6 file sets between them
(the bag image only shows one of the child works with its associated files)

csv: [export_2_19_1.zip](https://github.com/samvera-labs/bulkrax/files/9134433/export_2_19_1.zip)
bag: [export_3_21_1.zip](https://github.com/samvera-labs/bulkrax/files/9134394/export_3_21_1.zip)

| csv | bag|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/179576093-626474f1-6280-462e-8c30-03a1552638c2.png) | ![image](https://user-images.githubusercontent.com/29032869/179578379-9da2a436-4bb0-44f1-b670-33e1dc03a948.png) |