### PR TITLE
account-for-missing-original-file-on-export

### DIFF
--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -134,7 +134,8 @@ module Bulkrax
 
         record.file_sets.each do |fs|
           file_name = filename(fs)
-          next if file_name.blank?
+          next if file_name.blank? || fs.original_file.blank?
+
           io = open(fs.original_file.uri)
           file = Tempfile.new([file_name, File.extname(file_name)], binmode: true)
           file.write(io.read)


### PR DESCRIPTION
# issue
this might be the fix to the issue with pals constantly retrying 2 exporters. per the screen shot below, `.uri` is getting called on a nil class. `.uri` only shows up 3 times in the code. the bagit parser, csv parser and object factory inside of the `#create_file_set` method. we aren't creating, so I figure that's not the problem.

I'd think we should always have a file...but we're doing a check for "if file_set.original_file.blank?" in the `#filename` method in export_behavior.rb too. so I figured there must be a case where it doesn't exist.

<img width="1437" alt="Screen Shot 2022-07-27 at 2 07 33 PM" src="https://user-images.githubusercontent.com/29032869/181389085-5a77cdfc-1efb-4f75-b639-1b16ea77bb4a.png">

# expected behavior
- account for a missing original_file on csv and bagit export

# demo
![Screen Shot 2022-07-27 at 6 04 47 PM](https://user-images.githubusercontent.com/29032869/181389098-c81defb7-6281-4d12-8698-7276f3047603.png)

