### PR TITLE
Adding config to reindex child work's file sets

### DIFF
--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -278,6 +278,22 @@ module Bulkrax
               expect(importer.current_run.reload.processed_relationships).to equal(1)
             end
           end
+
+          context 'when update_child_records_works_file_sets is true' do
+            it 'updates index of child works\'s file sets' do
+              allow(Bulkrax::PendingRelationship).to receive(:find_each).and_return([pending_rel_work])
+              allow(Ability).to receive(:new).with(importer.user)
+              allow(Hyrax::CurationConcern.actor).to receive(:update).with(instance_of(env)).and_return(true)
+              file_set = double(FileSet, update_index: true)
+              allow(child_record).to receive(:file_sets).and_return([file_set])
+              create_relationships_job.update_child_records_works_file_sets = true
+              create_relationships_job.perform(
+                parent_identifier: parent_record.id,
+                importer_run_id: importer.current_run.id
+              )
+              expect(file_set).to have_received(:update_index)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Prior to this commit, we did not expose a means to cascade indexing
deeper than the child work.

With this commit we provide a configuration point for saying "Please
reindex the file sets of the child works we're processing for this
relationship job.

Closes #721

Related to:

- https://github.com/scientist-softserv/louisville-hyku/commit/128a9ef

## Release Notes

If you wish to enable reindex child works's file sets during the
CreateRelationshipsJob, you'll want to add the following to your
`config/initializer/bulkrax.rb`:

```ruby
Bulkrax::CreateRelationshipsJob.update_child_records_works_file_sets = true
```
