### PR TITLE
635 update default split value

### DIFF
--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -30,7 +30,7 @@ module Bulkrax
 
     def process_split
       if self.split.is_a?(TrueClass)
-        @result = @result.split(/\s*[|]\s*/) # default split by "|""
+        @result = @result.split(/\s*[|]\s*/) # default split by "|"
       elsif self.split
         result = @result.split(Regexp.new(self.split))
         @result = result.map(&:strip)

--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -30,7 +30,7 @@ module Bulkrax
 
     def process_split
       if self.split.is_a?(TrueClass)
-        @result = @result.split(/\s*[:;|]\s*/) # default split by : ; |
+        @result = @result.split(/\s*[|]\s*/) # default split by "|""
       elsif self.split
         result = @result.split(Regexp.new(self.split))
         @result = result.map(&:strip)

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -92,7 +92,7 @@ module Bulkrax
         field.to_s =>
         {
           from: [field.to_s],
-          split: false,
+          split: true,
           parsed: Bulkrax::ApplicationMatcher.method_defined?("parse_#{field}"),
           if: nil,
           excluded: false

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Bulkrax do
       end
 
       it 'is responds with default hash' do
-        expect(described_class.default_field_mapping.call('creator')).to eq("creator" => { excluded: false, from: ["creator"], if: nil, parsed: false, split: false })
+        expect(described_class.default_field_mapping.call('creator')).to eq("creator" => { excluded: false, from: ["creator"], if: nil, parsed: false, split: true })
       end
     end
 

--- a/spec/matchers/bulkrax/application_matcher_spec.rb
+++ b/spec/matchers/bulkrax/application_matcher_spec.rb
@@ -8,7 +8,7 @@ module Bulkrax
       it 'default split' do
         matcher = described_class.new(split: true)
         result = matcher.result(nil, " hey ; how : are | you")
-        expect(result).to eq(["hey", "how", "are", "you"])
+        expect(result).to eq(["hey ; how : are", "you"])
       end
 
       it 'custom regex split' do
@@ -21,12 +21,6 @@ module Bulkrax
         matcher = described_class.new(split: false)
         result = matcher.result(nil, " hey ; how : are | you")
         expect(result).to eq("hey ; how : are | you")
-      end
-
-      it 'custom split' do
-        matcher = described_class.new(split: '\|')
-        result = matcher.result(nil, " hey ; how : are | you")
-        expect(result).to eq(["hey ; how : are", "you"])
       end
     end
   end

--- a/spec/models/bulkrax/importer_spec.rb
+++ b/spec/models/bulkrax/importer_spec.rb
@@ -52,21 +52,21 @@ module Bulkrax
       context 'oai_parser' do
         it 'retrieves the default field mapping for oai_dc' do
           expect(importer.mapping).to eq(
-            "contributor" => { "excluded" => false, "from" => ["contributor"], "if" => nil, "parsed" => false, "split" => false },
-            "coverage" => { "excluded" => false, "from" => ["coverage"], "if" => nil, "parsed" => false, "split" => false },
-            "creator" => { "excluded" => false, "from" => ["creator"], "if" => nil, "parsed" => false, "split" => false },
-            "date" => { "excluded" => false, "from" => ["date"], "if" => nil, "parsed" => false, "split" => false },
-            "description" => { "excluded" => false, "from" => ["description"], "if" => nil, "parsed" => false, "split" => false },
-            "format" => { "excluded" => false, "from" => ["format"], "if" => nil, "parsed" => false, "split" => false },
-            "identifier" => { "excluded" => false, "from" => ["identifier"], "if" => nil, "parsed" => false, "split" => false },
-            "language" => { "excluded" => false, "from" => ["language"], "if" => nil, "parsed" => true, "split" => false },
-            "publisher" => { "excluded" => false, "from" => ["publisher"], "if" => nil, "parsed" => false, "split" => false },
-            "relation" => { "excluded" => false, "from" => ["relation"], "if" => nil, "parsed" => false, "split" => false },
-            "rights" => { "excluded" => false, "from" => ["rights"], "if" => nil, "parsed" => false, "split" => false },
-            "source" => { "excluded" => false, "from" => ["source"], "if" => nil, "parsed" => false, "split" => false },
-            "subject" => { "excluded" => false, "from" => ["subject"], "if" => nil, "parsed" => true, "split" => false },
-            "title" => { "excluded" => false, "from" => ["title"], "if" => nil, "parsed" => false, "split" => false },
-            "type" => { "excluded" => false, "from" => ["type"], "if" => nil, "parsed" => false, "split" => false }
+            "contributor" => { "excluded" => false, "from" => ["contributor"], "if" => nil, "parsed" => false, "split" => true },
+            "coverage" => { "excluded" => false, "from" => ["coverage"], "if" => nil, "parsed" => false, "split" => true },
+            "creator" => { "excluded" => false, "from" => ["creator"], "if" => nil, "parsed" => false, "split" => true },
+            "date" => { "excluded" => false, "from" => ["date"], "if" => nil, "parsed" => false, "split" => true },
+            "description" => { "excluded" => false, "from" => ["description"], "if" => nil, "parsed" => false, "split" => true },
+            "format" => { "excluded" => false, "from" => ["format"], "if" => nil, "parsed" => false, "split" => true },
+            "identifier" => { "excluded" => false, "from" => ["identifier"], "if" => nil, "parsed" => false, "split" => true },
+            "language" => { "excluded" => false, "from" => ["language"], "if" => nil, "parsed" => true, "split" => true },
+            "publisher" => { "excluded" => false, "from" => ["publisher"], "if" => nil, "parsed" => false, "split" => true },
+            "relation" => { "excluded" => false, "from" => ["relation"], "if" => nil, "parsed" => false, "split" => true },
+            "rights" => { "excluded" => false, "from" => ["rights"], "if" => nil, "parsed" => false, "split" => true },
+            "source" => { "excluded" => false, "from" => ["source"], "if" => nil, "parsed" => false, "split" => true },
+            "subject" => { "excluded" => false, "from" => ["subject"], "if" => nil, "parsed" => true, "split" => true },
+            "title" => { "excluded" => false, "from" => ["title"], "if" => nil, "parsed" => false, "split" => true },
+            "type" => { "excluded" => false, "from" => ["type"], "if" => nil, "parsed" => false, "split" => true }
           )
         end
       end
@@ -77,10 +77,10 @@ module Bulkrax
 
         it 'creates a default mapping from the column headers' do
           expect(importer.mapping).to eq(
-            "model" => { "excluded" => false, "from" => ["model"], "if" => nil, "parsed" => true, "split" => false },
-            "parents_column" => { "excluded" => false, "from" => ["parents_column"], "if" => nil, "parsed" => false, "split" => false },
-            "source_identifier" => { "excluded" => false, "from" => ["source_identifier"], "if" => nil, "parsed" => false, "split" => false },
-            "title" => { "excluded" => false, "from" => ["title"], "if" => nil, "parsed" => false, "split" => false }
+            "model" => { "excluded" => false, "from" => ["model"], "if" => nil, "parsed" => true, "split" => true },
+            "parents_column" => { "excluded" => false, "from" => ["parents_column"], "if" => nil, "parsed" => false, "split" => true },
+            "source_identifier" => { "excluded" => false, "from" => ["source_identifier"], "if" => nil, "parsed" => false, "split" => true },
+            "title" => { "excluded" => false, "from" => ["title"], "if" => nil, "parsed" => false, "split" => true }
           )
         end
       end


### PR DESCRIPTION
# expected behavior
- the default split value is now "true" do to reasons listed [in the issue](https://github.com/samvera-labs/bulkrax/issues/635)
- split will default to a pipe ("|") only because the semi-colon (";") is a valid character in the `remote_url` header. also removed the colon (":") as an option because I think it could mess up in the same place.


this is still a draft because I haven't tested this code, but these are the changes that felt right to me by just looking at the code.