### PR TITLE
611-base-path-per-tenant-v2

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -134,9 +134,9 @@ module Bulkrax
 
     # Base path for imported and exported files
     def base_path(type = 'import')
-      # account for multiple versions of hyku, but don't change the import paths
+      # account for multiple versions of hyku
       is_multitenant = ENV['HYKU_MULTITENANT'] == 'true' || ENV['SETTINGS__MULTITENANCY__ENABLED'] == 'true'
-      is_multitenant && type == 'export' ? File.join(Bulkrax.send("#{type}_path"), ::Site.instance.account.name) : Bulkrax.send("#{type}_path")
+      is_multitenant ? File.join(Bulkrax.send("#{type}_path"), ::Site.instance.account.name) : Bulkrax.send("#{type}_path")
     end
 
     # Path where we'll store the import metadata and files


### PR DESCRIPTION
# expected behavior
- keep the import and export paths the same

# demo
apps that were using the correct ENV variable, did have the export AND import paths separated by tenant name

![image](https://user-images.githubusercontent.com/29032869/181127851-8581bff9-314c-4604-8af5-2acc2aad9a69.png)
