### PR TITLE
Ensuring XML parser sets factory class then parses

### DIFF
--- a/spec/models/bulkrax/xml_entry_spec.rb
+++ b/spec/models/bulkrax/xml_entry_spec.rb
@@ -7,6 +7,29 @@ module Bulkrax
     let(:path) { './spec/fixtures/xml/single.xml' }
     let(:data) { described_class.read_data(path) }
     let(:source_identifier) { :DrisUnique }
+    let(:mappings) do
+      {
+        'title' => { from: ['TitleLargerEntity'] },
+        'abstract' => { from: ['Abstract'] },
+        'shape' => { from: ['shape'] },
+        'source' => { from: [source_identifier.to_s], source_identifier: true }
+      }
+    end
+
+    around do |spec|
+      # The original specs were changing global state, which if we were to run specs in random order
+      # could create odd results.  This change helps remove that pollution of global state; we could
+      # still run into problems if we ever run our specs in parallel.
+      original_mappings = Bulkrax.field_mappings['Bulkrax::XmlParser']
+      Bulkrax.field_mappings['Bulkrax::XmlParser'] = mappings
+
+      spec.run
+      if original_mappings.nil?
+        Bulkrax.field_mappings.delete('Bulkrax::XmlParser')
+      else
+        Bulkrax.field_mappings['Bulkrax::XmlParser'] = original_mappings
+      end
+    end
 
     describe 'class methods' do
       context '#read_data' do
@@ -39,16 +62,6 @@ module Bulkrax
       end
       let(:object_factory) { instance_double(ObjectFactory) }
 
-      before do
-        Bulkrax.field_mappings.merge!(
-          'Bulkrax::XmlParser' => {
-            'title' => { from: ['TitleLargerEntity'] },
-            'abstract' => { from: ['Abstract'] },
-            'source' => { from: ['DrisUnique'], source_identifier: true }
-          }
-        )
-      end
-
       it 'parses the delete as true if present' do
         expect(raw_metadata[:delete]).to be_truthy
       end
@@ -64,16 +77,6 @@ module Bulkrax
         i
       end
       let(:object_factory) { instance_double(ObjectFactory) }
-
-      before do
-        Bulkrax.field_mappings.merge!(
-          'Bulkrax::XmlParser' => {
-            'title' => { from: ['TitleLargerEntity'] },
-            'abstract' => { from: ['Abstract'] },
-            'source' => { from: ['DrisUnique'], source_identifier: true }
-          }
-        )
-      end
 
       it 'parses the delete as nil if it is not present' do
         expect(raw_metadata[:delete]).to be_nil
@@ -113,6 +116,38 @@ module Bulkrax
           xml_entry.build
           expect(xml_entry.status).to eq('Failed')
         end
+      end
+    end
+
+    describe '#build_metadata' do
+      subject(:entry) { described_class.new(importerexporter: importer) }
+      before do
+        class ::Avacado < Work
+          property :shape, predicate: ::RDF::Vocab::DC.format
+        end
+      end
+      after do
+        Object.send(:remove_const, :Avacado)
+      end
+      let(:importer) { FactoryBot.build(:bulkrax_importer_xml) }
+      let(:raw_metadata) do
+        %(<?xml version="1.0" encoding="UTF-8"?>) \
+         "<entry>" \
+         "<TitleLargerEntity>Green Friend for All</TitleLargerEntity>" \
+         "<shape>Lumpy and Kind of Brown</shape>" \
+         "<model>Avacado</model>" \
+         "<DrisUnique>123</DrisUnique>" \
+         "</entry>"
+      end
+
+      it "establishes the factory class before attempting to parse other fields" do
+        entry.raw_metadata = { "data" => raw_metadata, "DrisUnique" => "123" }
+        expect(entry.source_identifier).to eq("DrisUnique")
+        expect(entry.parser.model_field_mappings).to eq(["model"])
+        expect(entry.build_metadata)
+        expect(entry.parsed_metadata["shape"]).to eq(["Lumpy and Kind of Brown"])
+        expect(entry.parsed_metadata["title"]).to eq(["Green Friend for All"])
+        expect(entry.factory_class).to eq(Avacado)
       end
     end
   end


### PR DESCRIPTION
This commit for changing the `Bulkrax::XmlEntry` is the sibling to the changes made to `Bulkrax::OaiEntry` (see SHA 35970cee).  The salient information is pulled as a quote from that commit:

> Prior to this commit, as we were reading through the record's metadata
> when we were processing `shape` we would use the default
> `factory_class` to check if `shape` was a valid field.  Then we'd use
> the value of `model` to derive the `factory_class`.  And when we then
> processed `smell` we'd be using the newly derived `factory_class` from
> the `model` node.
>
> With this commit, we first establish the `factory_class` from the
> `model` node.  Then we again process the all the nodes to parse the
> metadata.  This ensures that both `shape` and `smell` are parsed
> against the expected `factory_class`.

In addition, I have refactored the spec to remove global state pollution of the parser config.

I have also renamed and documented a method to be more descriptive; the previous method name of `xml_elements` was opaque, as it returned an Array of strings (and not an array of XML elements).

Further steps could be to extract the now "ubiquitous" `Avacado` class into a spec fixture.

We may want to revisit the XML parser fundamental logic; namely we only parse nodes that are explicitly declared with in the `from`.  This is a bit different than other parsers, in that they will make assumptions about each encountered column (in the case of CSV) or node (in the case of OAI).  tl;dr - Here there be dragons.

Closes #702

Related to:

- https://github.com/samvera-labs/bulkrax/pull/703
- https://github.com/scientist-softserv/adventist-dl/issues/188
- https://github.com/scientist-softserv/adventist-dl/issues/187
- https://github.com/scientist-softserv/adventist-dl/issues/186
