### PR TITLE
update libxml-ruby

### DIFF
--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'iso8601', '~> 0.9.0'
   s.add_dependency 'kaminari'
   s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'
-  s.add_dependency 'libxml-ruby', '~> 3.1.0'
+  s.add_dependency 'libxml-ruby', '~> 3.2.4'
   s.add_dependency 'loofah', '>= 2.2.3' # security issue, remove on rails upgrade
   s.add_dependency 'oai', '>= 0.4', '< 2.x'
   s.add_dependency 'rack', '>= 2.0.6' # security issue, remove on rails upgrade


### PR DESCRIPTION
3.1.0 can fail to compile against libxml 2.10.2+
- https://lists.freebsd.org/archives/freebsd-pkg-fallout/2022-August/266803.html
- https://gist.github.com/dunn/a0341a2c1d3c2f15810b2416a54614bb
- xml4r/libxml-ruby#195
- https://github.com/xml4r/libxml-ruby/blob/master/HISTORY#L10

also remove the lockfile, since this is a library and not an applicatoin