### PR TITLE
Fixing bug introduced in #663

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -153,7 +153,7 @@ module Bulkrax
     # @see #create_relationships
     def create_objects(types = [])
       types.each do |object_type|
-        parser.send("create_#{object_type.pluralize}")
+        send("create_#{object_type.pluralize}")
       end
     end
 

--- a/spec/parsers/bulkrax/application_parser_spec.rb
+++ b/spec/parsers/bulkrax/application_parser_spec.rb
@@ -14,6 +14,19 @@ module Bulkrax
     let(:site) { instance_double(Site, id: 1, account_id: 1) }
     let(:account) { instance_double(Account, id: 1, name: 'bulkrax') }
 
+    describe '#create_objects' do
+      subject(:application_parser) { described_class.new(importer) }
+
+      it 'sends the create_* methods based on given types' do
+        expect(application_parser).to receive(:create_works)
+        expect(application_parser).to receive(:create_collections)
+        expect(application_parser).to receive(:create_file_sets)
+        expect(application_parser).to receive(:create_relationships)
+
+        application_parser.create_objects(%w[collection work file_set relationship])
+      end
+    end
+
     describe '#get_field_mapping_hash_for' do
       context 'with `[{}]` as the field mapping' do
         subject(:application_parser) { described_class.new(importer) }


### PR DESCRIPTION
Prior to this commit, I had refactored (in PR #663) logic to remove conditional logic.  However, I had introduced a bug, namely using `parser` and the receiver of `send`.  For the
`Bulkrax::ApplicationParser` there is no parser method.  This resulted in a notable bug.

With this commit, I'm removing `parser` as the receiver of `send` and instead favoring the implicit `self` as the receiver of `send`.