### PR TITLE
i646 - process remote files for filesets

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -165,27 +165,37 @@ module Bulkrax
 
         create_file_set_actor(attrs, work, work_permissions, uploaded_file)
       end
-
-      attrs['remote_files']&.each do |_file|
-        create_file_set_actor(attrs, work, work_permissions, nil)
+      # binding.pry
+      attrs['remote_files']&.each do |remote_file|
+        create_file_set_actor(attrs, work, work_permissions, nil, remote_file)
       end
 
       object.save!
     end
-
-    def create_file_set_actor(attrs, work, work_permissions, uploaded_file)
+    def create_file_set_actor(attrs, work, work_permissions, uploaded_file, remote_file = nil)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
       uploaded_file&.update(file_set_uri: actor.file_set.uri)
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(attrs)
       actor.create_content(uploaded_file) if uploaded_file
+      if remote_file
+        tmp_file = open(remote_file['url'])
+        actor.create_content(tmp_file, from_url: true) 
+        tmp_file.close
+      end
       actor.attach_to_work(work, attrs)
     end
+
+    
 
     def update_file_set(attrs)
       file_set_attrs = attrs.slice(*object.attributes.keys)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
-
+      attrs['remote_files']&.each do |remote_file|
+        tmp_file = open(remote_file['url'])
+        actor.update_content(tmp_file) 
+        tmp_file.close      
+      end
       actor.update_metadata(file_set_attrs)
     end
 

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -196,8 +196,6 @@ module Bulkrax
       actor.attach_to_work(work, attrs)
     end
 
-    
-
     def update_file_set(attrs)
       file_set_attrs = attrs.slice(*object.attributes.keys)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -171,9 +171,9 @@ module Bulkrax
 
       object.save!
     end
+
     def create_file_set_actor(attrs, work, work_permissions, uploaded_file, remote_file = nil)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
-
       uploaded_file&.update(file_set_uri: actor.file_set.uri)
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(attrs)
@@ -203,7 +203,7 @@ module Bulkrax
       attrs['remote_files']&.each do |remote_file|
         tmp_file = open(remote_file['url'])
         actor.update_content(tmp_file)
-        tmp_file.close 
+        tmp_file.close
       end
       actor.update_metadata(file_set_attrs)
     end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -211,7 +211,7 @@ module Bulkrax
 
         tmp_file.rewind
         actor.update_content(tmp_file)
-        tmp_file.close 
+        tmp_file.close
       end
       actor.update_metadata(file_set_attrs)
     end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -201,9 +201,17 @@ module Bulkrax
       file_set_attrs = attrs.slice(*object.attributes.keys)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
       attrs['remote_files']&.each do |remote_file|
-        tmp_file = open(remote_file['url'])
+        url = remote_file['url']
+        tmp_file = Tempfile.new(remote_file['file_name'].split('.').first)
+        tmp_file.binmode
+
+        open(url) do |url_file|
+          tmp_file.write(url_file.read)
+        end
+
+        tmp_file.rewind
         actor.update_content(tmp_file)
-        tmp_file.close
+        tmp_file.close 
       end
       actor.update_metadata(file_set_attrs)
     end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -173,6 +173,7 @@ module Bulkrax
     end
     def create_file_set_actor(attrs, work, work_permissions, uploaded_file, remote_file = nil)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
+
       uploaded_file&.update(file_set_uri: actor.file_set.uri)
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(attrs)
@@ -184,13 +185,13 @@ module Bulkrax
         url = remote_file['url']
         tmp_file = Tempfile.new(remote_file['file_name'].split('.').first)
         tmp_file.binmode
-        
+
         open(url) do |url_file|
           tmp_file.write(url_file.read)
         end
-        
+
         tmp_file.rewind
-        actor.create_content(tmp_file, from_url: true) 
+        actor.create_content(tmp_file, from_url: true)
         tmp_file.close
       end
       actor.attach_to_work(work, attrs)
@@ -201,8 +202,8 @@ module Bulkrax
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
       attrs['remote_files']&.each do |remote_file|
         tmp_file = open(remote_file['url'])
-        actor.update_content(tmp_file) 
-        tmp_file.close      
+        actor.update_content(tmp_file)
+        tmp_file.close 
       end
       actor.update_metadata(file_set_attrs)
     end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -165,7 +165,6 @@ module Bulkrax
 
         create_file_set_actor(attrs, work, work_permissions, uploaded_file)
       end
-      # binding.pry
       attrs['remote_files']&.each do |remote_file|
         create_file_set_actor(attrs, work, work_permissions, nil, remote_file)
       end
@@ -179,7 +178,18 @@ module Bulkrax
       actor.create_metadata(attrs)
       actor.create_content(uploaded_file) if uploaded_file
       if remote_file
-        tmp_file = open(remote_file['url'])
+        actor.file_set.label = remote_file['file_name']
+        actor.file_set.import_url = remote_file['url']
+
+        url = remote_file['url']
+        tmp_file = Tempfile.new(remote_file['file_name'].split('.').first)
+        tmp_file.binmode
+        
+        open(url) do |url_file|
+          tmp_file.write(url_file.read)
+        end
+        
+        tmp_file.rewind
         actor.create_content(tmp_file, from_url: true) 
         tmp_file.close
       end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -178,22 +178,7 @@ module Bulkrax
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(attrs)
       actor.create_content(uploaded_file) if uploaded_file
-      if remote_file
-        actor.file_set.label = remote_file['file_name']
-        actor.file_set.import_url = remote_file['url']
-
-        url = remote_file['url']
-        tmp_file = Tempfile.new(remote_file['file_name'].split('.').first)
-        tmp_file.binmode
-
-        open(url) do |url_file|
-          tmp_file.write(url_file.read)
-        end
-
-        tmp_file.rewind
-        actor.create_content(tmp_file, from_url: true)
-        tmp_file.close
-      end
+      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if remote_file
       actor.attach_to_work(work, attrs)
     end
 
@@ -201,19 +186,26 @@ module Bulkrax
       file_set_attrs = attrs.slice(*object.attributes.keys)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
       attrs['remote_files']&.each do |remote_file|
-        url = remote_file['url']
-        tmp_file = Tempfile.new(remote_file['file_name'].split('.').first)
-        tmp_file.binmode
-
-        open(url) do |url_file|
-          tmp_file.write(url_file.read)
-        end
-
-        tmp_file.rewind
-        actor.update_content(tmp_file)
-        tmp_file.close
+        handle_remote_file(remote_file: remote_file, actor: actor, update: true)
       end
       actor.update_metadata(file_set_attrs)
+    end
+
+    def handle_remote_file(remote_file:, actor:, update: false)
+      actor.file_set.label = remote_file['file_name']
+      actor.file_set.import_url = remote_file['url']
+
+      url = remote_file['url']
+      tmp_file = Tempfile.new(remote_file['file_name'].split('.').first)
+      tmp_file.binmode
+
+      open(url) do |url_file|
+        tmp_file.write(url_file.read)
+      end
+
+      tmp_file.rewind
+      update == true ? actor.update_content(tmp_file) : actor.create_content(tmp_file, from_url: true)
+      tmp_file.close
     end
 
     def clean_attrs(attrs)


### PR DESCRIPTION
ref: #646 

Import a csv with file set in its own row. If the FileSet row has a remote_files column, it should download those files and attach it to the FileSet. 

Sample file: 
[cats-2.csv](https://github.com/samvera-labs/bulkrax/files/9480243/cats-2.csv)





<img width="976" alt="Screen Shot 2022-09-02 at 11 22 39 AM" src="https://user-images.githubusercontent.com/10081604/188214892-4dcc73de-3f60-46f7-820d-5b7ccbbca476.png">

<img width="1141" alt="Screen Shot 2022-09-02 at 11 23 33 AM" src="https://user-images.githubusercontent.com/10081604/188215022-d78abf9b-7a75-443d-9bba-b995c6c6bea4.png">

<img width="1045" alt="Screen Shot 2022-09-02 at 11 23 12 AM" src="https://user-images.githubusercontent.com/10081604/188214977-5e6f4528-a8b1-49a8-9294-87aa7447f519.png">

Downloaded file: 
![Thinking-of-getting-a-cat20220901-696-1rxengo(2)](https://user-images.githubusercontent.com/10081604/188215149-c774a2c1-87ee-4371-a7d0-60f7d738662a.png)

UPDATE csv/importer - it should update the images seen above.
[update-cats-2.csv](https://github.com/samvera-labs/bulkrax/files/9481226/update-cats-2.csv)

<img width="1097" alt="Screen Shot 2022-09-02 at 2 53 08 PM" src="https://user-images.githubusercontent.com/10081604/188240021-50c4bf0f-68eb-41fe-a53b-c5254e2b24e0.png">

## Known Issue

This produces a Sidekiq error from a [hyrax](https://github.com/samvera/hyrax/blob/main/app/jobs/visibility_copy_job.rb#L12) misspelling. [This method](https://github.com/samvera/hyrax/blob/b034218b89dde7df534e32d1e5ade9161e129a1d/app/services/hyrax/visibility_propagator.rb#L39) probably should get updated to '[propagate](https://github.com/samvera/hyrax/search?q=propagate)'. But this fix is a hyrax concern: 

<img width="1247" alt="Screen Shot 2022-09-02 at 2 28 29 PM" src="https://user-images.githubusercontent.com/10081604/188237696-ab489575-62a8-4404-a147-d293d49132b8.png">


