### PR TITLE
only uses admin sets if Hyrax is present

### DIFF
--- a/app/helpers/bulkrax/importers_helper.rb
+++ b/app/helpers/bulkrax/importers_helper.rb
@@ -2,9 +2,9 @@
 
 module Bulkrax
   module ImportersHelper
-    # borrowd from batch-importer https://github.com/samvera-labs/hyrax-batch_ingest/blob/main/app/controllers/hyrax/batch_ingest/batches_controller.rb
+    # borrowed from batch-importer https://github.com/samvera-labs/hyrax-batch_ingest/blob/main/app/controllers/hyrax/batch_ingest/batches_controller.rb
     def available_admin_sets
-      # Restrict available_admin_sets to only those current user can desposit to.
+      # Restrict available_admin_sets to only those current user can deposit to.
       @available_admin_sets ||= Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set').map do |admin_set_id|
         [AdminSet.find(admin_set_id).title.first, admin_set_id]
       end

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -15,7 +15,7 @@ module Bulkrax
     has_many :entries, as: :importerexporter, dependent: :destroy
 
     validates :name, presence: true
-    validates :admin_set_id, presence: true
+    validates :admin_set_id, presence: true if defined?(::Hyrax)
     validates :parser_klass, presence: true
 
     delegate :valid_import?, :write_errored_entries_file, :visibility, to: :parser

--- a/app/views/bulkrax/importers/_form.html.erb
+++ b/app/views/bulkrax/importers/_form.html.erb
@@ -13,7 +13,7 @@
 
   <%= form.input :name, input_html: { class: 'form-control' } %>
 
-  <%= form.input :admin_set_id, collection: available_admin_sets %>
+  <%= form.input :admin_set_id, collection: available_admin_sets if defined?(::Hyrax) %>
 
   <%= form.hidden_field :user_id, value: current_user.id %>
 


### PR DESCRIPTION
Only uses admin sets in importer creation if Bulkrax is installed in a Hyrax instance.