### PR TITLE
Ensuring OAI parser sets factory class then parses

### DIFF
--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -64,7 +64,6 @@ module Bulkrax
       each_candidate_metadata_node do |node|
         next unless model_field_names.include?(node.name)
         add_metadata(node.name, node.content)
-        break
       end
     end
 

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -59,8 +59,6 @@ module Bulkrax
     # To ensure we capture the correct parse data, we first need to establish the factory_class.
     # @see https://github.com/samvera-labs/bulkrax/issues/702
     def establish_factory_class
-      # Why send?  Because in some implementations I've found that folks have privatized the
-      # model_field_mappings method.
       model_field_names = parser.model_field_mappings
 
       each_candidate_metadata_node do |node|


### PR DESCRIPTION
## Ensuring OAI parser sets factory class then parses

a086164abe2b6f6ac79d81e1ef54c65ef8071136

Let's say we have nodes with the following names (and order): `shape`, `model`,
`smell`

Prior to this commit, as we were reading through the record's metadata
when we were processing `shape` we would use the default `factory_class`
to check if `shape` was a valid field.  Then we'd use the value of
`model` to derive the `factory_class`.  And when we then processed
`smell` we'd be using the newly derived `factory_class` from the `model`
node.

With this commit, we first establish the `factory_class` from the
`model` node.  Then we again process the all the nodes to parse the
metadata.  This ensures that both `shape` and `smell` are parsed
against the expected `factory_class`.

Further, I have made a few refactorings that should ease upstream
overrides by extracting methods from the body of the `build_metadata`
method.

Related to:

- https://github.com/samvera-labs/bulkrax/issues/702
- https://github.com/scientist-softserv/adventist-dl/issues/188
- https://github.com/scientist-softserv/adventist-dl/issues/187

## Removing comment that no longer applies

41328a85e100554b0323b4c35ec347e6c734535f


## Removing `break` in loop for setting factory class

173c710893ec63238c3e762e457519cab0002fb2

In discussions with Kiah, having the `break` adds a slight performance
improvement.  However the `break` did break with the existing pattern.

We do take efforts to set the factory_class to the first encountered
`model`, so having mutliple `models` is probably okay.
