### PR TITLE
Normalizing serialized data for BOM characters

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -7,7 +7,7 @@ module Bulkrax
   # We do too much in these entry classes. We need to extract the common logic from the various
   # entry models into a module that can be shared between them.
   class CsvEntry < Entry # rubocop:disable Metrics/ClassLength
-    serialize :raw_metadata, JSON
+    serialize :raw_metadata, Bulkrax::NormalizedJson
 
     def self.fields_from_data(data)
       data.headers.flatten.compact.uniq

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -15,7 +15,7 @@ module Bulkrax
     alias importer importerexporter
     alias exporter importerexporter
 
-    serialize :parsed_metadata, JSON
+    serialize :parsed_metadata, Bulkrax::NormalizedJson
     # Do not serialize raw_metadata as so we can support xml or other formats
     serialize :collection_ids, Array
 

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -5,7 +5,7 @@ require 'ostruct'
 
 module Bulkrax
   class OaiEntry < Entry
-    serialize :raw_metadata, JSON
+    serialize :raw_metadata, Bulkrax::NormalizedJson
 
     delegate :record, to: :raw_record
 

--- a/app/models/bulkrax/rdf_entry.rb
+++ b/app/models/bulkrax/rdf_entry.rb
@@ -3,7 +3,7 @@
 require 'rdf'
 module Bulkrax
   class RdfEntry < Entry
-    serialize :raw_metadata, JSON
+    serialize :raw_metadata, Bulkrax::NormalizedJson
 
     def self.read_data(path)
       RDF::Reader.open(path)

--- a/app/models/bulkrax/xml_entry.rb
+++ b/app/models/bulkrax/xml_entry.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 module Bulkrax
   # Generic XML Entry
   class XmlEntry < Entry
-    serialize :raw_metadata, JSON
+    serialize :raw_metadata, Bulkrax::NormalizedJson
 
     def self.fields_from_data(data); end
 

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -195,13 +195,14 @@ module Bulkrax
       returning_value
     end
 
-    # Serializes an attribute value to a string that will be stored in the database.
+    # When we write the serialized data to the database, we "dump" the value into that database
+    # column.
     def self.dump(value)
       JSON.dump(normalize_keys(value))
     end
 
-    # Deserializes a string from the database to an attribute value.
-    # rubocop:disable Security/JSONLoad
+    # When we load the serialized data from the database, we pass the database's value into "load"
+    # function.
     def self.load(string)
       normalize_keys(JSON.load(string))
     end

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -4,6 +4,7 @@ require "bulkrax/version"
 require "bulkrax/engine"
 require 'active_support/all'
 
+# rubocop:disable Metrics/ModuleLength
 module Bulkrax
   class << self
     mattr_accessor :api_definition,
@@ -168,4 +169,43 @@ module Bulkrax
   def self.setup
     yield self
   end
+
+  # Responsible for stripping hidden characters from the given string.
+  #
+  # @param value [#to_s]
+  # @return [String] with hidden characters removed
+  #
+  # @see https://github.com/samvera-labs/bulkrax/issues/688
+  def self.normalize_string(value)
+    # Removing [Byte Order Mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark)
+    value.to_s.delete("\xEF\xBB\xBF")
+  end
+
+  # This class confirms to the Active::Support.serialze interface.  It's job is to ensure that we
+  # don't have keys with the tricksy Byte Order Mark character.
+  #
+  # @see https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize
+  class NormalizedJson
+    def self.normalize_keys(hash)
+      return hash unless hash.respond_to?(:each_pair)
+      returning_value = {}
+      hash.each_pair do |key, value|
+        returning_value[Bulkrax.normalize_string(key)] = value
+      end
+      returning_value
+    end
+
+    # Serializes an attribute value to a string that will be stored in the database.
+    def self.dump(value)
+      JSON.dump(normalize_keys(value))
+    end
+
+    # Deserializes a string from the database to an attribute value.
+    # rubocop:disable Security/JSONLoad
+    def self.load(string)
+      normalize_keys(JSON.load(string))
+    end
+    # rubocop:enable Security/JSONLoad
+  end
 end
+# rubocop:disable Metrics/ModuleLength

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -203,6 +203,8 @@ module Bulkrax
 
     # When we load the serialized data from the database, we pass the database's value into "load"
     # function.
+    #
+    # rubocop:disable Security/JSONLoad
     def self.load(string)
       normalize_keys(JSON.load(string))
     end

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -140,4 +140,19 @@ RSpec.describe Bulkrax do
       expect(described_class.api_definition).to be_a(Hash)
     end
   end
+
+  context '.normalize_string' do
+    it "returns a new string object" do
+      given = "string"
+      returned_value = described_class.normalize_string(given)
+      expect(given.object_id).not_to eq(returned_value.object_id)
+      expect(given).to eq(returned_value)
+    end
+
+    it "removes tricksy nasty hidden stringsy" do
+      given = "\xEF\xBB\xBFfile"
+      returned_value = described_class.normalize_string(given)
+      expect(returned_value).to eq("file")
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, when someone would upload a CSV it might have a column name that included the tricksy, invisibile [Byte Order Mark][1]. The manifestation was that you could look at the raw metadata and see a key called `"file"` however when checking `raw_metadata.key?("file")` the result was `false`.

To find this `entry.raw_metadata.keys.first.chars.map(&:chr)` I got `["", "f", "i", "l", "e"]` where the first value of that array was a [Byte Oder Mark][1].

With this commit, we're handling both how we persist and how we load persisted serialized data.  This follows on the documentation for the `ActiveRecord::Base.serialize` method.

It's envisioned that we might have more characters to sanitize.

Closes: samvera-labs/bulkrax#688
Related to: scientist-softserv/adventist-dl#179

[1]: https://en.wikipedia.org/wiki/Byte_order_mark