### PR TITLE
update reset rake task to switch tenants

### DIFF
--- a/lib/tasks/reset.rake
+++ b/lib/tasks/reset.rake
@@ -13,44 +13,46 @@ namespace :hyrax do
     task works_and_collections: [:environment] do
       confirm('You are about to delete all works and collections, this is not reversable!')
       require 'active_fedora/cleaner'
-      ActiveFedora::Cleaner.clean!
-      Hyrax::PermissionTemplateAccess.delete_all
-      Hyrax::PermissionTemplate.delete_all
-      Bulkrax::PendingRelationship.delete_all
-      Bulkrax::Entry.delete_all
-      Bulkrax::ImporterRun.delete_all
-      Bulkrax::Status.delete_all
-      # Remove sipity methods, everything but sipity roles
-      Sipity::Workflow.delete_all
-      Sipity::EntitySpecificResponsibility.delete_all
-      Sipity::Comment.delete_all
-      Sipity::Entity.delete_all
-      Sipity::WorkflowRole.delete_all
-      Sipity::WorkflowResponsibility.delete_all
-      Sipity::Agent.delete_all
-      Mailboxer::Receipt.destroy_all
-      Mailboxer::Notification.delete_all
-      Mailboxer::Conversation::OptOut.delete_all
-      Mailboxer::Conversation.delete_all
-      AccountElevator.switch!(Site.instance.account) if defined?(AccountElevator)
-      # we need to wait till Fedora is done with its cleanup
-      # otherwise creating the admin set will fail
-      while AdminSet.exists?(AdminSet::DEFAULT_ID)
-        puts 'waiting for delete to finish before reinitializing Fedora'
-        sleep 20
-      end
+      Account.find_each do |account|
+        Apartment::Tenant.switch!(account.tenant) if defined?(Apartment::Tenant)
+        ActiveFedora::Cleaner.clean!
+        Hyrax::PermissionTemplateAccess.delete_all
+        Hyrax::PermissionTemplate.delete_all
+        Bulkrax::PendingRelationship.delete_all
+        Bulkrax::Entry.delete_all
+        Bulkrax::ImporterRun.delete_all
+        Bulkrax::Status.delete_all
+        # Remove sipity methods, everything but sipity roles
+        Sipity::Workflow.delete_all
+        Sipity::EntitySpecificResponsibility.delete_all
+        Sipity::Comment.delete_all
+        Sipity::Entity.delete_all
+        Sipity::WorkflowRole.delete_all
+        Sipity::WorkflowResponsibility.delete_all
+        Sipity::Agent.delete_all
+        Mailboxer::Receipt.destroy_all
+        Mailboxer::Notification.delete_all
+        Mailboxer::Conversation::OptOut.delete_all
+        Mailboxer::Conversation.delete_all
+        # we need to wait till Fedora is done with its cleanup
+        # otherwise creating the admin set will fail
+        while AdminSet.exists?(AdminSet::DEFAULT_ID)
+          puts 'waiting for delete to finish before reinitializing Fedora'
+          sleep 20
+        end
 
-      Hyrax::CollectionType.find_or_create_default_collection_type
-      Hyrax::CollectionType.find_or_create_admin_set_type
-      AdminSet.find_or_create_default_admin_set_id
+        Hyrax::CollectionType.find_or_create_default_collection_type
+        Hyrax::CollectionType.find_or_create_admin_set_type
+        AdminSet.find_or_create_default_admin_set_id
 
-      collection_types = Hyrax::CollectionType.all
-      collection_types.each do |c|
-        next unless c.title.match?(/^translation missing/)
-        oldtitle = c.title
-        c.title = I18n.t(c.title.gsub("translation missing: en.", ''))
-        c.save
-        puts "#{oldtitle} changed to #{c.title}"
+        collection_types = Hyrax::CollectionType.all
+        collection_types.each do |c|
+          next unless c.title.match?(/^translation missing/)
+          oldtitle = c.title
+          c.title = I18n.t(c.title.gsub("translation missing: en.", ''))
+          c.save
+          puts "#{oldtitle} changed to #{c.title}"
+        end
       end
     end
 


### PR DESCRIPTION
When testing the previous implementation against a hyku app, the rake task failed because it wasn't able to switch into tenants properly. 

