### PR TITLE
undefined-method-length-for-nil-class

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -75,10 +75,9 @@ module Bulkrax
     def get_field_mapping_hash_for(key)
       return instance_variable_get("@#{key}_hash") if instance_variable_get("@#{key}_hash").present?
 
-      mapping = importerexporter.field_mapping == [{}] ? {} : importerexporter.field_mapping
       instance_variable_set(
         "@#{key}_hash",
-        mapping&.with_indifferent_access&.select { |_, h| h.key?(key) }
+        mapping&.with_indifferent_access&.select { |_, h| h.key?(key) } || {}
       )
       raise StandardError, "more than one #{key} declared: #{instance_variable_get("@#{key}_hash").keys.join(', ')}" if instance_variable_get("@#{key}_hash").length > 1
 

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -77,7 +77,7 @@ module Bulkrax
 
       instance_variable_set(
         "@#{key}_hash",
-        mapping&.with_indifferent_access&.select { |_, h| h.key?(key) } || {}
+        importerexporter.field_mapping&.with_indifferent_access&.select { |_, h| h.key?(key) } || {}
       )
       raise StandardError, "more than one #{key} declared: #{instance_variable_get("@#{key}_hash").keys.join(', ')}" if instance_variable_get("@#{key}_hash").length > 1
 

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -75,9 +75,10 @@ module Bulkrax
     def get_field_mapping_hash_for(key)
       return instance_variable_get("@#{key}_hash") if instance_variable_get("@#{key}_hash").present?
 
+      mapping = importerexporter.field_mapping.is_a?(Hash) ? importerexporter.field_mapping : {}
       instance_variable_set(
         "@#{key}_hash",
-        importerexporter.field_mapping&.with_indifferent_access&.select { |_, h| h.key?(key) } || {}
+        mapping&.with_indifferent_access&.select { |_, h| h.key?(key) }
       )
       raise StandardError, "more than one #{key} declared: #{instance_variable_get("@#{key}_hash").keys.join(', ')}" if instance_variable_get("@#{key}_hash").length > 1
 

--- a/spec/parsers/bulkrax/application_parser_spec.rb
+++ b/spec/parsers/bulkrax/application_parser_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Bulkrax
+  RSpec.describe ApplicationParser do
+    describe '#get_field_mapping_hash_for' do
+      let(:importer) { FactoryBot.create(:bulkrax_importer) }
+      let(:exporter_with_no_field_mapping) { FactoryBot.create(:bulkrax_exporter) }
+      let(:exporter_with_field_mapping) do
+        FactoryBot.create(:bulkrax_exporter, field_mapping: {
+                            "bulkrax_identifier" => { "from" => ["source_identifier"], "source_identifier" => true }
+                          })
+      end
+
+      context 'with `[{}]` as the field mapping' do
+        subject(:application_parser) { described_class.new(importer) }
+
+        it 'returns an empty hash' do
+          expect(application_parser.get_field_mapping_hash_for('source_identifier')).to eq({})
+        end
+      end
+
+      context 'with `nil` as the field mapping' do
+        subject(:application_parser) { described_class.new(exporter_with_no_field_mapping) }
+
+        it 'returns an empty hash' do
+          expect(application_parser.get_field_mapping_hash_for('source_identifier')).to eq({})
+        end
+      end
+
+      context 'with valid field mapping' do
+        subject(:application_parser) { described_class.new(exporter_with_field_mapping) }
+
+        it 'returns the field mapping for the given key' do
+          expect(application_parser.get_field_mapping_hash_for('source_identifier')).to eq({ "bulkrax_identifier" => { "from" => ["source_identifier"], "source_identifier" => true } })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# issue
ran into this issue while running this [rake task](https://github.com/samvera-labs/bulkrax/blob/main/lib/tasks/bulkrax_tasks.rake) on pals for all exporters that were exporting from a collection after updating to `v4.1.0`

sentry error: https://sentry.notch8.com/sentry/pals/issues/142067/
![image](https://user-images.githubusercontent.com/29032869/179631860-7370fcf6-04df-4716-9e82-940a5fda86c7.png)

# expected behavior
- account for when `importerexporter.field_mapping` is `nil` in the "get_field_mapping_hash_for" method

# demo
![image](https://user-images.githubusercontent.com/29032869/179633077-212f8fbb-ba9c-48b6-94c8-f39481ecc539.png)


