### PR TITLE
add configuration for using a custom ObjectFactory

### DIFF
--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -165,7 +165,7 @@ module Bulkrax
     end
 
     def factory
-      @factory ||= Bulkrax::ObjectFactory.new(attributes: self.parsed_metadata,
+      @factory ||= Bulkrax.object_factory.new(attributes: self.parsed_metadata,
                                               source_identifier_value: identifier,
                                               work_identifier: parser.work_identifier,
                                               related_parents_parsed_mapping: parser.related_parents_parsed_mapping,

--- a/app/models/concerns/bulkrax/import_behavior.rb
+++ b/app/models/concerns/bulkrax/import_behavior.rb
@@ -165,15 +165,16 @@ module Bulkrax
     end
 
     def factory
-      @factory ||= Bulkrax.object_factory.new(attributes: self.parsed_metadata,
-                                              source_identifier_value: identifier,
-                                              work_identifier: parser.work_identifier,
-                                              related_parents_parsed_mapping: parser.related_parents_parsed_mapping,
-                                              replace_files: replace_files,
-                                              user: user,
-                                              klass: factory_class,
-                                              importer_run_id: importerexporter.last_run.id,
-                                              update_files: update_files)
+      of = Bulkrax.object_factory || Bulkrax::ObjectFactory
+      @factory ||= of.new(attributes: self.parsed_metadata,
+                          source_identifier_value: identifier,
+                          work_identifier: parser.work_identifier,
+                          related_parents_parsed_mapping: parser.related_parents_parsed_mapping,
+                          replace_files: replace_files,
+                          user: user,
+                          klass: factory_class,
+                          importer_run_id: importerexporter.last_run.id,
+                          update_files: update_files)
     end
 
     def factory_class

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -16,6 +16,7 @@ module Bulkrax
                    :import_path,
                    :multi_value_element_join_on,
                    :multi_value_element_split_on,
+                   :object_factory,
                    :parsers,
                    :qa_controlled_properties,
                    :related_children_field_mapping,

--- a/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
+++ b/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb
@@ -10,6 +10,9 @@ Bulkrax.setup do |config|
   # Default is the first returned by Hyrax.config.curation_concerns
   # config.default_work_type = MyWork
 
+  # Factory Class to use when generating and saving objects
+  config.object_factory = Bulkrax::ObjectFactory
+
   # Path to store pending imports
   # config.import_path = 'tmp/imports'
 


### PR DESCRIPTION
this is a first step toward #672 and valkyrie support. we want to be able to drop in an ObjectFactory implementation that finds and saves using Valkyrie instead of ActiveFedora.