### PR TITLE
Ensuring exporter's queried file sets are in fact file sets

### DIFF
--- a/spec/parsers/bulkrax/parser_export_record_set_spec.rb
+++ b/spec/parsers/bulkrax/parser_export_record_set_spec.rb
@@ -51,6 +51,17 @@ end
       ]
     end
 
+    let(:file_sets) do
+      [
+        SolrDocument.new(id: "a"),
+        SolrDocument.new(id: "b"),
+        SolrDocument.new(id: "c"),
+        SolrDocument.new(id: "d"),
+        SolrDocument.new(id: "e"),
+        SolrDocument.new(id: "f")
+      ]
+    end
+
     let(:collections) do
       [
         SolrDocument.new(id: 100),
@@ -67,6 +78,7 @@ end
     before do
       allow(record_set).to receive(:works).and_return(works)
       allow(record_set).to receive(:collections).and_return(collections)
+      allow(record_set).to receive(:file_sets).and_return(file_sets)
     end
 
     describe '#count' do


### PR DESCRIPTION
Prior to this commit, we were assuming the `file_set_ids_ssim` did in fact only have ids for FileSets.  [Dear reader, that was a lie][1].

With this commit, we are taking each works's `file_set_ids_ssim` and querying Solr to grab only the ids that are, in fact, for FileSets.

A read through of the prior logic shows that we are grabbing the Fedora objects `file_set_ids`, which is almost certainly excludes child works. See below:

```ruby
ActiveFedora::Base.find(id).file_set_ids.each { |fs_id| @file_set_ids << fs_id }
```

**tl;dr** this is why we can't have nice things.

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/289
- https://github.com/samvera-labs/bulkrax/pull/749

[1]: https://github.com/samvera/hyrax/blob/64c0bbf0dc0d3e1b49f040b50ea70d177cc9d8f6/app/indexers/hyrax/work_indexer.rb#L15-L18