### PR TITLE
zip-entry-exists-error

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -264,6 +264,8 @@ module Bulkrax
 
       Dir["#{exporter_export_path}/**"].each do |folder|
         zip_path = "#{exporter_export_zip_path.split('/').last}_#{folder.split('/').last}.zip"
+        FileUtils.rm_rf("#{exporter_export_zip_path}/#{zip_path}")
+
         Zip::File.open(File.join("#{exporter_export_zip_path}/#{zip_path}"), create: true) do |zip_file|
           Dir["#{folder}/**/**"].each do |file|
             zip_file.add(file.sub("#{folder}/", ''), file)


### PR DESCRIPTION
# issue
sentry issue: https://sentry.notch8.com/sentry/pals/issues/142039/
![image](https://user-images.githubusercontent.com/29032869/179791307-922fb6cb-fbd4-4d73-8aeb-75a18ba7bc34.png)


# expected behavior
- remove existing zip files to avoid the Zip::EntryExistsError

# demo
![image](https://user-images.githubusercontent.com/29032869/179791764-7bba7fb7-1d7e-4ba1-ae87-0fdfbc37a57e.png)
