### PR TITLE
Refactoring to remove conditional

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -143,17 +143,13 @@ module Bulkrax
       import_objects(['relationship'])
     end
 
+    DEFAULT_OBJECT_TYPES = %w[collection work file_set relationship].freeze
+
     def import_objects(types_array = nil)
       self.only_updates ||= false
-      types = types_array || %w[collection work file_set relationship]
-      if parser.class == Bulkrax::CsvParser
-        parser.create_objects(types)
-      else
-        types.each do |object_type|
-          self.save if self.new_record? # Object needs to be saved for statuses
-          parser.send("create_#{object_type.pluralize}")
-        end
-      end
+      self.save if self.new_record? # Object needs to be saved for statuses
+      types = types_array || DEFAULT_OBJECT_TYPES
+      parser.create_objects(types)
     rescue StandardError => e
       status_info(e)
     end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -142,6 +142,21 @@ module Bulkrax
       @visibility ||= self.parser_fields['visibility'] || 'open'
     end
 
+    # @api public
+    #
+    # @param types [Array<Symbol>] the types of objects that we'll create.
+    #
+    # @see Bulkrax::Importer::DEFAULT_OBJECT_TYPES
+    # @see #create_collections
+    # @see #create_works
+    # @see #create_file_sets
+    # @see #create_relationships
+    def create_objects(types = [])
+      types.each do |object_type|
+        parser.send("create_#{object_type.pluralize}")
+      end
+    end
+
     # @abstract Subclass and override {#create_collections} to implement behavior for the parser.
     def create_collections
       raise NotImplementedError, 'must be defined' if importer?


### PR DESCRIPTION
Prior to this commit, we had an if statement that would check if the given parser was a `Bulkrax::CsvParser`, if so it would go down one logic pathway.  If not, it would call a different pathway.  Each pathway required knowledge of the implementation details of the parser.  The `Bulkrax::CsvParser` required knowledge of a non-public API setup (e.g. a method not defined on `Bulkrax::ApplicationParser`).

With this commit, we're favoring a single entry point for all parsers. Moving the logic down to the parser and allowing for polymorphism of the `Bulkrax::CsvParser` to provide it's different implementation.

One additional change is calling save on the importer before we create the objects.  This was something not called in the `Bulkrax::CsvParser` and based on the comment could have created a problem.