### PR TITLE
Capturing raw metadata for OAI parsing of works

### DIFF
--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -97,6 +97,7 @@ module Bulkrax
         break if limit_reached?(limit, index)
         seen[identifier] = true
         new_entry = entry_class.where(importerexporter: self.importerexporter, identifier: identifier).first_or_create!
+        new_entry.update!(raw_metadata: { xml: record.metadata.to_s })
         if record.deleted?
           DeleteWorkJob.send(perform_method, new_entry, importerexporter.current_run)
         else


### PR DESCRIPTION
Prior to this commit, we didn't capture the raw metadata of works parsed via OAI-PMH.

With this change, we now capture that information.

Below is an example showing that we need to use the record's `metadata` as a string.

```ruby
gem "oai"
require 'oai'
client = OAI::Client.new(
  "http://oai.adventistdigitallibrary.org/OAI-script",
  headers: { from: "jeremy@scientist.com" },
  parser: 'libxml')

opts = {
  metadata_prefix: "oai_adl",
  set: "adl:issue"
}

records = client.list_records(opts)

records.each_with_index do |r, i|
  puts "Working on record ##{i+1}"
  puts "Metadata:\n#{r.metadata.to_s}"
end
```