### PR TITLE
611-base-path-per-tenant

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -134,7 +134,9 @@ module Bulkrax
 
     # Base path for imported and exported files
     def base_path(type = 'import')
-      ENV['HYKU_MULTITENANT'] ? File.join(Bulkrax.send("#{type}_path"), Site.instance.account.name) : Bulkrax.send("#{type}_path")
+      # account for multiple versions of hyku
+      is_multitenant = ENV['HYKU_MULTITENANT'] || ENV['SETTINGS__MULTITENANCY__ENABLED'] == 'true'
+      is_multitenant ? File.join(Bulkrax.send("#{type}_path"), Site.instance.account.name) : Bulkrax.send("#{type}_path")
     end
 
     # Path where we'll store the import metadata and files

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -134,9 +134,9 @@ module Bulkrax
 
     # Base path for imported and exported files
     def base_path(type = 'import')
-      # account for multiple versions of hyku
-      is_multitenant = ENV['HYKU_MULTITENANT'] || ENV['SETTINGS__MULTITENANCY__ENABLED'] == 'true'
-      is_multitenant ? File.join(Bulkrax.send("#{type}_path"), Site.instance.account.name) : Bulkrax.send("#{type}_path")
+      # account for multiple versions of hyku, but don't change the import paths
+      is_multitenant = ENV['HYKU_MULTITENANT'] == 'true' || ENV['SETTINGS__MULTITENANCY__ENABLED'] == 'true'
+      is_multitenant && type == 'export' ? File.join(Bulkrax.send("#{type}_path"), ::Site.instance.account.name) : Bulkrax.send("#{type}_path")
     end
 
     # Path where we'll store the import metadata and files

--- a/lib/tasks/bulkrax_tasks.rake
+++ b/lib/tasks/bulkrax_tasks.rake
@@ -5,26 +5,27 @@ namespace :bulkrax do
   task rerun_all_exporters: :environment do
     if defined?(::Hyku)
       Account.find_each do |account|
-        puts "=============== updating #{account.name} ============"
         next if account.name == "search"
         switch!(account)
+        puts "=============== updating #{account.name} ============"
 
-        rerun_exporters_and_delete_zips
+        make_new_exports
 
         puts "=============== finished updating #{account.name} ============"
       end
     else
-      rerun_exporters_and_delete_zips
+      make_new_exports
     end
   end
 
-  def rerun_exporters_and_delete_zips
+  def make_new_exports
+    # delete the existing folders and zip files
+    Dir["tmp/exports/**"].each { |file| FileUtils.rm_rf(file) }
+
     begin
       Bulkrax::Exporter.all.each { |e| Bulkrax::ExporterJob.perform_later(e.id) }
     rescue => e
       puts "(#{e.message})"
     end
-
-    Dir["tmp/exports/**.zip"].each { |zip_path| FileUtils.rm_rf(zip_path) }
   end
 end

--- a/spec/parsers/bulkrax/application_parser_spec.rb
+++ b/spec/parsers/bulkrax/application_parser_spec.rb
@@ -37,42 +37,5 @@ module Bulkrax
         end
       end
     end
-
-    describe '#base_path' do
-      # TODO(alishaevn): determine if it's a way to get around the "uninitialized constant Bulkrax::Site" error.
-      # or is that against best practices to test for a model that exists in a different app?
-      let(:Site) { instance_double('Site') }
-
-      before do
-        ENV['SETTINGS__MULTITENANCY__ENABLED'] = 'true'
-        # Site.instance.account.name = 'bulkrax'
-
-        # allow(Site.instance.account).to receive(name).and_return('bulkrax')
-
-        # allow(Site).to receive(instance).and_return({})
-        # allow(Site.instance).to receive(account).and_return({})
-        # allow(Site.instance.account).to receive(name).and_return('hyku')
-      end
-
-      context 'in a hyku enabled app' do
-        xit 'sets the import path correctly' do
-          expect(importer.parser.base_path).to eq('tmp/imports/bulkrax')
-        end
-
-        xit 'sets the export path correctly' do
-          expect(importer.parser.base_path).to eq('tmp/exports/bulkrax')
-        end
-      end
-
-      context 'in a hyrax app' do
-        xit 'sets the import path correctly' do
-          expect(importer.parser.base_path).to eq('tmp/imports')
-        end
-
-        xit 'sets the export path correctly' do
-          expect(importer.parser.base_path).to eq('tmp/exports')
-        end
-      end
-    end
   end
 end

--- a/spec/parsers/bulkrax/application_parser_spec.rb
+++ b/spec/parsers/bulkrax/application_parser_spec.rb
@@ -37,5 +37,42 @@ module Bulkrax
         end
       end
     end
+
+    describe '#base_path' do
+      # TODO(alishaevn): determine if it's a way to get around the "uninitialized constant Bulkrax::Site" error.
+      # or is that against best practices to test for a model that exists in a different app?
+      let(:Site) { instance_double('Site') }
+
+      before do
+        ENV['SETTINGS__MULTITENANCY__ENABLED'] = 'true'
+        # Site.instance.account.name = 'bulkrax'
+
+        # allow(Site.instance.account).to receive(name).and_return('bulkrax')
+
+        # allow(Site).to receive(instance).and_return({})
+        # allow(Site.instance).to receive(account).and_return({})
+        # allow(Site.instance.account).to receive(name).and_return('hyku')
+      end
+
+      context 'in a hyku enabled app' do
+        xit 'sets the import path correctly' do
+          expect(importer.parser.base_path).to eq('tmp/imports/bulkrax')
+        end
+
+        xit 'sets the export path correctly' do
+          expect(importer.parser.base_path).to eq('tmp/exports/bulkrax')
+        end
+      end
+
+      context 'in a hyrax app' do
+        xit 'sets the import path correctly' do
+          expect(importer.parser.base_path).to eq('tmp/imports')
+        end
+
+        xit 'sets the export path correctly' do
+          expect(importer.parser.base_path).to eq('tmp/exports')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
ref #611 

# expected behavior
- use the tenant name in the parser export base_path in hyku apps

# demo

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/29032869/177658537-c20d13f5-092f-46b8-a326-9972d68725bf.png) | ![image](https://user-images.githubusercontent.com/29032869/181080181-853627b4-b11f-4a1d-a6e0-ed1df66e50fb.png)|

# info
the spec for this work is being done in #613 