### PR TITLE
Convert csv headers by explicit lambda

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -18,7 +18,7 @@ module Bulkrax
       raise StandardError, 'CSV path empty' if path.blank?
       CSV.read(path,
         headers: true,
-        header_converters: :symbol,
+        header_converters: ->(h) { h.to_sym },
         encoding: 'utf-8')
     end
 

--- a/spec/fixtures/csv/mixed-case.csv
+++ b/spec/fixtures/csv/mixed-case.csv
@@ -1,0 +1,1 @@
+title,title.alternate,collection.isPartOf,source_location

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -5,24 +5,36 @@ require 'rails_helper'
 
 module Bulkrax
   RSpec.describe CsvEntry, type: :model do
-    let(:collection) { FactoryBot.build(:collection) }
-    let(:hyrax_record) do
-      OpenStruct.new(
-        file_sets: [],
-        member_of_collections: [],
-        member_of_work_ids: [],
-        in_work_ids: [],
-        member_work_ids: []
-      )
-    end
-
-    before do
-      allow_any_instance_of(described_class).to receive(:collections_created?).and_return(true)
-      allow_any_instance_of(described_class).to receive(:find_collection).and_return(collection)
-      allow(subject).to receive(:hyrax_record).and_return(hyrax_record)
+    describe '.read_data' do
+      let(:path) { File.expand_path('../../fixtures/csv/mixed-case.csv', __dir__) }
+      subject(:data) { described_class.read_data(path) }
+      it 'handles mixed case and periods for column names' do
+        expect(data.headers).to match_array([
+          "title".to_sym,
+          "title.alternate".to_sym,
+          "collection.isPartOf".to_sym,
+          "source_location".to_sym
+        ])
+      end
     end
 
     describe 'builds entry' do
+      let(:collection) { FactoryBot.build(:collection) }
+      let(:hyrax_record) do
+        OpenStruct.new(
+          file_sets: [],
+          member_of_collections: [],
+          member_of_work_ids: [],
+          in_work_ids: [],
+          member_work_ids: []
+        )
+      end
+
+      before do
+        allow_any_instance_of(described_class).to receive(:collections_created?).and_return(true)
+        allow_any_instance_of(described_class).to receive(:find_collection).and_return(collection)
+        allow(subject).to receive(:hyrax_record).and_return(hyrax_record)
+      end
       subject { described_class.new(importerexporter: importer) }
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
 
@@ -298,11 +310,11 @@ module Bulkrax
       context 'with object fields prefixed' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-                              'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-                              'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-                              'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
-                              'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-                            })
+            'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+            'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+            'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
+            'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+          })
         end
 
         before do
@@ -329,11 +341,11 @@ module Bulkrax
       context 'with object fields and no prefix' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-                              'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-                              'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-                              'position' => { from: ['single_object_position'], object: 'single_object' },
-                              'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-                            })
+            'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+            'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+            'position' => { from: ['single_object_position'], object: 'single_object' },
+            'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+          })
         end
 
         before do
@@ -360,11 +372,11 @@ module Bulkrax
       context 'with multiple objects and fields prefixed' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-                              'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-                            })
+            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+            'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+          })
         end
 
         before do
@@ -397,11 +409,11 @@ module Bulkrax
       context 'with multiple objects and no fields prefixed' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-                              'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-                            })
+            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+            'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+          })
         end
 
         before do
@@ -434,10 +446,10 @@ module Bulkrax
       context 'with object fields prefixed and properties with multiple values' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-                            })
+            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+          })
         end
 
         before do
@@ -468,10 +480,10 @@ module Bulkrax
       context 'with object fields not prefixed and properties with multiple values' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-                            })
+            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+          })
         end
 
         before do
@@ -506,12 +518,12 @@ module Bulkrax
       context 'with object fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-                              'id' => { from: ['id'], source_identifier: true },
-                              'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-                              'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-                              'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
-                              'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-                            })
+            'id' => { from: ['id'], source_identifier: true },
+            'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+            'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+            'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
+            'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+          })
         end
 
         let(:work_obj) do
@@ -547,12 +559,12 @@ module Bulkrax
       context 'with object fields and no prefix' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-                              'id' => { from: ['id'], source_identifier: true },
-                              'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-                              'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-                              'position' => { from: ['single_object_position'], object: 'single_object' },
-                              'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-                            })
+            'id' => { from: ['id'], source_identifier: true },
+            'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+            'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+            'position' => { from: ['single_object_position'], object: 'single_object' },
+            'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+          })
         end
 
         let(:work_obj) do
@@ -588,12 +600,12 @@ module Bulkrax
       context 'with multiple objects and fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-                              'id' => { from: ['id'], source_identifier: true },
-                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-                              'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-                            })
+            'id' => { from: ['id'], source_identifier: true },
+            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+            'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+          })
         end
 
         let(:work_obj) do
@@ -641,12 +653,12 @@ module Bulkrax
       context 'with multiple objects and no fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-                              'id' => { from: ['id'], source_identifier: true },
-                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-                              'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-                            })
+            'id' => { from: ['id'], source_identifier: true },
+            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+            'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+          })
         end
 
         let(:work_obj) do
@@ -694,11 +706,11 @@ module Bulkrax
       context 'with object fields prefixed and properties with multiple values' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-                              'id' => { from: ['id'], source_identifier: true },
-                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-                            })
+            'id' => { from: ['id'], source_identifier: true },
+            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+          })
         end
 
         let(:work_obj) do
@@ -744,11 +756,11 @@ module Bulkrax
       context 'with object fields not prefixed and properties with multiple values' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-                              'id' => { from: ['id'], source_identifier: true },
-                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-                            })
+            'id' => { from: ['id'], source_identifier: true },
+            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+          })
         end
 
         let(:work_obj) do

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -6,19 +6,20 @@ require 'rails_helper'
 module Bulkrax
   RSpec.describe CsvEntry, type: :model do
     describe '.read_data' do
-      let(:path) { File.expand_path('../../fixtures/csv/mixed-case.csv', __dir__) }
       subject(:data) { described_class.read_data(path) }
+      let(:path) { File.expand_path('../../fixtures/csv/mixed-case.csv', __dir__) }
       it 'handles mixed case and periods for column names' do
         expect(data.headers).to match_array([
-          "title".to_sym,
-          "title.alternate".to_sym,
-          "collection.isPartOf".to_sym,
-          "source_location".to_sym
-        ])
+                                              "title".to_sym,
+                                              "title.alternate".to_sym,
+                                              "collection.isPartOf".to_sym,
+                                              "source_location".to_sym
+                                            ])
       end
     end
 
     describe 'builds entry' do
+      subject { described_class.new(importerexporter: importer) }
       let(:collection) { FactoryBot.build(:collection) }
       let(:hyrax_record) do
         OpenStruct.new(
@@ -35,7 +36,6 @@ module Bulkrax
         allow_any_instance_of(described_class).to receive(:find_collection).and_return(collection)
         allow(subject).to receive(:hyrax_record).and_return(hyrax_record)
       end
-      subject { described_class.new(importerexporter: importer) }
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
 
       context 'without required metadata' do
@@ -310,11 +310,11 @@ module Bulkrax
       context 'with object fields prefixed' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-            'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-            'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-            'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
-            'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-          })
+                              'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+                              'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+                              'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
+                              'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+                            })
         end
 
         before do
@@ -341,11 +341,11 @@ module Bulkrax
       context 'with object fields and no prefix' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-            'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-            'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-            'position' => { from: ['single_object_position'], object: 'single_object' },
-            'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-          })
+                              'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+                              'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+                              'position' => { from: ['single_object_position'], object: 'single_object' },
+                              'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+                            })
         end
 
         before do
@@ -372,11 +372,11 @@ module Bulkrax
       context 'with multiple objects and fields prefixed' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-            'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-          })
+                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+                              'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+                            })
         end
 
         before do
@@ -409,11 +409,11 @@ module Bulkrax
       context 'with multiple objects and no fields prefixed' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-            'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-          })
+                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+                              'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+                            })
         end
 
         before do
@@ -446,10 +446,10 @@ module Bulkrax
       context 'with object fields prefixed and properties with multiple values' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-          })
+                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+                            })
         end
 
         before do
@@ -480,10 +480,10 @@ module Bulkrax
       context 'with object fields not prefixed and properties with multiple values' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
-            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-          })
+                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+                            })
         end
 
         before do
@@ -518,12 +518,12 @@ module Bulkrax
       context 'with object fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-            'id' => { from: ['id'], source_identifier: true },
-            'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-            'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-            'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
-            'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-          })
+                              'id' => { from: ['id'], source_identifier: true },
+                              'single_object_first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+                              'single_object_last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+                              'single_object_position' => { from: ['single_object_position'], object: 'single_object' },
+                              'single_object_language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+                            })
         end
 
         let(:work_obj) do
@@ -559,12 +559,12 @@ module Bulkrax
       context 'with object fields and no prefix' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-            'id' => { from: ['id'], source_identifier: true },
-            'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
-            'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
-            'position' => { from: ['single_object_position'], object: 'single_object' },
-            'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
-          })
+                              'id' => { from: ['id'], source_identifier: true },
+                              'first_name' => { from: ['single_object_first_name'], object: 'single_object' },
+                              'last_name' => { from: ['single_object_last_name'], object: 'single_object' },
+                              'position' => { from: ['single_object_position'], object: 'single_object' },
+                              'language' => { from: ['single_object_language'], object: 'single_object', parsed: true }
+                            })
         end
 
         let(:work_obj) do
@@ -600,12 +600,12 @@ module Bulkrax
       context 'with multiple objects and fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-            'id' => { from: ['id'], source_identifier: true },
-            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-            'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-          })
+                              'id' => { from: ['id'], source_identifier: true },
+                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+                              'multiple_objects_language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+                            })
         end
 
         let(:work_obj) do
@@ -653,12 +653,12 @@ module Bulkrax
       context 'with multiple objects and no fields prefixed' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-            'id' => { from: ['id'], source_identifier: true },
-            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
-            'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
-          })
+                              'id' => { from: ['id'], source_identifier: true },
+                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects' },
+                              'language' => { from: ['multiple_objects_language'], object: 'multiple_objects', parsed: true }
+                            })
         end
 
         let(:work_obj) do
@@ -706,11 +706,11 @@ module Bulkrax
       context 'with object fields prefixed and properties with multiple values' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-            'id' => { from: ['id'], source_identifier: true },
-            'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-          })
+                              'id' => { from: ['id'], source_identifier: true },
+                              'multiple_objects_first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'multiple_objects_last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'multiple_objects_position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+                            })
         end
 
         let(:work_obj) do
@@ -756,11 +756,11 @@ module Bulkrax
       context 'with object fields not prefixed and properties with multiple values' do
         let(:exporter) do
           FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
-            'id' => { from: ['id'], source_identifier: true },
-            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
-            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
-            'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
-          })
+                              'id' => { from: ['id'], source_identifier: true },
+                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' },
+                              'position' => { from: ['multiple_objects_position'], object: 'multiple_objects', nested_type: 'Array' }
+                            })
         end
 
         let(:work_obj) do


### PR DESCRIPTION
Prior to this commit, we were leveraging the built in header_converters method of `:symbol`; which converts headers to symbols by removing "." and converting all upper case characters to lower case.

After this commit, we use a more explicit converter that doesn't perform string transformations.

Closes #669