### PR TITLE
Adding `Bulkrax::ParserExportRecordSet`

### DIFF
--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -85,18 +85,6 @@ module Bulkrax
       status_info(e)
     end
 
-    def total
-      @total = importer.parser_fields['total'] || 0 if importer?
-
-      @total = if exporter?
-                 limit.nil? || limit.zero? ? current_record_ids.count : limit
-               end
-
-      return @total || 0
-    rescue StandardError
-      @total = 0
-    end
-
     # export methods
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  # This module is responsible for providing the means of querying Solr for the appropriate works,
+  # collections, and file sets for an export of entries.
+  #
+  # @see .for
+  module ParserExportRecordSet
+    # @api public
+    #
+    # A factory method for returning an object that can yield each id and associated entry_class as
+    # well as return the count of objects in the record set.
+    #
+    # @param parser [Bulkrax::ApplicationParser]
+    # @param export_from [String]
+    #
+    # @return [#each, #count] An object, likely a descendant of
+    #         {Bulkrax::CurrentParserRecordSet::Base} that responds to {Base#count} and
+    #         {Base#each}.
+    def self.for(parser:, export_from:)
+      "Bulkrax::ParserExportRecordSet::#{export_from.classify}".constantize.new(parser: parser)
+    end
+
+    # @abstract
+    #
+    # @note This has {#each} and {#count} but is not an Enumerable.  But because it has these two
+    #       methods that echo {Array}, we can do some lovely mocking and stubbing in those classes
+    #       dependent on this file.  :)
+    class Base
+      def initialize(parser:)
+        @parser = parser
+      end
+      attr_reader :parser
+      private :parser
+
+      delegate :limit_reached?, :work_entry_class, :collection_entry_class, :file_set_entry_class, :importerexporter, to: :parser
+      private :limit_reached?, :work_entry_class, :collection_entry_class, :file_set_entry_class, :importerexporter
+
+      # @return [Integer]
+      def count
+        sum = works.count + collections.count + file_sets_count
+        return sum if limit.zero?
+        return limit if sum > limit
+        return sum
+      end
+
+      # Yield first the works, then collections, then file sets.  Once we've yielded as many times
+      # as the parser's limit, we break the iteration and return.
+      #
+      # @yieldparam id [String] The ID of the work/collection/file_set
+      # @yieldparam entry_class [Class] The parser associated entry class for the
+      #             work/collection/file_set.
+      #
+      # @note The order of what we yield has been previously determined.
+      def each
+        counter = 0
+
+        works.each do |work|
+          break if limit_reached?(limit, counter)
+          yield(work.fetch('id'), work_entry_class)
+          counter += 1
+        end
+
+        return if limit_reached?(limit, counter)
+
+        collections.each do |collection|
+          break if limit_reached?(limit, counter)
+          yield(collection.fetch('id'), collection_entry_class)
+          counter += 1
+        end
+
+        return if limit_reached?(limit, counter)
+
+        # Why this approach instead of the above?  Because the rules for file sets vary across the
+        # different subclasses of the Base class.
+        each_file_set_id do |file_set_id|
+          break if limit_reached?(limit, counter)
+          yield(file_set_id, file_set_entry_class)
+          counter += 1
+        end
+      end
+
+      private
+
+      def file_sets_count
+        works.sum { |work| work.fetch("file_set_ids_ssim", []).size }
+      end
+
+      # @note Specifically not memoizing this so we can merge values without changing the object.
+      #
+      # No sense attempting to query for more than the limit.
+      def query_kwargs
+        { fl: "id,file_set_ids_ssim", method: :post, rows: row_limit }
+      end
+
+      # If we have a limit, we need not query beyond that limit
+      def row_limit
+        return 2_147_483_647 if limit.zero?
+        limit
+      end
+
+      def limit
+        parser.limit.to_i
+      end
+
+      alias works_query_kwargs query_kwargs
+      alias collections_query_kwargs query_kwargs
+
+      def extra_filters
+        output = ""
+        if importerexporter.start_date.present?
+          start_dt = importerexporter.start_date.to_datetime.strftime('%FT%TZ')
+          finish_dt = importerexporter.finish_date.present? ? importerexporter.finish_date.to_datetime.end_of_day.strftime('%FT%TZ') : "NOW"
+          output += " AND system_modified_dtsi:[#{start_dt} TO #{finish_dt}]"
+        end
+        output += importerexporter.work_visibility.present? ? " AND visibility_ssi:#{importerexporter.work_visibility}" : ""
+        output += importerexporter.workflow_status.present? ? " AND workflow_state_name_ssim:#{importerexporter.workflow_status}" : ""
+        output
+      end
+
+      def works
+        @works ||= ActiveFedora::SolrService.query(works_query, **works_query_kwargs)
+      end
+
+      def collections
+        @collections ||= if collections_query
+                           ActiveFedora::SolrService.query(collections_query, **collections_query_kwargs)
+                         else
+                           []
+                         end
+      end
+
+      def solr_name(base_name)
+        if Module.const_defined?(:Solrizer)
+          ::Solrizer.solr_name(base_name)
+        else
+          ::ActiveFedora.index_field_mapper.solr_name(base_name)
+        end
+      end
+
+      def each_file_set_id
+        works.each do |work|
+          work.fetch("file_set_ids_ssim", []).each do |file_set_id|
+            yield(file_set_id)
+          end
+        end
+      end
+    end
+
+    class All < Base
+      def works_query
+        "has_model_ssim:(#{Hyrax.config.curation_concerns.join(' OR ')}) #{extra_filters}"
+      end
+
+      def collections_query
+        "has_model_ssim:Collection #{extra_filters}"
+      end
+    end
+
+    class Collection < Base
+      def works_query
+        "member_of_collection_ids_ssim:#{importerexporter.export_source} #{extra_filters} AND " \
+        "has_model_ssim:(#{Hyrax.config.curation_concerns.join(' OR ')})"
+      end
+
+      def collections_query
+        "(id:#{importerexporter.export_source} #{extra_filters}) OR " \
+        "(has_model_ssim:Collection AND member_of_collection_ids_ssim:#{importerexporter.export_source})"
+      end
+    end
+
+    class Worktype < Base
+      def works_query
+        "has_model_ssim:#{importerexporter.export_source} #{extra_filters}"
+      end
+
+      def collections_query
+        nil
+      end
+    end
+
+    class Importer < Base
+      private
+
+      delegate :work_identifier, to: :parser
+      private :work_identifier
+
+      def extra_filters
+        super || '*.*'
+      end
+
+      def complete_entry_identifiers
+        @complete_entry_identifiers ||=
+          begin
+            entry_ids ||= Bulkrax::Importer.find(importerexporter.export_source).entries.pluck(:id)
+            complete_statuses ||= Bulkrax::Status.latest_by_statusable
+                                                 .includes(:statusable)
+                                                 .where('bulkrax_statuses.statusable_id IN (?) AND bulkrax_statuses.statusable_type = ? AND status_message = ?', entry_ids, 'Bulkrax::Entry', 'Complete')
+
+            complete_statuses.map { |s| s.statusable&.identifier&.gsub(':', '\:') }
+          end
+      end
+
+      def works_query_kwargs
+        query_kwargs.merge(
+          fq: [
+            %(#{solr_name(work_identifier)}:("#{complete_entry_identifiers.join('" OR "')}")),
+            "has_model_ssim:(#{Hyrax.config.curation_concerns.join(' OR ')})"
+          ],
+          fl: 'id'
+        )
+      end
+
+      def works_query
+        extra_filters.to_s
+      end
+
+      def collections_query_kwargs
+        query_kwargs.merge(
+          fq: [
+            %(#{solr_name(work_identifier)}:("#{complete_entry_identifiers.join('" OR "')}")),
+            "has_model_ssim:Collection"
+          ],
+          fl: 'id'
+        )
+      end
+
+      def collections_query
+        "has_model_ssim:Collection #{extra_filters}"
+      end
+
+      def file_sets_query_kwargs
+        query_kwargs.merge(
+          fq: [
+            %(#{solr_name(work_identifier)}:("#{complete_entry_identifiers.join('" OR "')}")),
+            "has_model_ssim:FileSet"
+          ],
+          fl: 'id'
+        )
+      end
+
+      def file_sets
+        @file_sets ||= ActiveFedora::SolrService.query(extra_filters.to_s, file_sets_query_kwargs)
+      end
+
+      def each_file_set_id
+        file_sets.each { |doc| yield doc.fetch('id') }
+      end
+
+      def file_sets_count
+        file_sets.count
+      end
+    end
+  end
+end

--- a/lib/bulkrax/entry_spec_helper.rb
+++ b/lib/bulkrax/entry_spec_helper.rb
@@ -58,6 +58,23 @@ module Bulkrax
            **options)
     end
 
+    # @api public
+    #
+    # @param parser_class_name [String]
+    # @param parser_fields [Hash<String,Hash>]
+    #
+    # @return [Bulkrax::Exporter]
+    def self.exporter_for(parser_class_name:, parser_fields: {}, **options)
+      Bulkrax::Exporter.new(
+        name: options.fetch(:exporter_name, "Test importer for identifier"),
+        user: options.fetch(:exporter_user, User.new(email: "hello@world.com")),
+        limit: options.fetch(:exporter_limit, 1),
+        parser_klass: parser_class_name,
+        field_mapping: options.fetch(:exporter_field_mappings) { Bulkrax.field_mappings.fetch(parser_class_name) },
+        parser_fields: parser_fields
+      )
+    end
+
     ENTRY_TYPE_TO_METHOD_NAME_MAP = {
       entry: :entry_class,
       collection: :collection_entry_class,

--- a/spec/features/bagit_exporter_spec.rb
+++ b/spec/features/bagit_exporter_spec.rb
@@ -9,7 +9,8 @@ module Bulkrax
     let(:bulkrax_exporter_run) { FactoryBot.create(:bulkrax_exporter_run, exporter: exporter) }
     before do
       importer.import_works
-      allow(exporter.parser).to receive(:current_record_ids).and_return(importer.entries.pluck(:identifier))
+      allow(exporter.parser).to receive(:current_records_for_export)
+        .and_return(importer.entries.map { |e| [e.identifier, e.class] })
     end
 
     it 'exports a work' do

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -328,25 +328,6 @@ module Bulkrax
           end
         end
       end
-
-      describe '#total' do
-        before do
-          allow(subject).to receive(:current_record_ids).and_return(work_ids_solr + file_set_ids_solr)
-        end
-
-        context 'when there is no limit' do
-          it 'counts the correct number of works, collections, and filesets' do
-            expect(subject.total).to eq(5)
-          end
-        end
-
-        context 'when there is a limit' do
-          let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype_bagit, limit: 1) }
-          it 'counts the correct number of works, collections, and filesets' do
-            expect(subject.total).to eq(1)
-          end
-        end
-      end
     end
   end
 end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -392,58 +392,49 @@ module Bulkrax
       end
     end
 
-    describe '#find_child_file_sets' do
-      subject(:parser) { described_class.new(exporter) }
-      let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype) }
-      let(:work_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
-      let(:file_set_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
-      let(:parent_record_1) { build(:work) }
-
-      before do
-        parser.instance_variable_set(:@file_set_ids, [])
-        allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
-        allow(ActiveFedora::Base).to receive(:find).with(work_ids_solr.first.id).and_return(parent_record_1)
-        allow(parent_record_1).to receive(:file_set_ids).and_return(file_set_ids_solr.pluck(:id))
-      end
-
-      it 'returns the ids when child file sets are present' do
-        parser.find_child_file_sets(work_ids_solr.pluck(:id))
-        expect(parser.instance_variable_get(:@file_set_ids)).to eq(file_set_ids_solr.pluck(:id))
-      end
-    end
-
     describe '#create_new_entries' do
       subject(:parser) { described_class.new(exporter) }
       let(:exporter) { FactoryBot.create(:bulkrax_exporter, :all) }
-      # Use OpenStructs to simulate the behavior of ActiveFedora::SolrHit instances.
-      let(:work_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
-      let(:collection_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
-      let(:file_set_ids_solr) { [OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9)), OpenStruct.new(id: SecureRandom.alphanumeric(9))] }
+      let(:work_ids_solr) { [SolrDocument.new(id: SecureRandom.alphanumeric(9)), SolrDocument.new(id: SecureRandom.alphanumeric(9))] }
+      let(:collection_ids_solr) { [SolrDocument.new(id: SecureRandom.alphanumeric(9)), SolrDocument.new(id: SecureRandom.alphanumeric(9))] }
+      let(:file_set_ids_solr) { [SolrDocument.new(id: SecureRandom.alphanumeric(9)), SolrDocument.new(id: SecureRandom.alphanumeric(9)), SolrDocument.new(id: SecureRandom.alphanumeric(9))] }
+      let(:limit) { 1000 }
+
+      let(:record_set) do
+        (
+          work_ids_solr.map { |doc| [doc.id, parser.entry_class] } +
+          collection_ids_solr.map { |doc| [doc.id, parser.collection_entry_class] } +
+          file_set_ids_solr.map { |doc| [doc.id, parser.file_set_entry_class] }
+        )[0...limit]
+      end
 
       before do
-        allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr, collection_ids_solr, file_set_ids_solr)
+        allow(Bulkrax::ParserExportRecordSet).to(
+          receive(:for).with(parser: parser, export_from: exporter.export_from).and_return(record_set)
+        )
       end
 
       context 'with an export limit of 0' do
         it 'invokes Bulkrax::ExportWorkJob once per Entry' do
-          expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(7).times
+          expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(record_set.count).times
           parser.create_new_entries
         end
       end
 
       context 'with an export limit of 1' do
+        let(:limit) { 1 }
         it 'invokes Bulkrax::ExportWorkJob once' do
-          exporter.limit = 1
+          exporter.limit = limit
 
           # although the work has a file attached, the limit means the file set is not exported
-          expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(1).times
+          expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(limit).times
           parser.create_new_entries
         end
       end
 
       context 'when exporting all' do
         it 'exports works, collections, and file sets' do
-          expect(ExportWorkJob).to receive(:perform_now).exactly(7).times
+          expect(Bulkrax::ExportWorkJob).to receive(:perform_now).exactly(record_set.count).times
 
           parser.create_new_entries
         end
@@ -483,43 +474,6 @@ module Bulkrax
             .by(2)
             .and change(CsvEntry, :count)
             .by(7) # 7 csv entries minus 3 file set entries minus 2 collection entries equals 2 work entries
-        end
-      end
-
-      context 'when exporting by collection' do
-        let(:exporter) { FactoryBot.create(:bulkrax_exporter_collection) }
-        let(:parent_record_1) { build(:work, id: work_ids_solr.first.id) }
-
-        before do
-          allow(parent_record_1).to receive(:file_set_ids).and_return([file_set_ids_solr.pluck(:id).first])
-          allow(ActiveFedora::SolrService).to receive(:query).and_return([work_ids_solr.first], [collection_ids_solr.first], [collection_ids_solr.last])
-          allow(ActiveFedora::Base).to receive(:find).with(work_ids_solr.first.id).and_return(parent_record_1)
-        end
-
-        it 'exports the collection, child works, child collections, and file sets related to the child works' do
-          expect(ExportWorkJob).to receive(:perform_now).exactly(4).times
-
-          parser.create_new_entries
-        end
-      end
-
-      context 'when exporting by work type' do
-        let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype) }
-        let(:parent_record_1) { build(:work, id: work_ids_solr.first.id) }
-        let(:parent_record_2) { build(:work, id: work_ids_solr.last.id) }
-
-        before do
-          allow(parent_record_1).to receive(:file_set_ids).and_return([file_set_ids_solr.pluck(:id).first])
-          allow(parent_record_2).to receive(:file_set_ids).and_return(file_set_ids_solr.pluck(:id).from(1))
-          allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
-          allow(ActiveFedora::Base).to receive(:find).with(work_ids_solr.first.id).and_return(parent_record_1)
-          allow(ActiveFedora::Base).to receive(:find).with(work_ids_solr.last.id).and_return(parent_record_2)
-        end
-
-        it 'exports the works and file sets related to the works' do
-          expect(ExportWorkJob).to receive(:perform_now).exactly(5).times
-
-          parser.create_new_entries
         end
       end
     end
@@ -663,7 +617,7 @@ module Bulkrax
       end
 
       before do
-        allow(ActiveFedora::SolrService).to receive(:query).and_return(OpenStruct.new(id: work_id))
+        allow(ActiveFedora::SolrService).to receive(:query).and_return(SolrDocument.new(id: work_id))
         allow(exporter.entries).to receive(:where).and_return([entry])
         allow(parser).to receive(:headers).and_return(entry.parsed_metadata.keys)
       end

--- a/spec/parsers/bulkrax/parser_export_record_set_spec.rb
+++ b/spec/parsers/bulkrax/parser_export_record_set_spec.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'bulkrax/entry_spec_helper'
+
+RSpec.describe Bulkrax::ParserExportRecordSet do
+  describe '.for' do
+    let(:parser) { Bulkrax::CsvParser.new(nil) }
+    subject { described_class.for(parser: parser, export_from: export_from) }
+
+    context 'export_from: "all"' do
+      let(:export_from) { "all" }
+
+      it { is_expected.to be_a described_class::All }
+    end
+
+    context 'export_from: "worktype"' do
+      let(:export_from) { "worktype" }
+
+      it { is_expected.to be_a described_class::Worktype }
+    end
+
+    context 'export_from: "collection"' do
+      let(:export_from) { "collection" }
+
+      it { is_expected.to be_a described_class::Collection }
+    end
+
+    context 'export_from: "importer"' do
+      let(:export_from) { "importer" }
+
+      it { is_expected.to be_a described_class::Importer }
+    end
+
+    context 'export_from: "undefined"' do
+      let(:export_from) { "undefined" }
+
+      it "raises a NameError exception" do
+        expect { subject }.to raise_error(NameError)
+      end
+    end
+  end
+end
+
+[Bulkrax::ParserExportRecordSet::All, Bulkrax::ParserExportRecordSet::Worktype, Bulkrax::ParserExportRecordSet::Collection].each do |klass|
+  RSpec.describe klass do
+    let(:works) do
+      [
+        SolrDocument.new(id: 1, file_set_ids_ssim: ["a", "b", "c"]),
+        SolrDocument.new(id: 2, file_set_ids_ssim: ["d", "e", "f"])
+      ]
+    end
+
+    let(:collections) do
+      [
+        SolrDocument.new(id: 100),
+        SolrDocument.new(id: 200)
+      ]
+    end
+    let(:exporter) { Bulkrax::EntrySpecHelper.exporter_for(parser_class_name: "Bulkrax::CsvParser", exporter_limit: limit) }
+    let(:parser) { exporter.parser }
+
+    let(:count_of_items) { 10 } # I hand calculated that based on the above
+
+    let(:record_set) { described_class.new(parser: parser) }
+
+    before do
+      allow(record_set).to receive(:works).and_return(works)
+      allow(record_set).to receive(:collections).and_return(collections)
+    end
+
+    describe '#count' do
+      subject { record_set.count }
+
+      context 'when the number of items exceed the provided a limit' do
+        let(:limit) { 5 }
+        it "will return the limit" do
+          expect(subject).to eq(limit)
+        end
+      end
+
+      context 'when the number of items is less than (or equal) to the provided limit' do
+        let(:limit) { 100 }
+        it 'will return the count of associated items' do
+          expect(subject).to eq(count_of_items)
+        end
+      end
+
+      context 'where there is no limit' do
+        let(:limit) { nil }
+        it 'will return the count of associated items' do
+          expect(subject).to eq(count_of_items)
+        end
+      end
+    end
+
+    describe '#each' do
+      context 'when the number of items exceed the provided a limit' do
+        let(:limit) { 5 }
+        it "will only yield as many times as the given limit" do
+          expect do |block|
+            record_set.each(&block)
+          end.to yield_successive_args(
+                   [works[0].id, parser.entry_class],
+                   [works[1].id, parser.entry_class],
+                   [collections[0].id, parser.collection_entry_class],
+                   [collections[1].id, parser.collection_entry_class],
+                   [works[0].fetch("file_set_ids_ssim").first, parser.file_set_entry_class]
+                 )
+        end
+      end
+
+      context 'when the number of items is less than (or equal) to the provided limit' do
+        let(:limit) { 100 }
+        it "will yield all of the associated items" do
+          expect do |block|
+            record_set.each(&block)
+          end.to yield_successive_args(
+                   [works[0].id, parser.entry_class],
+                   [works[1].id, parser.entry_class],
+                   [collections[0].id, parser.collection_entry_class],
+                   [collections[1].id, parser.collection_entry_class],
+                   [works[0].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
+                   [works[0].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
+                   [works[0].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class],
+                   [works[1].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
+                   [works[1].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
+                   [works[1].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class]
+                 )
+        end
+      end
+
+      context "when there is no limit" do
+        let(:limit) { nil }
+        it "will yield all of the associcated items" do
+          expect do |block|
+            record_set.each(&block)
+          end.to yield_successive_args(
+                   [works[0].id, parser.entry_class],
+                   [works[1].id, parser.entry_class],
+                   [collections[0].id, parser.collection_entry_class],
+                   [collections[1].id, parser.collection_entry_class],
+                   [works[0].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
+                   [works[0].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
+                   [works[0].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class],
+                   [works[1].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
+                   [works[1].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
+                   [works[1].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class]
+                 )
+        end
+      end
+    end
+  end
+end
+
+RSpec.describe Bulkrax::ParserExportRecordSet::Importer do
+  let(:file_sets) do
+    [
+      SolrDocument.new(id: "a"),
+      SolrDocument.new(id: "b"),
+      SolrDocument.new(id: "c"),
+      SolrDocument.new(id: "d"),
+      SolrDocument.new(id: "e"),
+      SolrDocument.new(id: "f")
+    ]
+  end
+  let(:works) do
+    [
+      SolrDocument.new(id: 1),
+      SolrDocument.new(id: 2)
+    ]
+  end
+
+  let(:collections) do
+    [
+      SolrDocument.new(id: 100),
+      SolrDocument.new(id: 200)
+    ]
+  end
+  let(:exporter) { Bulkrax::EntrySpecHelper.exporter_for(parser_class_name: "Bulkrax::CsvParser", exporter_limit: limit) }
+  let(:parser) { exporter.parser }
+
+  let(:count_of_items) { 10 } # I hand calculated that based on the above
+
+  let(:record_set) { described_class.new(parser: parser) }
+
+  before do
+    allow(record_set).to receive(:works).and_return(works)
+    allow(record_set).to receive(:collections).and_return(collections)
+    allow(record_set).to receive(:file_sets).and_return(file_sets)
+  end
+
+  describe '#count' do
+    subject { record_set.count }
+
+    context 'when the number of items exceed the provided a limit' do
+      let(:limit) { 5 }
+      it "will return the limit" do
+        expect(subject).to eq(limit)
+      end
+    end
+
+    context 'when the number of items is less than (or equal) to the provided limit' do
+      let(:limit) { 100 }
+      it 'will return the count of associated items' do
+        expect(subject).to eq(count_of_items)
+      end
+    end
+
+    context 'where there is no limit' do
+      let(:limit) { nil }
+      it 'will return the count of associated items' do
+        expect(subject).to eq(count_of_items)
+      end
+    end
+  end
+
+  describe '#each' do
+    context 'when the number of items exceed the provided a limit' do
+      let(:limit) { 5 }
+      it "will only yield as many times as the given limit" do
+        expect do |block|
+          record_set.each(&block)
+        end.to yield_successive_args(
+                 [works[0].id, parser.entry_class],
+                 [works[1].id, parser.entry_class],
+                 [collections[0].id, parser.collection_entry_class],
+                 [collections[1].id, parser.collection_entry_class],
+                 [file_sets[0].id, parser.file_set_entry_class]
+               )
+      end
+    end
+
+    context 'when the number of items is less than (or equal) to the provided limit' do
+      let(:limit) { 100 }
+      it "will yield all of the associated items" do
+        expect do |block|
+          record_set.each(&block)
+        end.to yield_successive_args(
+                 [works[0].id, parser.entry_class],
+                 [works[1].id, parser.entry_class],
+                 [collections[0].id, parser.collection_entry_class],
+                 [collections[1].id, parser.collection_entry_class],
+                 [file_sets[0].id, parser.file_set_entry_class],
+                 [file_sets[1].id, parser.file_set_entry_class],
+                 [file_sets[2].id, parser.file_set_entry_class],
+                 [file_sets[3].id, parser.file_set_entry_class],
+                 [file_sets[4].id, parser.file_set_entry_class],
+                 [file_sets[5].id, parser.file_set_entry_class]
+               )
+      end
+    end
+
+    context "when there is no limit" do
+      let(:limit) { nil }
+      it "will yield all of the associcated items" do
+        expect do |block|
+          record_set.each(&block)
+        end.to yield_successive_args(
+                 [works[0].id, parser.entry_class],
+                 [works[1].id, parser.entry_class],
+                 [collections[0].id, parser.collection_entry_class],
+                 [collections[1].id, parser.collection_entry_class],
+                 [file_sets[0].id, parser.file_set_entry_class],
+                 [file_sets[1].id, parser.file_set_entry_class],
+                 [file_sets[2].id, parser.file_set_entry_class],
+                 [file_sets[3].id, parser.file_set_entry_class],
+                 [file_sets[4].id, parser.file_set_entry_class],
+                 [file_sets[5].id, parser.file_set_entry_class]
+               )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit the `Bulkrax::CsvParser` had complex query logic
for finding the records to process for export.  The logic was memory
inefficient: calling `#current_record_ids` twice (a very expensive
queries that issued many calls to Fedora which could've been a SOLR
query).  In large exports, the processes would spend over 90% of the
time in the finding file sets.

With this commit the `Bulkrax::ParserExportRecordSet` finder logic
echoes the logic once found in `Bulkrax::CsvParser`.  The purpose is to
isolate the place where the SOLR queries happen and to create less
memory intensive processes.

Further the `Bulkrax::ParserExportRecordSet.for` returns an object that
"quacks" like an Array of Arrays, with each inner Array having two
elements.  This makes the testing a bit easier.

Further, this extraction helps us create the conditions for other
exporters to re-use the export from logic that was presently tucked away
in the CSV Parser.

Of particular note, there are no real SOLR query tests of these changes,
nor the code prior to this commit.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/289
