### PR TITLE
No-op refactoring ImportWork/CollectionJob

### DIFF
--- a/app/jobs/bulkrax/import_collection_job.rb
+++ b/app/jobs/bulkrax/import_collection_job.rb
@@ -5,21 +5,26 @@ module Bulkrax
     queue_as :import
 
     # rubocop:disable Rails/SkipsModelValidations
-    def perform(*args)
-      entry = Entry.find(args[0])
+    # @param entry_id [Object] the key for the Bulkrax::Entry to build and save.
+    # @param run_id [Object] the key for the Bulkrax::ImporterRun in which we're running this entry.
+    #
+    # @return [String]
+    def perform(entry_id, run_id, *)
+      entry = Entry.find(entry_id)
+      importer_run = ImporterRun.find(run_id)
       begin
         entry.build
         entry.save!
-        ImporterRun.find(args[1]).increment!(:processed_records)
-        ImporterRun.find(args[1]).increment!(:processed_collections)
-        ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
+        importer_run.increment!(:processed_records)
+        importer_run.increment!(:processed_collections)
+        importer_run.decrement!(:enqueued_records) unless importer_run.enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
       rescue => e
-        ImporterRun.find(args[1]).increment!(:failed_records)
-        ImporterRun.find(args[1]).increment!(:failed_collections)
-        ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
+        importer_run.increment!(:failed_records)
+        importer_run.increment!(:failed_collections)
+        importer_run.decrement!(:enqueued_records) unless importer_run.enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
         raise e
       end
-      entry.importer.current_run = ImporterRun.find(args[1])
+      entry.importer.current_run = importer_run
       entry.importer.record_status
     end
     # rubocop:enable Rails/SkipsModelValidations

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -5,6 +5,10 @@ module Bulkrax
     queue_as :import
 
     # rubocop:disable Rails/SkipsModelValidations
+    # @param entry_id [Object] the key for the Bulkrax::Entry to build and save.
+    # @param run_id [Object] the key for the Bulkrax::ImporterRun in which we're running this entry.
+    #
+    # @return [String]
     def perform(entry_id, run_id, *)
       entry = Entry.find(entry_id)
       importer_run = ImporterRun.find(run_id)


### PR DESCRIPTION
As part of reviewing how we move from `Bulkrax::ImporterJob#perform` into the Hyrax stack, I wanted to understand how both the `Bulkrax::ImportCollectionJob` and `Bulkrax::ImportWorkJob` "worked".

This refactor removes the magic positional arguments and names them. Further it adds documentation regarding the parameters.  And last it creates a local variable instead of relying on multiple calls to `ActiveRecord::Base.find`, which while cached, are unnecessary.