### PR TITLE
pass attrs to actor stack to be used for visibility of filesets

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -166,7 +166,7 @@ module Bulkrax
         actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
         uploaded_file.update(file_set_uri: actor.file_set.uri)
         actor.file_set.permissions_attributes = work_permissions
-        actor.create_metadata
+        actor.create_metadata(attrs)
         actor.create_content(uploaded_file)
         actor.attach_to_work(work, attrs)
       end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -168,7 +168,7 @@ module Bulkrax
         actor.file_set.permissions_attributes = work_permissions
         actor.create_metadata
         actor.create_content(uploaded_file)
-        actor.attach_to_work(work)
+        actor.attach_to_work(work, attrs)
       end
 
       object.save!


### PR DESCRIPTION
ref #639 

# Summary
- pass in `attrs` to the actor stack since it contains the visibility of the individual filesets
- a pr/override needs to be made in Hyrax `FileSetActor` to make this work in projects

![image](https://user-images.githubusercontent.com/19597776/186475769-edec391d-c201-4999-969b-bc2e671892ff.png)
