### PR TITLE
🐛 add `required` for `Export From` fields

### DIFF
--- a/app/assets/javascripts/bulkrax/exporters.js
+++ b/app/assets/javascripts/bulkrax/exporters.js
@@ -1,15 +1,27 @@
 function hideUnhide(field) {
   var allSources = $('body').find('.export-source-option')
+  removeRequired(allSources)
   hide(allSources)
 
   if (field.length > 0) {
     var selectedSource = $('.' + field)
     unhideSelected(selectedSource)
+    addRequired(selectedSource)
   }
 
   if (field === 'collection') {
     initCollectionSearchInputs();
   }
+};
+
+function addRequired(selectedSource) {  
+  selectedSource.addClass('required').attr('required', 'required');
+  selectedSource.parent().addClass('required');
+}
+
+function removeRequired(allSources) {
+  allSources.removeClass('required').removeAttr('required');
+  allSources.parent().removeClass('required').removeAttr('required')
 };
 
 // hide all export_source

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -29,7 +29,7 @@
 
   <%= form.input :export_source_importer,
     label: t('bulkrax.exporter.labels.importer'),
-    # required: true,
+    required: true,
     prompt: 'Select from the list',
     label_html: { class: 'importer export-source-option hidden' },
     input_html: { class: 'importer export-source-option hidden' },
@@ -38,7 +38,7 @@
   <%= form.input :export_source_collection,
     prompt: 'Start typing ...',
     label: t('bulkrax.exporter.labels.collection'),
-    # required: true,
+    required: true,
     placeholder: @collection&.title&.first,
     label_html: { class: 'collection export-source-option hidden' },
     input_html: {
@@ -52,7 +52,7 @@
 
   <%= form.input :export_source_worktype,
     label: t('bulkrax.exporter.labels.worktype'),
-    # required: true,
+    required: true,
     prompt: 'Select from the list',
     label_html: { class: 'worktype export-source-option hidden' },
     input_html: { class: 'worktype export-source-option hidden' },


### PR DESCRIPTION
Ref: https://github.com/samvera-labs/bulkrax/issues/538
Original PR: https://github.com/samvera-labs/bulkrax/pull/575 (see for additional screenshots)

# Summary
- uncomment required attr for exporter from fields
- add javascript to handle required attrs while hidden

# Details
- original pr did not have javascript to handle required fields while hidden and thus was reverted in https://github.com/samvera-labs/bulkrax/pull/580 because it prevented the use from moving on to the next page

# Screenshot
![bulkrax-538](https://user-images.githubusercontent.com/19597776/183303264-398808cd-3792-4901-911b-a8c6e7c8672f.gif)

