### PR TITLE
exporter errors for non hyrax apps

### DIFF
--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -69,7 +69,7 @@ module Bulkrax
     end
 
     def workflow_status_list
-      Sipity::WorkflowState.all.map { |s| [s.name&.titleize, s.name] }.uniq
+      Sipity::WorkflowState.all.map { |s| [s.name&.titleize, s.name] }.uniq if defined?(::Hyrax)
     end
 
     # If field_mapping is empty, setup a default based on the export_properties
@@ -84,12 +84,20 @@ module Bulkrax
     end
 
     def export_from_list
-      [
-        [I18n.t('bulkrax.exporter.labels.importer'), 'importer'],
-        [I18n.t('bulkrax.exporter.labels.collection'), 'collection'],
-        [I18n.t('bulkrax.exporter.labels.worktype'), 'worktype'],
-        [I18n.t('bulkrax.exporter.labels.all'), 'all']
-      ]
+      if defined?(::Hyrax)
+        [
+          [I18n.t('bulkrax.exporter.labels.importer'), 'importer'],
+          [I18n.t('bulkrax.exporter.labels.collection'), 'collection'],
+          [I18n.t('bulkrax.exporter.labels.worktype'), 'worktype'],
+          [I18n.t('bulkrax.exporter.labels.all'), 'all']
+        ]
+      else
+        [
+          [I18n.t('bulkrax.exporter.labels.importer'), 'importer'],
+          [I18n.t('bulkrax.exporter.labels.collection'), 'collection'],
+          [I18n.t('bulkrax.exporter.labels.all'), 'all']
+        ]
+      end
     end
 
     def export_type_list

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -50,13 +50,15 @@
     }
   %>
 
-  <%= form.input :export_source_worktype,
-    label: t('bulkrax.exporter.labels.worktype'),
-    required: true,
-    prompt: 'Select from the list',
-    label_html: { class: 'worktype export-source-option hidden' },
-    input_html: { class: 'worktype export-source-option hidden' },
-    collection: Hyrax.config.curation_concerns.map {|cc| [cc.to_s, cc.to_s] } %>
+  <%  if defined?(::Hyrax) %>
+    <%= form.input :export_source_worktype,
+      label: t('bulkrax.exporter.labels.worktype'),
+      required: true,
+      prompt: 'Select from the list',
+      label_html: { class: 'worktype export-source-option hidden' },
+      input_html: { class: 'worktype export-source-option hidden' },
+      collection: Hyrax.config.curation_concerns.map {|cc| [cc.to_s, cc.to_s] } %>
+  <% end %>
 
   <%= form.input :limit,
     as: :integer,
@@ -85,13 +87,17 @@
                    as: :date,
                    label: t('bulkrax.exporter.labels.finish_date') %>
   </div>
-  <%= form.input :work_visibility,
-                 collection: form.object.work_visibility_list,
-                 label: t('bulkrax.exporter.labels.visibility') %>
+  <% if defined?(::Hyrax) %>
+    <%= form.input :work_visibility,
+                   collection: form.object.work_visibility_list,
+                  label: t('bulkrax.exporter.labels.visibility') %>
+  <% end %>
 
-  <%= form.input :workflow_status,
-                 collection: form.object.workflow_status_list,
-                 label: t('bulkrax.exporter.labels.status') %>
+  <% if defined?(::Hyrax) %>
+    <%= form.input :workflow_status,
+                  collection: form.object.workflow_status_list,
+                  label: t('bulkrax.exporter.labels.status') %>
+  <% end %>
 
   <%= form.input :parser_klass,
     collection: Bulkrax.parsers.map {|p| [p[:name], p[:class_name], {'data-partial' => p[:partial]}] if p[:class_name].constantize.export_supported? }.compact,


### PR DESCRIPTION
Closes #733 

When Bulkrax is installed on a non-Hyrax application, there are errors with the Exporters forms. This PR addresses these errros:
- Exporter form checks to see if Hyrax is defined for worktype, visibility and sipity workflow status
- Exporter model checks to see if Hyrax is defined for workflow status list
- Removes worktype from export_from_list in exporter model because worktype is a Hyrax concept