### PR TITLE
Adding guard for querying 0 rows for FileSets

### DIFF
--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -134,8 +134,15 @@ module Bulkrax
                          end
       end
 
+      # @note In most cases, when we don't have any candidate file sets, there is no need to query SOLR.
+      #
+      # @see Bulkrax::ParserExportRecordSet::Importer#file_sets
       def file_sets
-        @file_sets ||= ActiveFedora::SolrService.query(file_sets_query, **file_set_query_kwargs)
+        @file_sets ||= if candidate_file_set_ids.empty?
+                         []
+                       else
+                         ActiveFedora::SolrService.query(file_sets_query, **file_set_query_kwargs)
+                       end
       end
 
       # Why can't we just use the candidate_file_set_ids?  Because Hyrax is pushing child works into the
@@ -242,6 +249,14 @@ module Bulkrax
 
       def collections_query
         "has_model_ssim:Collection #{extra_filters}"
+      end
+
+      # This is an exception; we don't know how many candidate file sets there might be.  So we will instead
+      # make the query (assuming that there are {#complete_entry_identifiers}).
+      #
+      # @see Bulkrax::ParserExportRecordSet::Base#file_sets
+      def file_sets
+        @file_sets ||= ActiveFedora::SolrService.query(file_sets_query, **file_set_query_kwargs)
       end
 
       def file_sets_query_kwargs


### PR DESCRIPTION
Prior to this commit, when we would query to export file sets we didn't guard for no file sets associated with the works.  In [this importer][1] we saw a SOLR exception about an invalid query.  The SOLR query had the following:

```
fl=id&rows=0&q=has_model_ssim%3AFileSet+AND+id%3A%28%29+&qt=standard
```

In the above, we are querying for FileSets (selecting on the ID field). However there were no candidate file sets (e.g. `rows=0` and `id:()`) associated with the works for the export.

With this commit we guard against running a query for 0 rows.  Which should eliminate the particular problem.

Related to:

- https://github.com/samvera-labs/bulkrax/pull/749
- https://github.com/scientist-softserv/britishlibrary/issues/353
- https://github.com/scientist-softserv/britishlibrary/pull/328
- https://github.com/samvera-labs/bulkrax/pull/759

[1]: https://qa.bl-staging.notch8.cloud/exporters/5?locale=en