### PR TITLE
354-use-configured-base-paths

### DIFF
--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -29,8 +29,8 @@ module Bulkrax
       { name: "XML", class_name: "Bulkrax::XmlParser", partial: "xml_fields" }
     ]
 
-    self.import_path = 'tmp/imports'
-    self.export_path = 'tmp/exports'
+    self.import_path = config.import_path || 'tmp/imports'
+    self.export_path = config.export_path || 'tmp/exports'
     self.removed_image_path = Bulkrax::Engine.root.join('spec', 'fixtures', 'removed.png').to_s
     self.server_name = 'bulkrax@example.com'
 

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -29,8 +29,8 @@ module Bulkrax
       { name: "XML", class_name: "Bulkrax::XmlParser", partial: "xml_fields" }
     ]
 
-    self.import_path = config.import_path || 'tmp/imports'
-    self.export_path = config.export_path || 'tmp/exports'
+    self.import_path = Bulkrax.import_path || 'tmp/imports'
+    self.export_path = Bulkrax.export_path || 'tmp/exports'
     self.removed_image_path = Bulkrax::Engine.root.join('spec', 'fixtures', 'removed.png').to_s
     self.server_name = 'bulkrax@example.com'
 

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -17,20 +17,44 @@ RSpec.describe Bulkrax do
     end
 
     context 'import_path' do
+      after do
+        described_class.import_path = 'tmp/imports'
+      end
+
       it 'responds to import_path' do
         expect(described_class).to respond_to(:import_path)
       end
-      it 'import_path is settable' do
+
+      it 'has a default import_path' do
+        expect(described_class.import_path).to eq('tmp/imports')
+      end
+
+      it 'is settable' do
+        described_class.import_path = 'other/import/path'
+
         expect(described_class).to respond_to(:import_path=)
+        expect(described_class.import_path).to eq('other/import/path')
       end
     end
 
     context 'export_path' do
+      after do
+        described_class.export_path = 'tmp/exports'
+      end
+
       it 'responds to export_path' do
         expect(described_class).to respond_to(:export_path)
       end
+
+      it 'has a default export_path' do
+        expect(described_class.export_path).to eq('tmp/exports')
+      end
+
       it 'export_path is settable' do
+        described_class.export_path = 'other/export/path'
+
         expect(described_class).to respond_to(:export_path=)
+        expect(described_class.export_path).to eq('other/export/path')
       end
     end
 


### PR DESCRIPTION
# expected behavior
- check for the configured import and export paths first

# demo
``` ruby
# Path to store pending imports
config.import_path = 'tmp/my-other-import-path'

# Path to store exports before download
# config.export_path = 'tmp/my-other-export-path'
```

<img width="403" alt="image" src="https://user-images.githubusercontent.com/29032869/183234967-2a4f8a72-0e32-40c4-aca8-b24edb97d246.png">
