### PR TITLE
downgrade-migration-versions-to-five-point-one

### DIFF
--- a/db/migrate/20211203195233_rename_children_counters_to_relationships.rb
+++ b/db/migrate/20211203195233_rename_children_counters_to_relationships.rb
@@ -1,4 +1,4 @@
-class RenameChildrenCountersToRelationships < ActiveRecord::Migration[5.2]
+class RenameChildrenCountersToRelationships < ActiveRecord::Migration[5.1]
   def change
     rename_column :bulkrax_importer_runs, :processed_children, :processed_relationships unless column_exists?(:bulkrax_importer_runs, :processed_relationships)
     rename_column :bulkrax_importer_runs, :failed_children, :failed_relationships unless column_exists?(:bulkrax_importer_runs, :failed_relationships)

--- a/db/migrate/20211220195027_add_file_set_counters_to_importer_runs.rb
+++ b/db/migrate/20211220195027_add_file_set_counters_to_importer_runs.rb
@@ -1,4 +1,4 @@
-class AddFileSetCountersToImporterRuns < ActiveRecord::Migration[5.2]
+class AddFileSetCountersToImporterRuns < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_importer_runs, :processed_file_sets, :integer, default: 0 unless column_exists?(:bulkrax_importer_runs, :processed_file_sets)
     add_column :bulkrax_importer_runs, :failed_file_sets, :integer, default: 0 unless column_exists?(:bulkrax_importer_runs, :failed_file_sets)

--- a/db/migrate/20220118001339_add_import_attempts_to_entries.rb
+++ b/db/migrate/20220118001339_add_import_attempts_to_entries.rb
@@ -1,4 +1,4 @@
-class AddImportAttemptsToEntries < ActiveRecord::Migration[5.2]
+class AddImportAttemptsToEntries < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_entries, :import_attempts, :integer, default: 0 unless column_exists?(:bulkrax_entries, :import_attempts)
   end

--- a/db/migrate/20220119213325_add_work_counters_to_importer_runs.rb
+++ b/db/migrate/20220119213325_add_work_counters_to_importer_runs.rb
@@ -1,4 +1,4 @@
-class AddWorkCountersToImporterRuns < ActiveRecord::Migration[5.2]
+class AddWorkCountersToImporterRuns < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_importer_runs, :processed_works, :integer, default: 0 unless column_exists?(:bulkrax_importer_runs, :processed_works)
     add_column :bulkrax_importer_runs, :failed_works, :integer, default: 0 unless column_exists?(:bulkrax_importer_runs, :failed_works)

--- a/db/migrate/20220301001839_create_bulkrax_pending_relationships.rb
+++ b/db/migrate/20220301001839_create_bulkrax_pending_relationships.rb
@@ -1,4 +1,4 @@
-class CreateBulkraxPendingRelationships < ActiveRecord::Migration[5.2]
+class CreateBulkraxPendingRelationships < ActiveRecord::Migration[5.1]
   def change
     unless table_exists?(:bulkrax_pending_relationships)
       create_table :bulkrax_pending_relationships do |t|

--- a/db/migrate/20220303212810_add_order_to_bulkrax_pending_relationships.rb
+++ b/db/migrate/20220303212810_add_order_to_bulkrax_pending_relationships.rb
@@ -1,4 +1,4 @@
-class AddOrderToBulkraxPendingRelationships < ActiveRecord::Migration[5.2]
+class AddOrderToBulkraxPendingRelationships < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_pending_relationships, :order, :integer, default: 0 unless column_exists?(:bulkrax_pending_relationships, :order)
   end

--- a/db/migrate/20220412233954_add_include_thumbnails_to_bulkrax_exporters.rb
+++ b/db/migrate/20220412233954_add_include_thumbnails_to_bulkrax_exporters.rb
@@ -1,4 +1,4 @@
-class AddIncludeThumbnailsToBulkraxExporters < ActiveRecord::Migration[5.2]
+class AddIncludeThumbnailsToBulkraxExporters < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_exporters, :include_thumbnails, :boolean, default: false unless column_exists?(:bulkrax_exporters, :include_thumbnails)
   end

--- a/db/migrate/20220413180915_add_generated_metadata_to_bulkrax_exporters.rb
+++ b/db/migrate/20220413180915_add_generated_metadata_to_bulkrax_exporters.rb
@@ -1,4 +1,4 @@
-class AddGeneratedMetadataToBulkraxExporters < ActiveRecord::Migration[5.2]
+class AddGeneratedMetadataToBulkraxExporters < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_exporters, :generated_metadata, :boolean, default: false unless column_exists?(:bulkrax_exporters, :generated_metadata)
   end

--- a/db/migrate/20220609001128_rename_bulkrax_importer_run_to_importer_run.rb
+++ b/db/migrate/20220609001128_rename_bulkrax_importer_run_to_importer_run.rb
@@ -1,4 +1,4 @@
-class RenameBulkraxImporterRunToImporterRun < ActiveRecord::Migration[5.2]
+class RenameBulkraxImporterRunToImporterRun < ActiveRecord::Migration[5.1]
   def up
     if column_exists?(:bulkrax_pending_relationships, :bulkrax_importer_run_id)
       remove_foreign_key :bulkrax_pending_relationships, :bulkrax_importer_runs

--- a/spec/test_app/db/migrate/20220726162605_create_site.rb
+++ b/spec/test_app/db/migrate/20220726162605_create_site.rb
@@ -1,4 +1,4 @@
-class CreateSite < ActiveRecord::Migration[5.2]
+class CreateSite < ActiveRecord::Migration[5.1]
   def change
     create_table :sites do |t|
       t.integer :account_id

--- a/spec/test_app/db/migrate/20220726164334_create_account.rb
+++ b/spec/test_app/db/migrate/20220726164334_create_account.rb
@@ -1,4 +1,4 @@
-class CreateAccount < ActiveRecord::Migration[5.2]
+class CreateAccount < ActiveRecord::Migration[5.1]
   def change
     create_table :accounts do |t|
       t.string :name


### PR DESCRIPTION
Downgrades the migration versions from 5.2 to 5.1 specifically for atla since they are running on rails/activerecord 5.1.6.