### PR TITLE
Merge default field mapping in with field mapping

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -66,7 +66,7 @@ module Bulkrax
                    else
                      default_field_mapping.merge(self.field_mapping)
                    end
-                   
+
       # rubocop:enable Style/IfUnlessModifier
     end
 

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -63,7 +63,7 @@ module Bulkrax
                       default_field_mapping
                      end
                    else
-                     self.field_mapping.merge(default_field_mapping)
+                     default_field_mapping.merge(self.field_mapping)
                    end
     end
 

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -58,16 +58,21 @@ module Bulkrax
 
     # If field_mapping is empty, setup a default based on the export_properties
     def mapping
+      # rubocop:disable Style/IfUnlessModifier     
       @mapping ||= if self.field_mapping.blank? || self.field_mapping == [{}]
                      if parser.import_fields.present? || self.field_mapping == [{}]
-                      default_field_mapping
+                       default_field_mapping
                      end
                    else
                      default_field_mapping.merge(self.field_mapping)
                    end
+                   
+      # rubocop:enable Style/IfUnlessModifier     
     end
 
     def default_field_mapping
+      return self.field_mapping if parser.import_fields.nil?
+
       ActiveSupport::HashWithIndifferentAccess.new(
         parser.import_fields.reject(&:nil?).map do |m|
           Bulkrax.default_field_mapping.call(m)

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -58,7 +58,7 @@ module Bulkrax
 
     # If field_mapping is empty, setup a default based on the export_properties
     def mapping
-      # rubocop:disable Style/IfUnlessModifier     
+      # rubocop:disable Style/IfUnlessModifier
       @mapping ||= if self.field_mapping.blank? || self.field_mapping == [{}]
                      if parser.import_fields.present? || self.field_mapping == [{}]
                        default_field_mapping
@@ -67,7 +67,7 @@ module Bulkrax
                      default_field_mapping.merge(self.field_mapping)
                    end
                    
-      # rubocop:enable Style/IfUnlessModifier     
+      # rubocop:enable Style/IfUnlessModifier
     end
 
     def default_field_mapping

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -60,15 +60,19 @@ module Bulkrax
     def mapping
       @mapping ||= if self.field_mapping.blank? || self.field_mapping == [{}]
                      if parser.import_fields.present? || self.field_mapping == [{}]
-                       ActiveSupport::HashWithIndifferentAccess.new(
-                         parser.import_fields.reject(&:nil?).map do |m|
-                           Bulkrax.default_field_mapping.call(m)
-                         end.inject(:merge)
-                       )
+                      default_field_mapping
                      end
                    else
-                     self.field_mapping
+                     self.field_mapping.merge(default_field_mapping)
                    end
+    end
+
+    def default_field_mapping
+      ActiveSupport::HashWithIndifferentAccess.new(
+        parser.import_fields.reject(&:nil?).map do |m|
+          Bulkrax.default_field_mapping.call(m)
+        end.inject(:merge)
+      )
     end
 
     def parser_fields


### PR DESCRIPTION
A bug was found with the following scenario:

A client only had the necessary field mappings set (bulkrax_identifier, children, and parents). 

Because of this, [#mapping](https://github.com/samvera-labs/bulkrax/blob/main/app/models/bulkrax/importer.rb#L60-L72) would only return the field mapping. This caused an issue because [matcher](https://github.com/samvera-labs/bulkrax/blob/e88d0ea349afda5b3068836aa36ef86c93d4c62d/app/models/concerns/bulkrax/has_matchers.rb#L32) would return nil for all other imported values.

Because [it](https://github.com/samvera-labs/bulkrax/blob/e88d0ea349afda5b3068836aa36ef86c93d4c62d/app/models/concerns/bulkrax/has_matchers.rb#L44) was nil at the time of assigning the value, if the property was singular or multiple it would never process the split method to make [Subject A ; Subject B] into [Subject A, Subject B], for example.

This MR merges the default field mapping in with the field mapping, so that by default the splits would still be honored. It solves a bug found in bulkrax, but it also works for allinson flex's dynamic properties.

This was also tested using an importer with headers that didn't exist on any of the work types. Although it can be seen in the raw_metadata, parsed_metadata properly filters it out because #field_supported? returns false.

**NOTE**: in the following example donkey is an invalid field and should not be in the parsed metadata. And the client's default field mapping sets split to be a pipe. 


<img width="812" alt="Screen Shot 2022-11-02 at 12 31 11 PM" src="https://user-images.githubusercontent.com/10081604/199585635-02d4f00d-0aca-4227-aa68-bc22a999319f.png">
<img width="1006" alt="Screen Shot 2022-11-02 at 12 32 24 PM" src="https://user-images.githubusercontent.com/10081604/199585844-627ad6bd-e590-455f-830f-82b9a0dd1810.png">



