### PR TITLE
Favoring explicit "empty" lines handler

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -13,34 +13,48 @@ module Bulkrax
       data.headers.flatten.compact.uniq
     end
 
-    # Following on the {::CSV.new} documentation, this little module is responsible for determining
-    # if we should skip the line we read via {CSV.read}.
-    #
-    # @see https://ruby-doc.org/stdlib-3.0.0/libdoc/csv/rdoc/CSV.html#class-CSV-label-Option+skip_lines
-    module CsvLineSkipper
-      USE_LINE_REGEXP = %r{\w}.freeze
-
-      # @param string [String] the non-parsed row
-      # @return [TrueClass] when we should skip this line
-      # @return [FalseClass] when we should not skip this line
-      def self.match(string)
-        return false if USE_LINE_REGEXP.match(string)
-        true
-      end
-    end
-
-    class_attribute :csv_line_skipper, default: CsvLineSkipper
+    class_attribute(:csv_read_data_options, default: {})
 
     # there's a risk that this reads the whole file into memory and could cause a memory leak
     def self.read_data(path)
       raise StandardError, 'CSV path empty' if path.blank?
-      CSV.read(path,
+      options = {
         headers: true,
         header_converters: ->(h) { h.to_sym },
-        skip_blanks: true,
-        skip_lines: csv_line_skipper,
-        encoding: 'utf-8')
+        encoding: 'utf-8'
+      }.merge(csv_read_data_options)
+
+      results = CSV.read(path, **options)
+      csv_wrapper_class.new(results)
     end
+
+    # The purpose of this class is to reject empty lines.  This causes lots of grief in importing.
+    # But why not use {CSV.read}'s `skip_lines` option?  Because for some CSVs, it will never finish
+    # reading the file.
+    #
+    # There is a spec that demonstrates this approach works.
+    class CsvWrapper
+      include Enumerable
+      def initialize(original)
+        @original = original
+      end
+
+      delegate :headers, to: :@original
+
+      def each
+        @original.each do |row|
+          next if all_fields_are_empty_for(row: row)
+          yield(row)
+        end
+      end
+
+      private
+
+      def all_fields_are_empty_for(row:)
+        row.to_hash.values.all?(&:blank?)
+      end
+    end
+    class_attribute :csv_wrapper_class, default: CsvWrapper
 
     def self.data_for_entry(data, _source_id, parser)
       # If a multi-line CSV data is passed, grab the first row

--- a/spec/fixtures/csv/entry-causing-problems-in-2.7.6.csv
+++ b/spec/fixtures/csv/entry-causing-problems-in-2.7.6.csv
@@ -1,0 +1,3 @@
+file,identifier,identifier.ark,title,description,creator,contributor,date,date.other,format.extent,type,subject,language,source,relation.isPartOf,rights,coverage.spatial,publisher
+,"P007204","P007204","Village on a hillside in Tatsienlu, 1930s","Written on back:","Andrews, John Nevins 1891-1980",,"1930","1930","Photograph: b&w 7.7x10 cm","Image","Andrews, John Nevins 1891-1980",,"Center for Adventist Research","Center for Adventist Research Photograph Collection","http://rightsstatements.org/vocab/NoC-US/1.0/",,
+,,,,,,,,,,,,,,,,,

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -22,6 +22,12 @@ module Bulkrax
         data = described_class.read_data(path)
         expect(data.count).to eq(2)
       end
+
+      it 'handles a CSV that if we used a skip_lines option would never finishing parsing the CSV' do
+        path = File.expand_path('../../fixtures/csv/entry-causing-problems-in-2.7.6.csv', __dir__)
+        data = described_class.read_data(path)
+        expect(data.count).to eq(1)
+      end
     end
 
     context 'AttributeBuilderMethod.for' do


### PR DESCRIPTION
Prior to this commit, we were relying on the documented `CSV.read`'s `:skip_lines` option.

However, in testing the CSV that is part of this commit, the `CSV.read` would never complete.  Diving deep into the internals, it kept finding lines that upon inspecttion were an empty string.

With this commit, we're moving the skip logic outside of the parser and instead wrapping the results.  This is perhaps less performant, but compared to never completing due to infinite string processing, it actually is more performant.

Further, I have added additional configuration options in the event that this change does not work downstream.  Those configuration options should allow for more immediate relief as the general solution works its way back into Bulkrax.

This refines changes made in 792ccf0a7cfd03eb9083e76b134081af606df329.

Related to:

- https://github.com/samvera-labs/bulkrax/pull/751
- https://github.com/scientist-softserv/adventist-dl/issues/113
- https://github.com/scientist-softserv/britishlibrary/issues/280