### PR TITLE
Renaming method to reflect it's state changing nature

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -76,7 +76,7 @@ module Bulkrax
       create_relationships
       pending_relationships.each(&:destroy)
     rescue ::StandardError => e
-      parent_entry ? parent_entry.status_info(e) : child_entry.status_info(e)
+      parent_entry ? parent_entry.set_status_info(e) : child_entry.set_status_info(e)
       Bulkrax::ImporterRun.find(importer_run_id).increment!(:failed_relationships) # rubocop:disable Rails/SkipsModelValidations
     end
 

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -13,7 +13,7 @@ module Bulkrax
       entry.save!
       entry.importer.current_run = ImporterRun.find(importer_run.id)
       entry.importer.record_status
-      entry.status_info("Deleted", ImporterRun.find(importer_run.id))
+      entry.set_status_info("Deleted", ImporterRun.find(importer_run.id))
     end
     # rubocop:enable Rails/SkipsModelValidations
   end

--- a/app/jobs/bulkrax/export_work_job.rb
+++ b/app/jobs/bulkrax/export_work_job.rb
@@ -29,9 +29,9 @@ module Bulkrax
       return entry if exporter_run.enqueued_records.positive?
 
       if exporter_run.failed_records.positive?
-        exporter_run.exporter.status_info('Complete (with failures)')
+        exporter_run.exporter.set_status_info('Complete (with failures)')
       else
-        exporter_run.exporter.status_info('Complete')
+        exporter_run.exporter.set_status_info('Complete')
       end
 
       return entry

--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -41,7 +41,7 @@ module Bulkrax
         ImportFileSetJob.set(wait: (entry.import_attempts + 1).minutes).perform_later(entry_id, importer_run_id)
       else
         ImporterRun.find(importer_run_id).decrement!(:enqueued_records) # rubocop:disable Rails/SkipsModelValidations
-        entry.status_info(e)
+        entry.set_status_info(e)
       end
     end
 

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -13,7 +13,7 @@ module Bulkrax
       update_current_run_counters(importer)
       schedule(importer) if importer.schedulable?
     rescue CSV::MalformedCSVError => e
-      importer.status_info(e)
+      importer.set_status_info(e)
     end
 
     def import(importer, only_updates_since_last_import)

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -47,12 +47,12 @@ module Bulkrax
       if importer_run.failed_records.positive?
         if importer_run.invalid_records.present?
           e = Bulkrax::ImportFailed.new('Failed with Invalid Records', importer_run.invalid_records.split("\n"))
-          importer_run.importer.status_info(e)
+          importer_run.importer.set_status_info(e)
         else
-          importer_run.importer.status_info('Complete (with failures)')
+          importer_run.importer.set_status_info('Complete (with failures)')
         end
       else
-        importer_run.importer.status_info('Complete')
+        importer_run.importer.set_status_info('Complete')
       end
     end
 

--- a/app/models/concerns/bulkrax/status_info.rb
+++ b/app/models/concerns/bulkrax/status_info.rb
@@ -33,15 +33,20 @@ module Bulkrax
       current_status&.created_at
     end
 
-    def status_info(e = nil, current_run = nil)
+    def set_status_info(e = nil, current_run = nil)
+      runnable = current_run || last_run
       if e.nil?
-        self.statuses.create!(status_message: 'Complete', runnable: current_run || last_run)
+        self.statuses.create!(status_message: 'Complete', runnable: runnable)
       elsif e.is_a?(String)
-        self.statuses.create!(status_message: e, runnable: current_run || last_run)
+        self.statuses.create!(status_message: e, runnable: runnable)
       else
-        self.statuses.create!(status_message: 'Failed', runnable: current_run || last_run, error_class: e.class.to_s, error_message: e.message, error_backtrace: e.backtrace)
+        self.statuses.create!(status_message: 'Failed', runnable: runnable, error_class: e.class.to_s, error_message: e.message, error_backtrace: e.backtrace)
       end
     end
+
+    alias status_info set_status_info
+
+    deprecation_deprecate status_info: "Favor Bulkrax::StatusInfo.set_status_info.  We will be removing .status_info in Bulkrax v6.0.0"
 
     # api compatible with previous error structure
     def last_error

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -143,7 +143,7 @@ module Bulkrax
           begin
             bag.add_file(file_name, file.path) if bag.bag_files.select { |b| b.include?(file_name) }.blank?
           rescue => e
-            entry.status_info(e)
+            entry.set_status_info(e)
             status_info(e)
           end
         end

--- a/spec/jobs/bulkrax/import_file_set_job_spec.rb
+++ b/spec/jobs/bulkrax/import_file_set_job_spec.rb
@@ -105,7 +105,7 @@ module Bulkrax
             end
 
             it 'logs a MissingParentError on the entry' do
-              expect(entry).to receive(:status_info).with(instance_of(MissingParentError))
+              expect(entry).to receive(:set_status_info).with(instance_of(MissingParentError))
 
               import_file_set_job.perform(entry.id, importer_run.id)
             end


### PR DESCRIPTION
Prior to this commit, `status_info` was changing underlying runner information.  This is unexpected behavior given the method name (status_info implies getting information about the status information.)

With this commit, I'm deprecating the `status_info` method with a v6.0.0 deprecation horizon.