### PR TITLE
Adding `Samvera::Derivatives` for interface discussion

### DIFF
--- a/lib/samvera/derivatives.rb
+++ b/lib/samvera/derivatives.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+##
+# Why Samvera and not Hyrax?  Because there are folks creating non-Hyrax applications that will
+# almost certainly want to leverage this work.  And there might be switches for `defined?(Hyrax)`.
+#
+# Further the following four gems have interest in the interfaces of this module:
+#
+# - Hyrax
+# - Hydra::Derivatives
+# - Bulkrax
+# - IiifPrint
+#
+# As such, it makes some sense to isolate the module and begin defining interfaces.
+module Samvera
+  ##
+  # This module separates the finding/creation of a derivative binary (via {FileLocator}) and
+  # applying that derivative to the FileSet (via {FileApplicator}).
+  #
+  # @todo Consider how we might bundle/adapt the existing Hyrax::FileSetDerivativesService to serve
+  #       as both a locator and an applicator.  What would need to be true?  Conceptually it's a bit
+  #       challenging because the mapping of behavior is different.  However, it would be possible
+  #       to have the FileLocator fail to return any paths and then if the paths are nil, run the
+  #       corresponding Hyrax::FileSetDerivativesService; which because of the many different types
+  #       might result in attempting to create multiple derivatives.
+  module Derivatives
+    ##
+    # The purpose of this module is to find the derivative file path for a FileSet and a given
+    # derivative type (e.g. :thumbnail).
+    #
+    # @see https://github.com/samvera-labs/bulkrax/issues/760 Design Document
+    #
+    # @note Ideally, this module would be part of Hyrax or Hydra::Derivatives
+    # @see https://github.com/samvera/hyrax
+    # @see https://github.com/samvera/hydra-derivatives
+    module FileLocator
+      ##
+      # @api public
+      #
+      # This method is responsible for finding the correct file names for the given file set and
+      # derivative type.
+      #
+      # @param file_set [FileSet]
+      # @param derivative_type [#to_sym]
+      # @param strategies [Array<#find>]
+      #
+      # @return [Array<String>] path to files that are the desired derivative type.
+      #
+      # @note Why {.call}?  This allows for a simple lambda interface, which can greatly ease testing
+      #       and composition.
+      def self.call(file_set:, derivative_type:, strategies: default_strategies)
+        paths = nil
+
+        strategies.each do |strategy|
+          paths = strategy.find(file_set: file_set, derivative_type: derivative_type)
+          break if paths.present?
+        end
+
+        # TODO: How do we handle the nil case?
+        paths
+      end
+
+      def self.default_strategies
+        [Strategy]
+      end
+      private_class_method :default_strategies
+
+      ##
+      # @abstract
+      #
+      # The purpose of this abstract class is to provide the public interface for strategies.
+      #
+      # @see {.find}
+      class Strategy
+        ##
+        # @api public
+        # @param file_set [FileSet]
+        # @param derivative_type [#to_sym]
+        #
+        # @return [Array<String>] when this is a valid strategy
+        # @return [NilClass] when this is not a valid strategy
+        def self.find(file_set:, derivative_type:)
+          raise NotImplementedError
+        end
+      end
+    end
+
+    module FileApplicator
+      ##
+      # @api
+      #
+      # @param file_set [FileSet]
+      # @param derivative_type [#to_sym]
+      # @param from_paths [Array<String>] the paths of the files that are to be applied/written to
+      #        the :file_set
+      # @param strategies [Array<#write!>]
+      def self.call(file_set:, derivative_type:, from_paths:, strategies: default_strategies)
+        strategies.each do |strategy|
+          strategy.write!(file_set: file_set, derivative_type: derivative_type, from_paths: from_paths)
+        end
+      end
+
+      def self.default_strategies
+        [Strategy]
+      end
+      private_class_method :default_strategies
+
+      ##
+      # @abstract
+      #
+      # The purpose of this abstract class is to provide the public interface for strategies.
+      #
+      # @see {.find}
+      class Strategy
+        ##
+        # @param file_set [FileSet]
+        # @param derivative_type [#to_sym]
+        # @param from_paths [Array<String>] the paths of the files that are to be applied/written to
+        #        the :file_set
+        def self.write!(file_set:, derivative_type:, from_paths:)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit begins to define an interface for the separation of concerns regarding the long-standing implementation of `Hydra::Derivatives` and `Hyrax::FileSetDerivativesService` as those relate to the existence of pre-existing derivatives.

This does not address the implementation details related to Bulkrax handling this work.  I would instead assume that Bulkrax would implement a subclass(es) `Samvera::Derivatives::FileLocator::Strategy`, which would in turn address the specific needs and implementation details.

As I've explored the implementations, a challenge of Hydra::Derivatives is that is combines the concern of finding the derivative (by making it) and applying that derivative to the corresponding file set.

Also, there is a higher level concern that is not addressed in this implementation; namely what are the derivatives of concern for a given `FileSet`; something that is likely based on the mime_type of the original file and metadata from the parent work.

Why not create another gem?

1. The immediate need is Bulkrax related.
2. The plumbing is laid for Bulkrax's test suite.
3. We probably don't need another gem to triangulate for a general solution.

That said, I am name spacing this interface in `Samvera` so if we find it useful we can extract a `samvera-derivatives` gem.  After all, not everyone's going to want Bulkrax.

Why not put this in Hyrax?

1. Because Bulkrax works across many different Hyrax versions.  Thus by being in Bulkrax it is generally more available than if it were in Hyrax; something which we'd need to backport.

An advantage of establishing the interface is that work can be done to now "fan out".  That is someone can work on a locator strategy while another works on the applicator strategy.

Related to:

- https://github.com/samvera-labs/bulkrax/issues/760
- https://github.com/scientist-softserv/utk-hyku/issues/343