### PR TITLE
Guard on reindex_extent assignment

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -81,7 +81,7 @@ module Bulkrax
     # This is adding the reverse relationship, from the child to the parent
     def collection_parent_work_child
       child_work_ids = child_records[:works].map(&:id)
-      parent_record.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+      parent_record.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
 
       parent_record.add_member_objects(child_work_ids)
       ImporterRun.find(importer_run_id).increment!(:processed_relationships, child_work_ids.count) # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
Ref https://github.com/scientist-softserv/utk-hyku/issues/245

The use of the graph indexer in hyrax 3.x + turns off the nesting indexer, and means that reindex_extent is not defined. This is fixed by adding a guard on the method, which allows the relationships job to complete normally.

**Before:** 

![Screen Shot 2022-11-30 at 6 25 43 PM](https://user-images.githubusercontent.com/17851674/205143471-995d58cf-499f-4698-bdeb-5bdbfa80ff4f.png)
