### PR TITLE
Ensuring CSV sets factory class before metadata parsing

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -43,6 +43,7 @@ module Bulkrax
 
       self.parsed_metadata = {}
       add_identifier
+      establish_factory_class
       add_ingested_metadata
       # TODO(alishaevn): remove the collections stuff entirely and only reference collections via the new parents code
       add_collections
@@ -57,6 +58,12 @@ module Bulkrax
 
     def add_identifier
       self.parsed_metadata[work_identifier] = [record[source_identifier]]
+    end
+
+    def establish_factory_class
+      parser.model_field_mappings.each do |key|
+        add_metadata('model', record[key]) if record.key?(key)
+      end
     end
 
     def add_metadata_for_model

--- a/spec/fixtures/csv/factory_class_test.csv
+++ b/spec/fixtures/csv/factory_class_test.csv
@@ -1,2 +1,2 @@
-work_type,,title,shape,source_identifier
+work_type,title,shape,source_identifier
 Avacado,A tasty treat,Kind of Lumpy,1234-5678

--- a/spec/fixtures/csv/factory_class_test.csv
+++ b/spec/fixtures/csv/factory_class_test.csv
@@ -1,0 +1,2 @@
+work_type,,title,shape,source_identifier
+Avacado,A tasty treat,Kind of Lumpy,1234-5678


### PR DESCRIPTION
## Ensuring CSV sets factory class before metadata parsing

dbd24b8ee1c6adc5907ef95a93dbe0fdd745ad79

Prior to this commit, if we had configured bulkrax such that we were
allowing for our model import to come from multiple fields
(e.g. `from: ['model', 'work_type']`) and the CSV had `work_type` as the
column name, we would get an error as follows:

```
NoMethodError:
  undefined method `method_defined?' for nil:NilClass
    # ./app/models/concerns/bulkrax/has_matchers.rb:128:in `field_supported?'
    # ./app/models/concerns/bulkrax/has_matchers.rb:157:in `multiple?'
    # ./app/models/concerns/bulkrax/has_matchers.rb:34:in `block in add_metadata'
    # ./app/models/concerns/bulkrax/has_matchers.rb:31:in `each'
    # ./app/models/concerns/bulkrax/has_matchers.rb:31:in `add_metadata'
    # ./app/models/bulkrax/csv_entry.rb:77:in `block in add_ingested_metadata'
    # ./app/models/bulkrax/csv_entry.rb:75:in `each'
    # ./app/models/bulkrax/csv_entry.rb:75:in `add_ingested_metadata'
    # ./app/models/bulkrax/csv_entry.rb:43:in `build_metadata'
```

Tracing this line it is because the `factory_class` is nil.  And if the
model column were to be a later column, any columns that occurred before
we established the factory class may have been skipped.

With this commit, we're echoing the functionality introduced in #705 and #703.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/211
- https://github.com/samvera-labs/bulkrax/pull/705
- https://github.com/samvera-labs/bulkrax/pull/703

Closes #718

## Update spec/fixtures/csv/factory_class_test.csv

f47505d321630c45f2782fddc5392767465951a1

Co-authored-by: Benjamin Kiah Stroud <32469930+bkiahstroud@users.noreply.github.com>