### PR TITLE
Add Permissions For Bulkrax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-gem 'blacklight', '~> 6.20.0'
+gem 'blacklight', '~> 6.25.0'
 gem 'bootstrap-sass', '~> 3.0'
 gem 'coderay'
 gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     amazing_print (1.4.0)
     arel (9.0.0)
     ast (2.4.2)
-    autoprefixer-rails (10.3.1.0)
+    autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     awesome_nested_set (3.5.0)
       activerecord (>= 4.0.0, < 7.1)
@@ -126,7 +126,7 @@ GEM
       rubocop-performance
       rubocop-rails
       rubocop-rspec
-    blacklight (6.20.0)
+    blacklight (6.25.0)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid
@@ -179,6 +179,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    date (3.3.3)
     declarative (0.0.20)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
@@ -268,7 +269,7 @@ GEM
       unicode-types (~> 1.7)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    erubi (1.11.0)
+    erubi (1.12.0)
     ethon (0.14.0)
       ffi (>= 1.15.0)
     execjs (2.8.1)
@@ -277,13 +278,13 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (0.17.5)
+    faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.5)
       faraday
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.15.3)
+    ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -448,7 +449,8 @@ GEM
     iiif_manifest (1.1.0)
       activesupport (>= 4)
     iso8601 (0.9.1)
-    jbuilder (2.11.2)
+    jbuilder (2.11.5)
+      actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.1)
     jquery-datatables-rails (3.4.0)
@@ -456,7 +458,7 @@ GEM
       jquery-rails
       railties (>= 3.1)
       sass-rails
-    jquery-rails (4.4.0)
+    jquery-rails (4.5.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -548,11 +550,14 @@ GEM
     llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    loofah (2.18.0)
+    loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     mailboxer (0.15.1)
       carrierwave (>= 0.5.8)
       rails (>= 5.0.0)
@@ -565,8 +570,8 @@ GEM
     mime-types-data (3.2021.0704)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
-    minitest (5.16.3)
+    mini_portile2 (2.8.1)
+    minitest (5.17.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
@@ -574,12 +579,21 @@ GEM
       redic
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     nio4r (2.5.8)
     noid (0.9.0)
     noid-rails (3.0.3)
       actionpack (>= 5.0.0, < 7)
       noid (~> 0.9)
-    nokogiri (1.13.9)
+    nokogiri (1.14.0)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nokogumbo (2.0.5)
@@ -620,8 +634,8 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.2)
       rdf
-    racc (1.6.0)
-    rack (2.2.4)
+    racc (1.6.2)
+    rack (2.2.5)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (5.2.8.1)
@@ -640,8 +654,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.3)
-      loofah (~> 2.3)
+    rails-html-sanitizer (1.4.4)
+      loofah (~> 2.19, >= 2.19.1)
     rails_autolink (1.1.6)
       rails (> 3.1)
     railties (5.2.8.1)
@@ -738,9 +752,9 @@ GEM
       rack (>= 1.4)
     retriable (3.1.2)
     rexml (3.2.5)
-    rsolr (2.3.0)
+    rsolr (2.5.0)
       builder (>= 2.1.2)
-      faraday (>= 0.9.0)
+      faraday (>= 0.9, < 3, != 2.0.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -866,6 +880,7 @@ GEM
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timeout (0.3.1)
     tinymce-rails (5.8.2)
       railties (>= 3.1.1)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
@@ -908,7 +923,7 @@ PLATFORMS
 
 DEPENDENCIES
   bixby
-  blacklight (~> 6.20.0)
+  blacklight (~> 6.25.0)
   bootstrap-sass (~> 3.0)
   bulkrax!
   byebug

--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -7,6 +7,7 @@ module Bulkrax
   class EntriesController < ApplicationController
     include Hyrax::ThemedLayoutController
     before_action :authenticate_user!
+    before_action :check_permissions
     with_themed_layout 'dashboard'
 
     def show
@@ -39,6 +40,10 @@ module Bulkrax
       add_breadcrumb 'Exporters', bulkrax.exporters_path
       add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
       add_breadcrumb @entry.id
+    end
+
+    def check_permissions
+      raise CanCan::AccessDenied unless current_ability.can_import_works? || current_ability.can_export_works?
     end
   end
 end

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -7,6 +7,7 @@ module Bulkrax
     include Hyrax::ThemedLayoutController
     include Bulkrax::DownloadBehavior
     before_action :authenticate_user!
+    before_action :check_permissions
     before_action :set_exporter, only: [:show, :edit, :update, :destroy]
     with_themed_layout 'dashboard'
 
@@ -130,6 +131,10 @@ module Bulkrax
 
     def file_path
       "#{@exporter.exporter_export_zip_path}/#{params['exporter']['exporter_export_zip_files']}"
+    end
+
+    def check_permissions
+      raise CanCan::AccessDenied unless current_ability.can_export_works?
     end
   end
 end

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -14,6 +14,7 @@ module Bulkrax
     protect_from_forgery unless: -> { api_request? }
     before_action :token_authenticate!, if: -> { api_request? }, only: [:create, :update, :delete]
     before_action :authenticate_user!, unless: -> { api_request? }
+    before_action :check_permissions
     before_action :set_importer, only: [:show, :edit, :update, :destroy]
     with_themed_layout 'dashboard'
 
@@ -318,6 +319,10 @@ module Bulkrax
         @importer.parser_fields['metadata_only'] = true
       end
       @importer.save
+    end
+
+    def check_permissions
+      raise CanCan::AccessDenied unless current_ability.can_import_works?
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/views/hyrax/dashboard/sidebar/_bulkrax_sidebar_additions.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_bulkrax_sidebar_additions.html.erb
@@ -1,7 +1,9 @@
-<% if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true' %>
+<% if current_ability.can_import_works? %>
   <%= menu.nav_link(bulkrax.importers_path) do %>
     <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
   <% end %>
+<% end %>
+<% if current_ability.can_export_works? %>
   <%= menu.nav_link(bulkrax.exporters_path) do %>
     <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
   <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,27 +1,30 @@
-  <li class="h5 nav-item"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
+<li class="h5 nav-item"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
 
-  <%= menu.nav_link(hyrax.my_collections_path,
-                    class: "nav-link",
-                    onclick: "dontChangeAccordion(event);",
-                    also_active_for: hyrax.dashboard_collections_path) do %>
-    <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
-  <% end %>
+<%= menu.nav_link(hyrax.my_collections_path,
+                  class: "nav-link",
+                  onclick: "dontChangeAccordion(event);",
+                  also_active_for: hyrax.dashboard_collections_path) do %>
+  <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+<% end %>
 
-  <%= menu.nav_link(hyrax.my_works_path,
-                    class: "nav-link",
-                    onclick: "dontChangeAccordion(event);",
-                    also_active_for: hyrax.dashboard_works_path) do %>
-    <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
-  <% end %>
+<%= menu.nav_link(hyrax.my_works_path,
+                  class: "nav-link",
+                  onclick: "dontChangeAccordion(event);",
+                  also_active_for: hyrax.dashboard_works_path) do %>
+  <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
+<% end %>
 
-  <% if ::Hyrax::DashboardController&.respond_to?(:sidebar_partials) %>
+<% if ::Hyrax::DashboardController&.respond_to?(:sidebar_partials) %>
   <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :repository_content %>
-  <% else %>
-  <%= menu.nav_link(bulkrax.importers_path) do %>
-    <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
+<% else %>
+  <% if current_ability.can_import_works? %>
+    <%= menu.nav_link(bulkrax.importers_path) do %>
+      <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
+    <% end %>
   <% end %>
-
-  <%= menu.nav_link(bulkrax.exporters_path) do %>
-    <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
+  <% if current_ability.can_export_works? %>
+    <%= menu.nav_link(bulkrax.exporters_path) do %>
+      <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
+    <% end %>
   <% end %>
-  <% end %>
+<% end %>

--- a/lib/generators/bulkrax/install_generator.rb
+++ b/lib/generators/bulkrax/install_generator.rb
@@ -60,17 +60,19 @@ class Bulkrax::InstallGenerator < Rails::Generators::Base
     file_text = File.read(file)
     import_line = 'def can_import_works?'
     export_line = 'def can_export_works?'
-    if !file_text.include?(import_line)
-      insert_into_file file, before: /\s*def can_create_any_work\?/ do
-        "    def can_import_works?\n      can_create_any_work?\n    end"
+    unless file_text.include?(import_line)
+      insert_into_file file, before: /^end/ do
+        "  def can_import_works?\n    can_create_any_work?\n  end"
       end
     end
 
-    if !file_text.include?(export_line)
-      insert_into_file file, before: /\s*def can_create_any_work\?/ do
-        "    def can_export_works?\n      can_create_any_work?\n    end"
+    # rubocop:disable Style/GuardClause
+    unless file_text.include?(export_line)
+      insert_into_file file, before: /^end/ do
+        "  def can_export_works?\n    can_create_any_work?\n  end"
       end
     end
+    # rubocop:enable Style/GuardClause
   end
 
   def add_css

--- a/lib/generators/bulkrax/install_generator.rb
+++ b/lib/generators/bulkrax/install_generator.rb
@@ -55,6 +55,24 @@ class Bulkrax::InstallGenerator < Rails::Generators::Base
     end
   end
 
+  def add_ability
+    file = 'app/models/ability.rb'
+    file_text = File.read(file)
+    import_line = 'def can_import_works?'
+    export_line = 'def can_export_works?'
+    if !file_text.include?(import_line)
+      insert_into_file file, before: /\s*def can_create_any_work\?/ do
+        "    def can_import_works?\n      can_create_any_work?\n    end"
+      end
+    end
+
+    if !file_text.include?(export_line)
+      insert_into_file file, before: /\s*def can_create_any_work\?/ do
+        "    def can_export_works?\n      can_create_any_work?\n    end"
+      end
+    end
+  end
+
   def add_css
     ['css', 'scss', 'sass'].map do |ext|
       file = "app/assets/stylesheets/application.#{ext}"

--- a/spec/controllers/bulkrax/exporters_controller_spec.rb
+++ b/spec/controllers/bulkrax/exporters_controller_spec.rb
@@ -32,7 +32,12 @@ module Bulkrax
     before do
       module Bulkrax::Auth
         def authenticate_user!
+          @current_user = User.first
           true
+        end
+
+        def current_user
+          @current_user
         end
       end
       described_class.prepend Bulkrax::Auth

--- a/spec/controllers/bulkrax/importers_controller_spec.rb
+++ b/spec/controllers/bulkrax/importers_controller_spec.rb
@@ -32,7 +32,12 @@ module Bulkrax
     before do
       module Bulkrax::Auth
         def authenticate_user!
+          @current_user = User.first
           true
+        end
+
+        def current_user
+          @current_user
         end
       end
       described_class.prepend Bulkrax::Auth

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require Rails.root.parent.parent.join('spec', 'models', 'concerns', 'bulkrax', 'dynamic_record_lookup_spec').to_s
 
 module Bulkrax
   RSpec.describe CreateRelationshipsJob, type: :job do

--- a/spec/jobs/bulkrax/import_file_set_job_spec.rb
+++ b/spec/jobs/bulkrax/import_file_set_job_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require Rails.root.parent.parent.join('spec', 'models', 'concerns', 'bulkrax', 'dynamic_record_lookup_spec').to_s
 
 module Bulkrax
   RSpec.describe ImportFileSetJob, type: :job do

--- a/spec/models/bulkrax/csv_file_set_entry_spec.rb
+++ b/spec/models/bulkrax/csv_file_set_entry_spec.rb
@@ -47,7 +47,7 @@ module Bulkrax
 
         it 'does not raise a StandardError' do
           expect { entry.validate_presence_of_filename! }
-            .not_to raise_error(StandardError)
+            .not_to raise_error
         end
       end
 

--- a/spec/models/bulkrax/object_factory_spec.rb
+++ b/spec/models/bulkrax/object_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require Rails.root.parent.parent.join('spec', 'models', 'concerns', 'bulkrax', 'dynamic_record_lookup_spec').to_s
 
 module Bulkrax
   # NOTE: Unable to put this file in spec/factories/bulkrax (where it would mirror the path in app/) because

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ Bulkrax.default_work_type = 'Work'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/dynamic_record_lookup.rb
+++ b/spec/support/dynamic_record_lookup.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 module Bulkrax
   RSpec.shared_examples 'dynamic record lookup' do
     let(:importer) { FactoryBot.create(:bulkrax_importer_csv_complex) }

--- a/spec/test_app/app/controllers/application_controller.rb
+++ b/spec/test_app/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   include Blacklight::Controller
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
-
+  skip_after_action :discard_flash_if_xhr
   protect_from_forgery with: :exception
 
 end

--- a/spec/test_app/app/models/ability.rb
+++ b/spec/test_app/app/models/ability.rb
@@ -2,7 +2,7 @@
 
 class Ability
   include Hydra::Ability
-  
+
   include Hyrax::Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
 
@@ -19,5 +19,17 @@ class Ability
     # if user_groups.include? 'special_group'
     #   can [:create], ActiveFedora::Base
     # end
+  end
+
+  def can_import_works?
+    can_create_any_work?
+  end
+
+  def can_export_works?
+    can_create_any_work?
+  end
+
+  def can_create_any_work?
+    true
   end
 end

--- a/spec/test_app/app/models/user.rb
+++ b/spec/test_app/app/models/user.rb
@@ -2,4 +2,12 @@
 
 class User < ApplicationRecord
   def self.batch_user; end
+
+  def guest?
+    false
+  end
+
+  def user_key
+    ''
+  end
 end

--- a/spec/test_app/config/application.rb
+++ b/spec/test_app/config/application.rb
@@ -19,7 +19,7 @@ module TestApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
-
+    config.active_record.sqlite3.represent_boolean_as_integer = true
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
# Issue #
Ref https://github.com/scientist-softserv/britishlibrary/issues/227

# Scope #
- [x] put limits around the sidebar links
- [x] put limits in the controllers
- [ ] scope exporter for allowed works

# For Release Notes #

There are 2 new Ability methods that need to be added to `ability.rb`. If you are using the generator, these methods will be added for you. However, if you are upgrading Bulkrax, you will need to add the following to your `app/models/ability.rb` file above the `can_create_any_works?` method definition. Feel free to adjust the definitions as needed.

```
    def can_import_works?
      can_create_any_work?
    end
    
    def can_export_works?
      can_create_any_work?
    end
```
