### PR TITLE
check if Hyrax is defined

### DIFF
--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -23,13 +23,12 @@ module Bulkrax
       @importer = Importer.find(params[:importer_id])
       @entry = Entry.find(params[:id])
 
-      if defined?(::Hyrax)
-        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb 'Importers', bulkrax.importers_path
-        add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-        add_breadcrumb @entry.id
-      end
+      return unless defined?(::Hyrax)
+      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb 'Importers', bulkrax.importers_path
+      add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+      add_breadcrumb @entry.id
     end
 
     # GET /exporters/1/entries/1
@@ -37,13 +36,12 @@ module Bulkrax
       @exporter = Exporter.find(params[:exporter_id])
       @entry = Entry.find(params[:id])
 
-      if defined?(::Hyrax)
-        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb 'Exporters', bulkrax.exporters_path
-        add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
-        add_breadcrumb @entry.id
-      end
+      return unless defined?(::Hyrax)
+      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb 'Exporters', bulkrax.exporters_path
+      add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
+      add_breadcrumb @entry.id
     end
 
     def check_permissions

--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -5,10 +5,10 @@ require_dependency "oai"
 
 module Bulkrax
   class EntriesController < ApplicationController
-    include Hyrax::ThemedLayoutController
+    include Hyrax::ThemedLayoutController if defined?(::Hyrax)
     before_action :authenticate_user!
     before_action :check_permissions
-    with_themed_layout 'dashboard'
+    with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     def show
       if params[:importer_id].present?
@@ -23,11 +23,13 @@ module Bulkrax
       @importer = Importer.find(params[:importer_id])
       @entry = Entry.find(params[:id])
 
-      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Importers', bulkrax.importers_path
-      add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-      add_breadcrumb @entry.id
+      if defined?(::Hyrax)
+        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb 'Importers', bulkrax.importers_path
+        add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+        add_breadcrumb @entry.id
+      end
     end
 
     # GET /exporters/1/entries/1
@@ -35,11 +37,13 @@ module Bulkrax
       @exporter = Exporter.find(params[:exporter_id])
       @entry = Entry.find(params[:id])
 
-      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Exporters', bulkrax.exporters_path
-      add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
-      add_breadcrumb @entry.id
+      if defined?(::Hyrax)
+        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb 'Exporters', bulkrax.exporters_path
+        add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
+        add_breadcrumb @entry.id
+      end
     end
 
     def check_permissions

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -4,24 +4,26 @@ require_dependency "bulkrax/application_controller"
 
 module Bulkrax
   class ExportersController < ApplicationController
-    include Hyrax::ThemedLayoutController
+    include Hyrax::ThemedLayoutController if defined?(::Hyrax)
     include Bulkrax::DownloadBehavior
     before_action :authenticate_user!
     before_action :check_permissions
     before_action :set_exporter, only: [:show, :edit, :update, :destroy]
-    with_themed_layout 'dashboard'
+    with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     # GET /exporters
     def index
       @exporters = Exporter.all
 
-      add_exporter_breadcrumbs
+      add_exporter_breadcrumbs if defined?(::Hyrax)
     end
 
     # GET /exporters/1
     def show
-      add_exporter_breadcrumbs
-      add_breadcrumb @exporter.name
+      if defined?(::Hyrax)
+        add_exporter_breadcrumbs
+        add_breadcrumb @exporter.name
+      end
 
       @work_entries = @exporter.entries.where(type: @exporter.parser.entry_class.to_s).page(params[:work_entries_page]).per(30)
       @collection_entries = @exporter.entries.where(type: @exporter.parser.collection_entry_class.to_s).page(params[:collections_entries_page]).per(30)
@@ -31,16 +33,19 @@ module Bulkrax
     # GET /exporters/new
     def new
       @exporter = Exporter.new
-
-      add_exporter_breadcrumbs
-      add_breadcrumb 'New'
+      if defined?(::Hyrax)
+        add_exporter_breadcrumbs
+        add_breadcrumb 'New' if defined?(::Hyrax)
+      end
     end
 
     # GET /exporters/1/edit
     def edit
-      add_exporter_breadcrumbs
-      add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
-      add_breadcrumb 'Edit'
+      if defined?(::Hyrax)
+        add_exporter_breadcrumbs
+        add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
+        add_breadcrumb 'Edit'
+      end
 
       # Correctly populate export_source_collection input
       @collection = Collection.find(@exporter.export_source) if @exporter.export_source.present? && @exporter.export_from == 'collection'

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -33,10 +33,9 @@ module Bulkrax
     # GET /exporters/new
     def new
       @exporter = Exporter.new
-      if defined?(::Hyrax)
-        add_exporter_breadcrumbs
-        add_breadcrumb 'New' if defined?(::Hyrax)
-      end
+      return unless defined?(::Hyrax)
+      add_exporter_breadcrumbs
+      add_breadcrumb 'New'
     end
 
     # GET /exporters/1/edit

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -23,8 +23,8 @@ module Bulkrax
       @importers = Importer.all
       if api_request?
         json_response('index')
-      else
-        add_importer_breadcrumbs if defined?(::Hyrax)
+      elsif defined?(::Hyrax)
+        add_importer_breadcrumbs
       end
     end
 

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -6,7 +6,7 @@ require_dependency 'oai'
 module Bulkrax
   # rubocop:disable Metrics/ClassLength
   class ImportersController < ApplicationController
-    include Hyrax::ThemedLayoutController
+    include Hyrax::ThemedLayoutController if defined?(::Hyrax)
     include Bulkrax::DownloadBehavior
     include Bulkrax::API
     include Bulkrax::ValidationHelper
@@ -16,7 +16,7 @@ module Bulkrax
     before_action :authenticate_user!, unless: -> { api_request? }
     before_action :check_permissions
     before_action :set_importer, only: [:show, :edit, :update, :destroy]
-    with_themed_layout 'dashboard'
+    with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     # GET /importers
     def index
@@ -24,7 +24,7 @@ module Bulkrax
       if api_request?
         json_response('index')
       else
-        add_importer_breadcrumbs
+        add_importer_breadcrumbs if defined?(::Hyrax)
       end
     end
 
@@ -33,8 +33,10 @@ module Bulkrax
       if api_request?
         json_response('show')
       else
-        add_importer_breadcrumbs
-        add_breadcrumb @importer.name
+        if defined?(::Hyrax)
+          add_importer_breadcrumbs
+          add_breadcrumb @importer.name
+        end
 
         @work_entries = @importer.entries.where(type: @importer.parser.entry_class.to_s).page(params[:work_entries_page]).per(30)
         @collection_entries = @importer.entries.where(type: @importer.parser.collection_entry_class.to_s).page(params[:collections_entries_page]).per(30)
@@ -48,8 +50,10 @@ module Bulkrax
       if api_request?
         json_response('new')
       else
-        add_importer_breadcrumbs
-        add_breadcrumb 'New'
+        if defined?(::Hyrax)
+          add_importer_breadcrumbs
+          add_breadcrumb 'New'
+        end
       end
     end
 
@@ -58,9 +62,11 @@ module Bulkrax
       if api_request?
         json_response('edit')
       else
-        add_importer_breadcrumbs
-        add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-        add_breadcrumb 'Edit'
+        if defined?(::Hyrax)
+          add_importer_breadcrumbs
+          add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+          add_breadcrumb 'Edit'
+        end
       end
     end
 
@@ -159,11 +165,13 @@ module Bulkrax
     # GET /importer/1/upload_corrected_entries
     def upload_corrected_entries
       @importer = Importer.find(params[:importer_id])
-      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Importers', bulkrax.importers_path
-      add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-      add_breadcrumb 'Upload Corrected Entries'
+      if defined?(::Hyrax)
+        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb 'Importers', bulkrax.importers_path
+        add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+        add_breadcrumb 'Upload Corrected Entries'
+      end
     end
 
     # POST /importer/1/upload_corrected_entries_file

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -32,11 +32,9 @@ module Bulkrax
     def show
       if api_request?
         json_response('show')
-      else
-        if defined?(::Hyrax)
-          add_importer_breadcrumbs
-          add_breadcrumb @importer.name
-        end
+      elsif defined?(::Hyrax)
+        add_importer_breadcrumbs
+        add_breadcrumb @importer.name
 
         @work_entries = @importer.entries.where(type: @importer.parser.entry_class.to_s).page(params[:work_entries_page]).per(30)
         @collection_entries = @importer.entries.where(type: @importer.parser.collection_entry_class.to_s).page(params[:collections_entries_page]).per(30)
@@ -49,11 +47,9 @@ module Bulkrax
       @importer = Importer.new
       if api_request?
         json_response('new')
-      else
-        if defined?(::Hyrax)
-          add_importer_breadcrumbs
-          add_breadcrumb 'New'
-        end
+      elsif defined?(::Hyrax)
+        add_importer_breadcrumbs
+        add_breadcrumb 'New'
       end
     end
 
@@ -61,12 +57,10 @@ module Bulkrax
     def edit
       if api_request?
         json_response('edit')
-      else
-        if defined?(::Hyrax)
-          add_importer_breadcrumbs
-          add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-          add_breadcrumb 'Edit'
-        end
+      elsif defined?(::Hyrax)
+        add_importer_breadcrumbs
+        add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+        add_breadcrumb 'Edit'
       end
     end
 
@@ -165,13 +159,12 @@ module Bulkrax
     # GET /importer/1/upload_corrected_entries
     def upload_corrected_entries
       @importer = Importer.find(params[:importer_id])
-      if defined?(::Hyrax)
-        add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb 'Importers', bulkrax.importers_path
-        add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-        add_breadcrumb 'Upload Corrected Entries'
-      end
+      return unless defined?(::Hyrax)
+      add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb 'Importers', bulkrax.importers_path
+      add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
+      add_breadcrumb 'Upload Corrected Entries'
     end
 
     # POST /importer/1/upload_corrected_entries_file

--- a/app/helpers/bulkrax/application_helper.rb
+++ b/app/helpers/bulkrax/application_helper.rb
@@ -3,7 +3,7 @@ require 'coderay'
 
 module Bulkrax
   module ApplicationHelper
-    include ::Hyrax::HyraxHelperBehavior
+    include ::Hyrax::HyraxHelperBehavior if defined?(::Hyrax)
 
     def coderay(value, opts)
       CodeRay


### PR DESCRIPTION
Closes #729 and closes #730 

Wrapping references to Hyrax and Breadcrumbs with `is_defined?(::Hyrax)` fixes these errors in non-Hyrax based applications that install Bulkrax.