### PR TITLE
 ignore-misidentified-collection-entries

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -324,7 +324,7 @@ module Bulkrax
     def write_files
       require 'open-uri'
       folder_count = 0
-      sorted_entries = sort_entries(importerexporter.entries)
+      sorted_entries = sort_entries(importerexporter.entries.uniq(&:identifier))
 
       sorted_entries[0..limit || total].in_groups_of(records_split_count, false) do |group|
         folder_count += 1


### PR DESCRIPTION
# issue
ran into this issue while running this [rake task](https://github.com/samvera-labs/bulkrax/blob/main/lib/tasks/bulkrax_tasks.rake) on pals for all exporters that were exporting from a collection after updating to `v4.1.0`

sentry error: https://sentry.notch8.com/sentry/pals/issues/142068/
![image](https://user-images.githubusercontent.com/29032869/179643839-624f236c-728c-4848-afe8-4155401bc567.png)

# demo
before https://github.com/samvera-labs/bulkrax/pull/597, child collections were exported as a CsvEntry class instead of CsvCollectionEntry. this means that when that importer/exporter is run again, the old entry still exists, but a new one is created as well. the newer entry is at index 0, so calling `uniq` on the identifier value (as seen below), returns index 0.

![Screen Shot 2022-07-18 at 8 37 59 PM](https://user-images.githubusercontent.com/29032869/179645676-ff29a8e4-e49d-4456-a9d4-a4bffc982bc0.png)

# expected behavior
- ignore misidentified collection entries when writing files from the csv parser