### PR TITLE
avoid-ldp-gone-when-writing-files-on-export

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -342,6 +342,8 @@ module Bulkrax
 
     def store_files(identifier, folder_count)
       record = ActiveFedora::Base.find(identifier)
+      return unless record
+
       file_sets = record.file_set? ? Array.wrap(record) : record.file_sets
       file_sets << record.thumbnail if exporter.include_thumbnails && record.thumbnail.present? && record.work?
       file_sets.each do |fs|


### PR DESCRIPTION
# issue
sentry error: https://sentry.notch8.com/sentry/pals/issues/142081/
![image](https://user-images.githubusercontent.com/29032869/179796981-f3c30eef-bb0b-4b4a-8e2d-ffcf2e8bd085.png)


# expected behavior
- return from #store_files in the csv parser if the record is not found