### PR TITLE
i289 Exporter Issue

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -169,7 +169,7 @@ module Bulkrax
         next unless hyrax_record.respond_to?(key.to_s) || object_key.present?
         models_to_skip = Array.wrap(value.fetch('skip_object_for_model_names', []))
 
-        if object_key.present? && !models_to_skip.detect{ |s| hyrax_record.model_name.name == s }
+        if object_key.present? && !models_to_skip.detect { |s| hyrax_record.model_name.name == s }
           build_object(value)
         else
           build_value(key, value)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -167,8 +167,9 @@ module Bulkrax
 
         object_key = key if value.key?('object')
         next unless hyrax_record.respond_to?(key.to_s) || object_key.present?
+        models_to_skip = Array.wrap(value.fetch('skip_object_for_model_names', []))
 
-        if object_key.present?
+        if object_key.present? && !models_to_skip.detect{ |s| hyrax_record.model_name.name == s }
           build_object(value)
         else
           build_value(key, value)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -157,27 +157,46 @@ module Bulkrax
       end
     end
 
-    def build_mapping_metadata
-      mapping = fetch_field_mapping
-      mapping.each do |key, value|
-        # these keys are handled by other methods
-        next if ['model', 'file', related_parents_parsed_mapping, related_children_parsed_mapping].include?(key)
-        next if value['excluded']
-        next if Bulkrax.reserved_properties.include?(key) && !field_supported?(key)
+    # The purpose of this helper module is to make easier the testing of the rather complex
+    # switching logic for determining the method we use for building the value.
+    module AttributeBuilderMethod
+      # @param key [Symbol]
+      # @param value [Hash<String, Object>]
+      # @param entry [Bulkrax::Entry]
+      #
+      # @return [NilClass] when we won't be processing this field
+      # @return [Symbol] (either :build_value or :build_object)
+      def self.for(key:, value:, entry:)
+        return if key == 'model'
+        return if key == 'file'
+        return if key == entry.related_parents_parsed_mapping
+        return if key == entry.related_children_parsed_mapping
+        return if value['excluded'] || value[:excluded]
+        return if Bulkrax.reserved_properties.include?(key) && !entry.field_supported?(key)
 
-        object_key = key if value.key?('object')
-        next unless hyrax_record.respond_to?(key.to_s) || object_key.present?
-        models_to_skip = Array.wrap(value.fetch('skip_object_for_model_names', []))
+        object_key = key if value.key?('object') || value.key?(:object)
+        return unless entry.hyrax_record.respond_to?(key.to_s) || object_key.present?
 
-        if object_key.present? && !models_to_skip.detect { |s| hyrax_record.model_name.name == s }
-          build_object(value)
-        else
-          build_value(key, value)
-        end
+        models_to_skip = Array.wrap(value['skip_object_for_model_names'] || value[:skip_object_for_model_names] || [])
+
+        return :build_value if models_to_skip.detect { |model| entry.factory_class.model_name.name == model }
+        return :build_object if object_key.present?
+
+        :build_value
       end
     end
 
-    def build_object(value)
+    def build_mapping_metadata
+      mapping = fetch_field_mapping
+      mapping.each do |key, value|
+        method_name = AttributeBuilderMethod.for(key: key, value: value, entry: self)
+        next unless method_name
+
+        send(method_name, key, value)
+      end
+    end
+
+    def build_object(_key, value)
       data = hyrax_record.send(value['object'])
       return if data.empty?
 
@@ -218,6 +237,14 @@ module Bulkrax
     end
 
     def object_metadata(data)
+      # NOTE: What is `d` in this case:
+      #
+      #  "[{\"single_object_first_name\"=>\"Fake\", \"single_object_last_name\"=>\"Fakerson\", \"single_object_position\"=>\"Leader, Jester, Queen\", \"single_object_language\"=>\"english\"}]"
+      #
+      # The above is a stringified version of a Ruby string.  Using eval is a very bad idea as it
+      # will execute the value of `d` within the full Ruby interpreter context.
+      #
+      # TODO: Would it be possible to store this as a non-string?  Maybe the actual Ruby Array and Hash?
       data = data.map { |d| eval(d) }.flatten # rubocop:disable Security/Eval
 
       data.each_with_index do |obj, index|

--- a/app/models/bulkrax/exporter.rb
+++ b/app/models/bulkrax/exporter.rb
@@ -18,16 +18,7 @@ module Bulkrax
 
     def export
       current_run && setup_export_path
-      case self.export_from
-      when 'collection'
-        create_from_collection
-      when 'importer'
-        create_from_importer
-      when 'worktype'
-        create_from_worktype
-      when 'all'
-        create_from_all
-      end
+      send("create_from_#{self.export_from}")
     rescue StandardError => e
       status_info(e)
     end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -18,6 +18,31 @@ module Bulkrax
       end
     end
 
+    context 'AttributeBuilderMethod.for' do
+      # Why is this spec here?  Because we have a LOT of before blocks that are saying stubbing and
+      # allowing different things.  When I had this method in a more logical place, it was getting
+      # the following error:
+      #
+      #   ArgumentError: Cannot proxy frozen objects. Symbols such as build_value cannot be mocked
+      #                  or stubbed.
+      context 'with valid field that is declared as an object but model skips object' do
+        let(:my_model) { FileSet }
+        let(:hyrax_record) { my_model.new }
+        let(:value) { { object: "creator", skip_object_for_model_names: [my_model.model_name.name.to_s] } }
+        let(:entry) do
+          double(described_class,
+                 hyrax_record: hyrax_record,
+                 related_parents_parsed_mapping: 'parents',
+                 related_children_parsed_mapping: 'children',
+                 factory_class: my_model,
+                 field_supported?: true)
+        end
+        subject { described_class::AttributeBuilderMethod.for(key: "creator", value: value, entry: entry) }
+
+        it { is_expected.to eq :build_value }
+      end
+    end
+
     describe '#build_metadata' do
       around do |spec|
         # Why am I doing this instead of passing it into the parser?  Because of


### PR DESCRIPTION
## refactor export method

fefd7344f6ff352197da52babd8dd8b3b814c7fd


## WIP: set up configuration for skip_object_for_model_names

47180367b0189580fb3c0b53c0a4c4b696cccb21


## fix linting error

fb91aa7e48b01d7c29ee21a9e1bff997adb71430


## Extracting helper module and tests for new feature

bea021a361c6bf0cb292bbdfdc1be32144794935

With this commit, we introduce the tested property of
'skip_object_for_model_names' for a parser line.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/289
