### PR TITLE
Adding ApplicationParser#file_set_entry_class to API

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -52,6 +52,12 @@ module Bulkrax
     end
 
     # @api public
+    # @abstract Subclass and override {#file_set_entry_class} to implement behavior for the parser.
+    def file_set_entry_class
+      raise NotImplementedError, 'must be defined'
+    end
+
+    # @api public
     # @abstract Subclass and override {#records} to implement behavior for the parser.
     def records(_opts = {})
       raise NotImplementedError, 'must be defined'

--- a/app/parsers/bulkrax/xml_parser.rb
+++ b/app/parsers/bulkrax/xml_parser.rb
@@ -12,6 +12,12 @@ module Bulkrax
     # @todo not yet supported
     def create_collections; end
 
+    # @todo not yet supported
+    def file_set_entry_class; end
+
+    # @todo not yet supported
+    def create_file_sets; end
+
     # TODO: change to differentiate between collection and work records when adding ability to import collection metadata
     def works_total
       total


### PR DESCRIPTION
Prior to this commit, this method was not defined on the `ApplicationParser` yet there was an assumption in the `Bulkrax::ImportersController` and `Bulkrax::ExportersController` that this method existed.

With this commit, we're acknowledging that each parser should implement this method.

In addition this commit adds a `#create_file_sets` method for the `Bulkrax::XmlParser`.  This change mirrors the
`Bulkrax::XmlParser#create_collections` implementation and todo item.

A future state that would be wonderful is to create spec helpers that implementers could use in their specs to ensure a compliant interface. This echoes how Valkyrie does things.