### PR TITLE
Scour blank strings from the creation attributes

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -16,6 +16,17 @@ module Bulkrax
     class_attribute :base_permitted_attributes,
       default: %i[id edit_users edit_groups read_groups visibility work_members_attributes admin_set_id]
 
+    # @return [Boolean]
+    #
+    # @example
+    #   Bulkrax::ObjectFactory.transformation_removes_blank_hash_values = true
+    #
+    # @see #transform_attributes
+    # @see https://github.com/samvera-labs/bulkrax/pull/708 For discussion concerning this feature
+    # @see https://github.com/samvera-labs/bulkrax/wiki/Interacting-with-Metadata For documentation
+    #      concerning default behavior.
+    class_attribute :transformation_removes_blank_hash_values, default: false
+
     define_model_callbacks :save, :create
     attr_reader :attributes, :object, :source_identifier_value, :klass, :replace_files, :update_files, :work_identifier, :related_parents_parsed_mapping, :importer_run_id
 
@@ -245,7 +256,7 @@ module Bulkrax
     def transform_attributes(update: false)
       @transform_attributes = attributes.slice(*permitted_attributes)
       @transform_attributes.merge!(file_attributes(update_files)) if with_files
-      @transform_attributes = remove_blank_hash_values(@transform_attributes)
+      @transform_attributes = remove_blank_hash_values(@transform_attributes) if transformation_removes_blank_hash_values?
       update ? @transform_attributes.except(:id) : @transform_attributes
     end
 

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -6,6 +6,14 @@ module Bulkrax
     include Bulkrax::FileFactory
     include DynamicRecordLookup
 
+    # These are the attributes that we assume all "work type" classes (e.g. the given :klass) will
+    # have in addition to their specific attributes.
+    #
+    # @return [Array<Symbol>]
+    # @see #permitted_attributes
+    class_attribute :base_permitted_attributes,
+      default: %i[id edit_users edit_groups read_groups visibility work_members_attributes admin_set_id]
+
     define_model_callbacks :save, :create
     attr_reader :attributes, :object, :source_identifier_value, :klass, :replace_files, :update_files, :work_identifier, :related_parents_parsed_mapping, :importer_run_id
 
@@ -58,7 +66,7 @@ module Bulkrax
         elsif klass == FileSet
           update_file_set(attrs)
         else
-          work_actor.update(environment(attrs))
+          update_work(attrs)
         end
       end
       object.apply_depositor_metadata(@user) && object.save! if object.depositor.nil?
@@ -104,7 +112,7 @@ module Bulkrax
           elsif klass == FileSet
             create_file_set(attrs)
           else
-            work_actor.create(environment(attrs))
+            create_work(attrs)
           end
         end
       end
@@ -137,6 +145,14 @@ module Bulkrax
 
     def work_actor
       Hyrax::CurationConcern.actor
+    end
+
+    def create_work(attrs)
+      work_actor.create(environment(attrs))
+    end
+
+    def update_work(attrs)
+      work_actor.update(environment(attrs))
     end
 
     def create_collection(attrs)
@@ -227,12 +243,32 @@ module Bulkrax
     def transform_attributes(update: false)
       @transform_attributes = attributes.slice(*permitted_attributes)
       @transform_attributes.merge!(file_attributes(update_files)) if with_files
+      @transform_attributes = remove_blank_hash_values(@transform_attributes)
       update ? @transform_attributes.except(:id) : @transform_attributes
     end
 
     # Regardless of what the Parser gives us, these are the properties we are prepared to accept.
     def permitted_attributes
-      klass.properties.keys.map(&:to_sym) + %i[id edit_users edit_groups read_groups visibility work_members_attributes admin_set_id]
+      klass.properties.keys.map(&:to_sym) + base_permitted_attributes
+    end
+
+    # Return a copy of the given attributes, such that all values that are empty or an array of all
+    # empty values are fully emptied.  (See implementation details)
+    #
+    # @param attributes [Hash]
+    # @return [Hash]
+    #
+    # @see https://github.com/emory-libraries/dlp-curate/issues/1973
+    def remove_blank_hash_values(attributes)
+      dupe = attributes.dup
+      dupe.each do |key, values|
+        if values.is_a?(Array) && values.all? { |value| value.is_a?(String) && value.empty? }
+          dupe[key] = []
+        elsif values.is_a?(String) && values.empty?
+          dupe[key] = nil
+        end
+      end
+      dupe
     end
   end
 end

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -6,6 +6,8 @@ module Bulkrax
     include Bulkrax::FileFactory
     include DynamicRecordLookup
 
+    # @api private
+    #
     # These are the attributes that we assume all "work type" classes (e.g. the given :klass) will
     # have in addition to their specific attributes.
     #

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -7,6 +7,10 @@ require 'active_support/all'
 # rubocop:disable Metrics/ModuleLength
 module Bulkrax
   class << self
+    # @todo Move from module attribute methods to a configuration class.  With module attributes,
+    #       when we make a change we are polluting the global space.  This means that our tests that
+    #       modify these config values are modifying global state.  Which is not desirous, as it can
+    #       introduce unexpected flakey tests.
     mattr_accessor :api_definition,
                    :default_field_mapping,
                    :default_work_type,

--- a/spec/factories/bulkrax/object_factory_spec.rb
+++ b/spec/factories/bulkrax/object_factory_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::ObjectFactory do
+  # Why aren't there more tests?  In part because so much of the ObjectFactory require that we boot
+  # up Fedora and SOLR; something that remains non-desirous due to speed.
+  describe "#transform_attributes" do
+    it "empties arrays that only have empty values" do
+      attributes = { empty_array: ["", ""], empty_string: "", filled_array: ["A", "B"], filled_string: "A" }
+      factory = described_class.new(attributes: attributes, source_identifier_value: 123, work_identifier: "filled_string")
+      factory.base_permitted_attributes = %i[empty_array empty_string filled_array filled_string]
+      expect(factory.send(:transform_attributes))
+        .to eq({ empty_array: [], empty_string: nil, filled_array: ["A", "B"], filled_string: "A" }.stringify_keys)
+    end
+  end
+end

--- a/spec/factories/bulkrax/object_factory_spec.rb
+++ b/spec/factories/bulkrax/object_factory_spec.rb
@@ -6,12 +6,24 @@ RSpec.describe Bulkrax::ObjectFactory do
   # Why aren't there more tests?  In part because so much of the ObjectFactory require that we boot
   # up Fedora and SOLR; something that remains non-desirous due to speed.
   describe "#transform_attributes" do
-    it "empties arrays that only have empty values" do
-      attributes = { empty_array: ["", ""], empty_string: "", filled_array: ["A", "B"], filled_string: "A" }
-      factory = described_class.new(attributes: attributes, source_identifier_value: 123, work_identifier: "filled_string")
-      factory.base_permitted_attributes = %i[empty_array empty_string filled_array filled_string]
-      expect(factory.send(:transform_attributes))
-        .to eq({ empty_array: [], empty_string: nil, filled_array: ["A", "B"], filled_string: "A" }.stringify_keys)
+    context 'default behavior' do
+      it "does not empty arrays that only have empty values" do
+        attributes = { empty_array: ["", ""], empty_string: "", filled_array: ["A", "B"], filled_string: "A" }
+        factory = described_class.new(attributes: attributes, source_identifier_value: 123, work_identifier: "filled_string")
+        factory.base_permitted_attributes = %i[empty_array empty_string filled_array filled_string]
+        expect(factory.send(:transform_attributes)).to eq(attributes.stringify_keys)
+      end
+    end
+
+    context 'when :transformation_removes_blank_hash_values = true' do
+      it "empties arrays that only have empty values" do
+        attributes = { empty_array: ["", ""], empty_string: "", filled_array: ["A", "B"], filled_string: "A" }
+        factory = described_class.new(attributes: attributes, source_identifier_value: 123, work_identifier: "filled_string")
+        factory.base_permitted_attributes = %i[empty_array empty_string filled_array filled_string]
+        factory.transformation_removes_blank_hash_values = true
+        expect(factory.send(:transform_attributes))
+          .to eq({ empty_array: [], empty_string: nil, filled_array: ["A", "B"], filled_string: "A" }.stringify_keys)
+      end
     end
   end
 end


### PR DESCRIPTION
There are three changes in this commit:

1. Exposing a class attribute
2. Scouring attribute hash
3. Extracting a method

**Exposing a class attribute**

This was added to allow for easier testing of a private method.  It also "exposes" a hidden assumption in a private method; turning that assumption into a telegraphed potential configuration point.

**Scouring attribute hash**

This resolves the reported problem by @eporter23:

> When testing an import on 9/16/22, the work row failed to validate,
> returning an error regarding "invalid entry for administrative_unit".
>
> The CSV used had the header for that field, but no values entered. Our
> preprocessors output field headers for mapped fields, but sometimes
> there are no values entered for a given header.
>
> -- https://github.com/emory-libraries/dlp-curate/issues/1973

The likely most vexing problem being an array that has only empty values.  This is likely something that should be remedied upstream in the data modeling for Hyrax models; but alas we're not there yet.

**Extracting a method**

This is a happy little refactor to create symmetry between the other create/update methods for collections and file sets.  In doing this, we provide a mechanism for folks to more readily over-ride methods at a lower level.

Related to:

- https://github.com/emory-libraries/dlp-curate/issues/1973
- https://github.com/emory-libraries/dlp-curate/pull/1981