### PR TITLE
add rights_statement to list of fields with multiple values

### DIFF
--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -147,6 +147,7 @@ module Bulkrax
         %W[
           file
           remote_files
+          rights_statement
           #{related_parents_parsed_mapping}
           #{related_children_parsed_mapping}
         ]


### PR DESCRIPTION
By default, `ImportBehavior#add_rights_statement` sets the value to an array, which causes an error since `sanitize_controlled_uri_values!` doesn't know to treat it as such.

This whole section needs to be refactored, since the rights statement service can be overridden locally, but this at least un-breaks the default configuration.