### PR TITLE
Favoring ActiveRecord query over in-memory select

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -51,9 +51,9 @@ module Bulkrax
     # parent_identifier or child_identifier param. For example, if a parent_identifier is passed, we know @base_entry
     # is the child in the relationship, and vice versa if a child_identifier is passed.
     def perform(parent_identifier:, importer_run_id:) # rubocop:disable Metrics/AbcSize
-      pending_relationships = Bulkrax::PendingRelationship.find_each.select do |rel|
-        rel.importer_run_id == importer_run_id && rel.parent_id == parent_identifier
-      end.sort_by(&:order)
+      pending_relationships = Bulkrax::PendingRelationship
+                                .where(importer_run_id: importer_run_id, parent_id: parent_identifier)
+                                .order(:order)
 
       @importer_run_id = importer_run_id
       @parent_entry, @parent_record = find_record(parent_identifier, importer_run_id)


### PR DESCRIPTION
Prior to this commit, we were using array selection.  This loads each object into memory and then selects based on the criteria.

With this commit, we're relying on ActiveRecord's querying to perform the selection.  This means we only load in memory the objects that match our selection criteria.