### PR TITLE
Adding `Bulkrax::EntryDerivative` model

### DIFF
--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -16,6 +16,8 @@ module Bulkrax
     alias importer importerexporter
     alias exporter importerexporter
 
+    has_many :derivatives, dependent: :destroy
+
     serialize :parsed_metadata, Bulkrax::NormalizedJson
     # Do not serialize raw_metadata as so we can support xml or other formats
     serialize :collection_ids, Array

--- a/app/models/bulkrax/entry_derivative.rb
+++ b/app/models/bulkrax/entry_derivative.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  # The purpose of this model is to provide a means of capturing (for later use) the derivatives
+  # that are associated with a Bulkrax::Entry (for importers).
+  #
+  # @see https://github.com/samvera-labs/bulkrax/issues/760
+  class EntryDerivative < ApplicationRecord
+    belongs_to :entry
+
+    # These are enforced on the database schema, but we might as well telegraph that here.
+    validates :derivative_type, :path, presence: true
+  end
+end

--- a/db/migrate/20230316001839_create_bulkrax_entry_derivatives.rb
+++ b/db/migrate/20230316001839_create_bulkrax_entry_derivatives.rb
@@ -1,0 +1,13 @@
+class CreateBulkraxEntryDerivatives < ActiveRecord::Migration[5.1]
+  def change
+    unless table_exists?(:bulkrax_entry_derivatives)
+      create_table :bulkrax_entry_derivatives do |t|
+        t.belongs_to :entry, foreign_key: true, null: false
+        t.string :derivative_type, null: false
+        t.text :path, null: false
+
+        t.timestamps
+      end
+    end
+  end
+end

--- a/lib/samvera/derivatives/bulkrax.rb
+++ b/lib/samvera/derivatives/bulkrax.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Samvera
+  module Derivatives
+    module Bulkrax
+      ##
+      # Responsible for locating a derivative associated with a Bulkrax import.
+      #
+      # @see .locate
+      class FileLocator
+        ##
+        # @param file_set [FileSet]
+        # @param derivative_type [#to_sym]
+        #
+        # @return [FalseClass] when no {Bulkrax::EntryDerivative} is found for the given parameters
+        #         or when we encounter errors retrieving that derivative.
+        # @return [String] the full path to the derivative described by the corresponding
+        #         {Bulkrax::EntryDerivative}
+        #
+        # @see Samvera::Derivatives::FileLocator::Strategy
+        #
+        # @note If there are multiple {Bulkrax::EntryDerivative} objects for the associated
+        #       {FileSet}, process the most recently created one.
+        def self.locate(file_set:, derivative_type:, *)
+          # Find the corresponding Bulkrax::EntryDerivative for the given :derivative_type and :file_set
+          #
+          # Return false if no Bulkrax::EntryDerivative is found
+          #
+          # Otherwise
+          #
+          # - determine the resuling path to the derivative.  If it exists, return that path.
+          # - If it does not exist attempt to fetch the remote URL and write it to the resulting path.
+          # - Rescue fetch errors by:
+          #   ...reporting an exception
+          #   and
+          #   ...returning false (e.g. we'll run the local derivatives)
+        end
+      end
+
+      class FileApplicator
+        ##
+        # @param file_set [FileSet]
+        # @param derivative_type [#to_sym]
+        # @param from_location [String]
+        #
+        # Copy the from_location to a to location on the file system, following the pattern
+        # established in {Hyrax::FileSetDerivativesService}
+        #
+        # @see Samvera::Derivatives::FileLocator::Strategy
+        def self.apply!(file_set:, derivative_type:, from_location:)
+          new(file_set: file_set, derivative_type: derivative_type, from_location: from_location)
+        end
+
+        # Why not set a default?  Because the ::Hyrax may not be defined.  This setup allows for a
+        # lazier definition.
+        class_attribute :derivative_path_service, instance_accessor: false
+
+        ##
+        # @param file_set [FileSet]
+        # @param derivative_type [#to_sym]
+        # @param from_location [String]
+        # @param derivative_path_service [#derivative_path_for_reference]
+        def initialize(file_set:, derivative_type:, from_location:, derivative_path_service: default_derivative_path_service)
+          @file_set = file_set
+          @derivative_type = derivative_type
+          @from_location = from_location
+          @derivative_path_service = derivative_path_service
+        end
+
+        attr_reader :file_set, :derivative_type, :from_location, :derivative_path_service
+        private :file_set, :derivative_type, :from_location, :derivative_path_service
+
+        private
+
+        def process_apply!
+          to_location = derivative_path_service.derivative_path_for_reference(file_set, extension)
+          to_dir = File.dirname(to_location)
+          FileUtils.mkdir_p(to_dir) unless File.directory?(to_dir)
+          FileUtils.cp(from_location, to_location)
+        end
+
+        def default_derivative_path_service
+          self.class.default_derivative_path_service || ::Hyrax::DerivativePath
+        end
+
+        def extension
+          # TODO: How do we determine that based on derivative type?
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_26_164334) do
+ActiveRecord::Schema.define(version: 2023_03_16_001839) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "name"
@@ -41,6 +41,15 @@ ActiveRecord::Schema.define(version: 2022_07_26_164334) do
     t.datetime "last_succeeded_at"
     t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.integer "import_attempts", default: 0
+  end
+
+  create_table "bulkrax_entry_derivatives", force: :cascade do |t|
+    t.integer "entry_id", null: false
+    t.string "derivative_type", null: false
+    t.text "path", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entry_id"], name: "index_bulkrax_entry_derivatives_on_entry_id"
   end
 
   create_table "bulkrax_exporter_runs", force: :cascade do |t|


### PR DESCRIPTION
## Adding `Bulkrax::EntryDerivative` model

8ee3fe37c1097d3a365311e5a058f911c969ca37

This is preliminary modeling for imports to handle associating existing
derivatives with a `Bulkrax::Entry`.

Hyrax has implicit derivative_types that are not declared, but in part
assumed as a general list of derivatives.  In this model, we want to
begin name those derivatives to address the following use cases:

```gherkin
Given a FileSet
When I provide a thumbnail derivative
Then I want to add that as the thumbnail for the FileSet

Given a FileSet
When I do not provide a thumbnail derivative
Then I want to generate a thumbnail
And add the generated as the thumbnail for the FileSet
```

Related to:

- https://github.com/samvera-labs/bulkrax/pull/761
- https://github.com/samvera-labs/bulkrax/issues/760
- https://github.com/scientist-softserv/utk-hyku/issues/371

## Stubbing out derivatives locator/applicator logic

923c52756b90502a40bbe3d2f8cf79aa7398b03d

With this commit, I begin to take the work already done in [this PR][1]
and start pseudo-coding my approach.

All of this continues to circle around the configuration for a
downstream implementation.  However, it's drawing closer.

[1]: https://github.com/samvera-labs/bulkrax/pull/761
