### PR TITLE
Ensuring that we load the Bulkrax::VERSION

### DIFF
--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bulkrax/version"
 require "bulkrax/engine"
 require 'active_support/all'
 


### PR DESCRIPTION
By requiring this file, upstream applications can then interrogate what
version of Bulkrax is running.  This can be helpful for coordinating
local overrides in the application that can/should/will be merged into
Bulkrax but due to time constraints are not immediately available.

See [Responsible Monkey Patching of Ruby Methods // Take on Rules][1]
for some further details

Closes samvera-labs/bulkrax#641

[1]:(https://takeonrules.com/2022/07/06/responsible-monkey-patching-of-ruby-methods/)