### PR TITLE
Replace solrizer reference so that feature works with hyrax 3+

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -234,13 +234,17 @@ module Bulkrax
         instance_variable_set(instance_var, ActiveFedora::SolrService.post(
           extra_filters.to_s,
           fq: [
-            %(#{::ActiveFedora.index_field_mapper.solr_name(work_identifier)}:("#{complete_entry_identifiers.join('" OR "')}")),
+            %(#{solr_name(work_identifier)}:("#{complete_entry_identifiers.join('" OR "')}")),
             "has_model_ssim:(#{models_to_search.join(' OR ')})"
           ],
           fl: 'id',
           rows: 2_000_000_000
         )['response']['docs'].map { |obj| obj['id'] })
       end
+    end
+
+    def solr_name(base_name)
+      Module.const_defined?(:Solrizer) ? ::Solrizer.solr_name(base_name) : ::ActiveFedora.index_field_mapper.solr_name(base_name)
     end
 
     def create_new_entries

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -234,7 +234,7 @@ module Bulkrax
         instance_variable_set(instance_var, ActiveFedora::SolrService.post(
           extra_filters.to_s,
           fq: [
-            %(#{::Solrizer.solr_name(work_identifier)}:("#{complete_entry_identifiers.join('" OR "')}")),
+            %(#{::ActiveFedora.index_field_mapper.solr_name(work_identifier)}:("#{complete_entry_identifiers.join('" OR "')}")),
             "has_model_ssim:(#{models_to_search.join(' OR ')})"
           ],
           fl: 'id',


### PR DESCRIPTION
Addresses:
https://github.com/samvera-labs/bulkrax/issues/699

This change might not work with hyrax < 2.8, since it looks like solrizer got merged into activefedora in 12.0.0, so if we need to support those versions of hyrax we will likely need to add some logic in here to decide whether to use solrizer or activefedora.

I also suspect this code might not be getting fully tested, since bulkrax is using hyrax 3, but no tests seem to be impacted by this issue.