### PR TITLE
i638-create-content-for-remote-files

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -174,11 +174,12 @@ module Bulkrax
 
     def create_file_set_actor(attrs, work, work_permissions, file, type:)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
-      file&.update(file_set_uri: actor.file_set.uri) if type = 'uploaded'
+      # TODO(alishaevn): confirm that the line below doesn't need to be applied to remote files too
+      file&.update(file_set_uri: actor.file_set.uri) if type == 'uploaded'
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(attrs)
       actor.create_content(file)
-      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if type = 'remote'
+      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if type == 'remote'
       actor.attach_to_work(work, attrs)
     end
 

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -163,22 +163,22 @@ module Bulkrax
         uploaded_file = ::Hyrax::UploadedFile.find(uploaded_file_id)
         next if uploaded_file.file_set_uri.present?
 
-        create_file_set_actor(attrs, work, work_permissions, uploaded_file)
+        create_file_set_actor(attrs, work, work_permissions, uploaded_file, type: 'uploaded')
       end
       attrs['remote_files']&.each do |remote_file|
-        create_file_set_actor(attrs, work, work_permissions, nil, remote_file)
+        create_file_set_actor(attrs, work, work_permissions, remote_file, type: 'remote')
       end
 
       object.save!
     end
 
-    def create_file_set_actor(attrs, work, work_permissions, uploaded_file, remote_file = nil)
+    def create_file_set_actor(attrs, work, work_permissions, file, type:)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
-      uploaded_file&.update(file_set_uri: actor.file_set.uri)
+      file&.update(file_set_uri: actor.file_set.uri) if type = 'uploaded'
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(attrs)
-      actor.create_content(uploaded_file) if uploaded_file
-      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if remote_file
+      actor.create_content(file)
+      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if type = 'remote'
       actor.attach_to_work(work, attrs)
     end
 


### PR DESCRIPTION
ref: https://gitlab.com/notch8/utk-hyku/-/issues/173#note_1090318824

# expected behavior
- call `#create_content` in the file set actor method for remote files too

# demo
![image](https://user-images.githubusercontent.com/29032869/188782119-212cf716-8ce9-4e77-b55a-c399c15aa692.png)
