### PR TITLE
Convert source_identifier from relationship to single value

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -107,7 +107,9 @@ module Bulkrax
     # Metadata required by Bulkrax for round-tripping
     def build_system_metadata
       self.parsed_metadata['id'] = hyrax_record.id
-      self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
+      source_id = hyrax_record.send(work_identifier)
+      source_id = source_id.to_a.first if source_id.is_a?(ActiveTriples::Relation)
+      self.parsed_metadata[source_identifier] = source_id
       self.parsed_metadata[key_for_export('model')] = hyrax_record.has_model.first
     end
 

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -802,6 +802,40 @@ module Bulkrax
           expect(metadata['multiple_objects_position_2_3']).to eq('Duke')
         end
       end
+
+      context 'with source_identifier field with returns a relationship' do
+        let(:exporter) do
+          FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'id' => { from: ['id'] },
+                              'multiple_objects' => { from: ['multiple_objects'], source_identifier: true }
+                            })
+        end
+        let(:source_id_rel) { double() }
+
+        let(:work_obj) do
+          Work.new(
+            title: ['test']
+          )
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return('test123')
+          allow(work_obj).to receive(:member_of_work_ids).and_return([])
+          allow(work_obj).to receive(:in_work_ids).and_return([])
+          allow(work_obj).to receive(:member_work_ids).and_return([])
+          allow(work_obj).to receive(:multiple_objects).and_return(source_id_rel)
+          allow(source_id_rel).to receive(:is_a?).with(ActiveTriples::Relation).and_return(true)
+          allow(source_id_rel).to receive(:to_a).and_return(['test_work_source_id'])
+          allow(source_id_rel).to receive(:each_with_index).and_return(['test_work_source_id', 0])
+        end
+
+        it 'succeeds' do
+          metadata = subject.build_export_metadata
+          expect(metadata['multiple_objects']).to eq('test_work_source_id')
+        end
+      end
     end
 
     describe '#build_relationship_metadata' do

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -810,7 +810,7 @@ module Bulkrax
                               'multiple_objects' => { from: ['multiple_objects'], source_identifier: true }
                             })
         end
-        let(:source_id_rel) { double() }
+        let(:source_id_rel) { double }
 
         let(:work_obj) do
           Work.new(


### PR DESCRIPTION
Address https://github.com/samvera-labs/bulkrax/issues/711

I'm not sure if this is the right approach or not, but it resolves issue #711 by converting the source_identifier field from a relationship to a single value during export. The result is that the export CSV has `work_20230117` as the source_identifier value, rather than `["work_20230117"]`. A `source_1` field is also still added in my testing, not sure if this is desirable or not.

The test is also not great, since its difficult to have fields return Relation without using Work.create, which requires running the whole stack.