### PR TITLE
Ensuring metadata_prefix option is correctly passed

### DIFF
--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -276,7 +276,7 @@ module Bulkrax
     def setup_client(url)
       return false if url.nil?
       headers = { from: Bulkrax.server_name }
-      @client ||= OAI::Client.new(url, headers: headers, parser: 'libxml', metadata_prefix: 'oai_dc')
+      @client ||= OAI::Client.new(url, headers: headers, parser: 'libxml')
     end
 
     # Download methods

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -13,8 +13,7 @@ module Bulkrax
     def client
       @client ||= OAI::Client.new(importerexporter.parser_fields['base_url'],
                                   headers: headers,
-                                  parser: 'libxml',
-                                  metadata_prefix: importerexporter.parser_fields['metadata_prefix'])
+                                  parser: 'libxml')
     rescue StandardError
       raise OAIError
     end
@@ -32,6 +31,7 @@ module Bulkrax
     end
 
     def records(opts = {})
+      opts[:metadata_prefix] ||= importerexporter.parser_fields['metadata_prefix']
       opts[:set] = collection_name unless collection_name == 'all'
 
       opts[:from] = importerexporter&.last_imported_at&.strftime("%Y-%m-%d") if importerexporter.last_imported_at && only_updates


### PR DESCRIPTION
Prior to this commit, the `metadata_prefix` passed on `OAI::Client.new` was discarded.  In the current code, that option is not processed.  It is instead a parameter to pass to the OAI verb
action (e.g. `ListIdentifiers` and `GetRecords`).

With this commit, we ensure that we pass the `metadata_prefix` to the specific verb.

https://github.com/code4lib/ruby-oai/blob/d0303be9800e7247532286330cf3b0cf135f19d7/lib/oai/client.rb#L86-L121

Closes https://github.com/samvera-labs/bulkrax/issues/676
