### PR TITLE
Adding Bulkrax config for multi-value split/join delimiters

### DIFF
--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -30,7 +30,7 @@ module Bulkrax
 
     def process_split
       if self.split.is_a?(TrueClass)
-        @result = @result.split(/\s*[:;|]\s*/) # default split by : ; |
+        @result = @result.split(Bulkrax.multi_value_element_split_on)
       elsif self.split
         result = @result.split(Regexp.new(self.split))
         @result = result.map(&:strip)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -81,7 +81,7 @@ module Bulkrax
     def add_file
       self.parsed_metadata['file'] ||= []
       if record['file']&.is_a?(String)
-        self.parsed_metadata['file'] = record['file'].split(/\s*[;|]\s*/)
+        self.parsed_metadata['file'] = record['file'].split(Bulkrax.multi_value_element_split_on)
       elsif record['file'].is_a?(Array)
         self.parsed_metadata['file'] = record['file']
       end
@@ -176,7 +176,7 @@ module Bulkrax
       data = hyrax_record.send(key.to_s)
       if data.is_a?(ActiveTriples::Relation)
         if value['join']
-          self.parsed_metadata[key_for_export(key)] = data.map { |d| prepare_export_data(d) }.join(' | ').to_s # TODO: make split char dynamic
+          self.parsed_metadata[key_for_export(key)] = data.map { |d| prepare_export_data(d) }.join(Bulkrax.multi_value_element_join_on).to_s
         else
           data.each_with_index do |d, i|
             self.parsed_metadata["#{key_for_export(key)}_#{i + 1}"] = prepare_export_data(d)
@@ -236,7 +236,7 @@ module Bulkrax
 
     def handle_join_on_export(key, values, join)
       if join
-        parsed_metadata[key] = values.join(' | ') # TODO: make split char dynamic
+        parsed_metadata[key] = values.join(Bulkrax.multi_value_element_join_on)
       else
         values.each_with_index do |value, i|
           parsed_metadata["#{key}_#{i + 1}"] = value
@@ -260,7 +260,7 @@ module Bulkrax
       return [] unless parent_field_mapping.present? && record[parent_field_mapping].present?
 
       identifiers = []
-      split_references = record[parent_field_mapping].split(/\s*[;|]\s*/)
+      split_references = record[parent_field_mapping].split(Bulkrax.multi_value_element_split_on)
       split_references.each do |c_reference|
         matching_collection_entries = importerexporter.entries.select do |e|
           (e.raw_metadata&.[](source_identifier) == c_reference) &&

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -440,7 +440,7 @@ module Bulkrax
         file_mapping = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from)&.first&.to_sym || :file
         next if r[file_mapping].blank?
 
-        r[file_mapping].split(/\s*[:;|]\s*/).map do |f|
+        r[file_mapping].split(Bulkrax.multi_value_element_split_on).map do |f|
           file = File.join(path_to_files, f.tr(' ', '_'))
           if File.exist?(file) # rubocop:disable Style/GuardClause
             file
@@ -468,7 +468,7 @@ module Bulkrax
       entry_uid ||= if Bulkrax.fill_in_blank_source_identifiers.present?
                       Bulkrax.fill_in_blank_source_identifiers.call(self, records.find_index(collection_hash))
                     else
-                      collection_hash[:title].split(/\s*[;|]\s*/).first
+                      collection_hash[:title].split(Bulkrax.multi_value_element_split_on).first
                     end
 
       entry_uid

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -6,21 +6,23 @@ require 'active_support/all'
 
 module Bulkrax
   class << self
-    mattr_accessor :parsers,
-                   :default_work_type,
+    mattr_accessor :api_definition,
                    :default_field_mapping,
+                   :default_work_type,
+                   :export_path,
+                   :field_mappings,
                    :fill_in_blank_source_identifiers,
                    :generated_metadata_mapping,
+                   :import_path,
+                   :multi_value_element_join_on,
+                   :multi_value_element_split_on,
+                   :parsers,
+                   :qa_controlled_properties,
                    :related_children_field_mapping,
                    :related_parents_field_mapping,
-                   :reserved_properties,
-                   :qa_controlled_properties,
-                   :field_mappings,
-                   :import_path,
-                   :export_path,
                    :removed_image_path,
-                   :server_name,
-                   :api_definition
+                   :reserved_properties,
+                   :server_name
 
     self.parsers = [
       { name: "OAI - Dublin Core", class_name: "Bulkrax::OaiDcParser", partial: "oai_fields" },
@@ -136,6 +138,29 @@ module Bulkrax
         ).result
       )
     )
+  end
+
+  DEFAULT_MULTI_VALUE_ELEMENT_JOIN_ON = ' | '
+  # Specify the delimiter for joining an attribute's multi-value array into a string.
+  #
+  # @note the specific delimeter should likely be present in the multi_value_element_split_on
+  #       expression.
+  def self.multi_value_element_join_on
+    @multi_value_element_join_on ||= DEFAULT_MULTI_VALUE_ELEMENT_JOIN_ON
+  end
+
+  DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON = /\s*[:;|]\s*/.freeze
+  # @return [RegexClass] the regular express to use to "split" an attribute's values.  If set to
+  # `true` use the DEFAULT_MULTI_VALUE_ELEMENT_JOIN_ON.
+  #
+  # @note The "true" value is to preserve backwards compatibility.
+  # @see DEFAULT_MULTI_VALUE_ELEMENT_JOIN_ON
+  def self.multi_value_element_split_on
+    if @multi_value_element_join_on.is_a?(TrueClass)
+      DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON
+    else
+      @multi_value_element_split_on ||= DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON
+    end
   end
 
   # this function maps the vars from your app into your engine

--- a/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
+++ b/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
@@ -67,6 +67,13 @@ Bulkrax.setup do |config|
   # is controlled by the active terms in config/authorities/rights_statements.yml
   # Defaults: 'rights_statement' and 'license'
   # config.qa_controlled_properties += ['my_field']
+
+  # Specify the delimiter regular expression for splitting an attribute's values into a multi-value array.
+  # config.multi_value_element_split_on = //\s*[:;|]\s*/.freeze
+
+  # Specify the delimiter for joining an attribute's multi-value array into a string.  Note: the
+  # specific delimeter should likely be present in the multi_value_element_split_on expression.
+  # config.multi_value_element_join_on = ' | '
 end
 
 # Sidebar for hyrax 3+ support


### PR DESCRIPTION
Prior to this commit, we had "magic" strings/regexs sprinkled throughout the code.  This change now moves that towards a consistent and configurable interface.

There are two nuances:

1. The collections title split now includes a new default (e.g. `;`) in the split.  That may introduce a bug.
2. This preserves the ability to specify `split: true` and use the default; which creates the least invasive change for downstream adopters.

Closes #429, #213