### PR TITLE
importers/exporters links to not show up if bulkrax is not enabled

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_bulkrax_sidebar_additions.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_bulkrax_sidebar_additions.html.erb
@@ -1,6 +1,8 @@
-<%= menu.nav_link(bulkrax.importers_path) do %>
-  <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
-<% end %>
-<%= menu.nav_link(bulkrax.exporters_path) do %>
-  <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
+<% if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true' %>
+  <%= menu.nav_link(bulkrax.importers_path) do %>
+    <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
+  <% end %>
+  <%= menu.nav_link(bulkrax.exporters_path) do %>
+    <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Since Bulkrax comes default with Hyku, if someone wants to not use Bulkrax, via `HYKU_BULKRAX_ENABLED=false` environment variable for example, the sidebar will break since it won't know what `bulkrax` is.  Putting this conditional before it will take care of that and remove the `Importers` and `Exporters` links from the sidebar.

<img width="404" alt="image" src="https://user-images.githubusercontent.com/19597776/202860193-20b1e476-9509-4129-8ac6-0bd57ded6807.png">
