### PR TITLE
Moving OAI metadata capture to entry processing

### DIFF
--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -28,6 +28,7 @@ module Bulkrax
     def build_metadata
       self.parsed_metadata = {}
       self.parsed_metadata[work_identifier] = [record.header.identifier]
+      self.raw_metadata = { xml: record.metadata.to_s }
 
       record.metadata.children.each do |child|
         child.children.each do |node|

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -97,7 +97,6 @@ module Bulkrax
         break if limit_reached?(limit, index)
         seen[identifier] = true
         new_entry = entry_class.where(importerexporter: self.importerexporter, identifier: identifier).first_or_create!
-        new_entry.update!(raw_metadata: { xml: record.metadata.to_s })
         if record.deleted?
           DeleteWorkJob.send(perform_method, new_entry, importerexporter.current_run)
         else


### PR DESCRIPTION
In writing #694 I introduced an OAI bug.  There are two OAI fetch cycles.

The first is the list of records.  These are fetched via the `list_identifiers` method.  That method returns header information without metadata.  Then, we submit one job per header.  At that point we perform the second fetch of the record.  This includes the full metadata.