### PR TITLE
Deprecate parse_resource_type method as it isn't used anymore

### DIFF
--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -101,8 +101,8 @@ module Bulkrax
     end
 
     # Only add valid resource types
-    # @todo(bjustice) - remove hyrax reference NOT USED?
     def parse_resource_type(src)
+      ActiveSupport::Deprecation.warn("#parse_resource_type will be removed in the near future. ")
       Hyrax::ResourceTypesService.label(src.to_s.strip.titleize)
     rescue KeyError
       nil

--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -102,7 +102,7 @@ module Bulkrax
 
     # Only add valid resource types
     def parse_resource_type(src)
-      ActiveSupport::Deprecation.warn("#parse_resource_type will be removed in the near future. ")
+      ActiveSupport::Deprecation.warn('#parse_resource_type will be removed in Bulkrax v6.0.0')
       Hyrax::ResourceTypesService.label(src.to_s.strip.titleize)
     rescue KeyError
       nil


### PR DESCRIPTION
Method doesn't seem to be used anywhere in the code. Deprecating to warn anyone who might be using it, then going to remove in a few months.