### PR TITLE
Fix #add_to_work

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -112,7 +112,7 @@ module Bulkrax
     end
 
     def add_to_work(child_record, parent_record)
-      return true if parent_record.ordered_members.include?(child_record)
+      return true if parent_record.ordered_members.to_a.include?(child_record)
 
       parent_record.ordered_members << child_record
       @parent_record_members_added = true


### PR DESCRIPTION
`ordered_members` needed to be transformed into an Array before `#include?` could be called, otherwise we get a `NoMethodError`.