### PR TITLE
Adding logic to skip blank lines

### DIFF
--- a/spec/fixtures/csv/with_empty_rows.csv
+++ b/spec/fixtures/csv/with_empty_rows.csv
@@ -1,0 +1,7 @@
+title,title.alternate,collection.isPartOf,source_location
+
+Hello,,,
+,,,
+World,,,
+,,,
+"",,,

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -6,15 +6,21 @@ require 'rails_helper'
 module Bulkrax
   RSpec.describe CsvEntry, type: :model do
     describe '.read_data' do
-      subject(:data) { described_class.read_data(path) }
-      let(:path) { File.expand_path('../../fixtures/csv/mixed-case.csv', __dir__) }
       it 'handles mixed case and periods for column names' do
+        path = File.expand_path('../../fixtures/csv/mixed-case.csv', __dir__)
+        data = described_class.read_data(path)
         expect(data.headers).to match_array([
                                               "title".to_sym,
                                               "title.alternate".to_sym,
                                               "collection.isPartOf".to_sym,
                                               "source_location".to_sym
                                             ])
+      end
+
+      it 'skips lines that do not have data' do
+        path = File.expand_path('../../fixtures/csv/with_empty_rows.csv', __dir__)
+        data = described_class.read_data(path)
+        expect(data.count).to eq(2)
       end
     end
 


### PR DESCRIPTION
As we've been working with folks uploading CSVs, we're encountering issues when they upload CSVs that has lines that don't have data.

There are three types of lines we might encounter:

- a blank line; the singular line looks as follows `\n`
- a line with empty fields; the singular line looks as follows `,,,\n`
- a line might might have empty strings for cells (e.g. `"","","",""\n`)

These blank lines are making their way to the parser's `@records` instance variable and then we start seeing weird exceptions such as the following:

```
Missing identifier for {:﻿file=>nil, :identifier=>nil,
:"identifier.ark"=>nil, :title=>nil, :description=>nil, :creator=>nil,
:contributor=>nil, :date=>nil, :"date.other"=>nil,
:"format.extent"=>nil, :type=>nil, :subject=>nil, :language=>nil,
:source=>nil, :"relation.isPartOf"=>nil, :rights=>nil,
:"coverage.spatial"=>nil}
```

There are no values in the above hash, so my working assumption is that the row is one of the aforementioned types of rows that are causing havoc.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/113
- https://github.com/scientist-softserv/britishlibrary/issues/280