### PR TITLE
I754

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -233,6 +233,8 @@ module Bulkrax
     end
 
     def build_object(_key, value)
+      return unless hyrax_record.respond_to?(value['object'])
+
       data = hyrax_record.send(value['object'])
       return if data.empty?
 
@@ -241,6 +243,8 @@ module Bulkrax
     end
 
     def build_value(key, value)
+      return unless hyrax_record.respond_to?(key.to_s)
+
       data = hyrax_record.send(key.to_s)
       if data.is_a?(ActiveTriples::Relation)
         if value['join']

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -216,7 +216,7 @@ module Bulkrax
         if importer?
           importer.parser_fields['total'] || 0
         elsif exporter?
-          limit.to_i.zero? ? current_record_ids.count : limit.to_i
+          limit.to_i.zero? ? current_records_for_export.count : limit.to_i
         else
           0
         end
@@ -261,7 +261,8 @@ module Bulkrax
       sorted_entries = sort_entries(importerexporter.entries.uniq(&:identifier))
                        .select { |e| valid_entry_types.include?(e.type) }
 
-      sorted_entries[0..limit || total].in_groups_of(records_split_count, false) do |group|
+      group_size = limit.to_i.zero? ? total : limit.to_i
+      sorted_entries[0..group_size].in_groups_of(records_split_count, false) do |group|
         folder_count += 1
 
         CSV.open(setup_export_file(folder_count), "w", headers: export_headers, write_headers: true) do |csv|


### PR DESCRIPTION
## Avoid building value/object if hyrax_record does not respond

bd42b4af78814fc1e8caa2a58f547a3bceaca249

Prior to this commit, we'd attempt to export the field even if the
"from" object did not respond to that property.  That would raise a
`NoMethodError`.

With this commit, we're skipping the building of the value/object if the
hyrax_record does not respond to the source method.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/289
- https://github.com/samvera-labs/bulkrax/issues/754

## Fixing bug regarding total and export limits

951128d06f4ba247ffe082c9cb139eb5eefabcc7

The `current_record_ids` was removed in 4cf0207 (e.g. #749) in favor of
`current_records_for_export`; however the `Bulkrax::CsvParser#total`
method was not updated to reflect this change.

In this commit, we fix that issue.  Also we tighten up the logic
regarding the sorted_entries array.  There was an assumption that we
would have a `nil` limit; but the documentation mentions that 0 and
`nil` are equivalent.  But `(0..(0 || total))` is different from
`(0..(nil || total))`.

Partially closes #754
