### PR TITLE
Fix `Hyrax::VisibilityPropagator` error for remote files

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -178,8 +178,8 @@ module Bulkrax
       actor.file_set.permissions_attributes = work_permissions
       actor.create_metadata(attrs)
       actor.create_content(uploaded_file) if uploaded_file
-      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if remote_file
       actor.attach_to_work(work, attrs)
+      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if remote_file
     end
 
     def update_file_set(attrs)


### PR DESCRIPTION
In UTK, we were getting a `Hyrax::VisibilityPropagator::NullVisibilityPropogator` error for remote files that was triggered by a misspelling.  Conveniently, this led to the question of why is it even hitting the `NullVisibilityPropogator` in the first place?  Turns out, the `FileSet` that comes in did not have a parent because of the logic in Bulkrax.

This PR swaps the logic so the `FileSet` should have a parent prior to hitting the `Hyrax::VisibilityPropagator`