### PR TITLE
call URI.open due to deprecation warning msg

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -199,7 +199,7 @@ module Bulkrax
       tmp_file = Tempfile.new(remote_file['file_name'].split('.').first)
       tmp_file.binmode
 
-      open(url) do |url_file|
+      URI.open(url) do |url_file|
         tmp_file.write(url_file.read)
       end
 


### PR DESCRIPTION
Minor update to explicitly call URI.open instead of open, as suggested via a deprecation warning msg. 