### PR TITLE
Ensuring we handle non-string keys for persisted mappings

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -91,8 +91,10 @@ module Bulkrax
     def missing_elements(record)
       keys_from_record = keys_without_numbers(record.reject { |_, v| v.blank? }.keys.compact.uniq.map(&:to_s))
       keys = []
-      importerexporter.mapping.map do |k, v|
-        v[:from].each do |vf|
+      # Because we're persisting the mapping in the database, these are likely string keys.
+      # However, there's no guarantee.  So, we need to ensure that by running stringify.
+      importerexporter.mapping.stringify_keys.map do |k, v|
+        Array.wrap(v['from'])).each do |vf|
           keys << k if keys_from_record.include?(vf)
         end
       end


### PR DESCRIPTION
Prior to this commit, the `mapping` method is data persisted in the `importerexporter`.  Those are persisted and reified with string keys.

We discovered this bug in a failing spec for
https://github.com/scientist-softserv/britishlibrary/pull/360

With this commit, we're coercing the keys to strings and then checking the stringified keys.  This ensures that if the implementation of `mapping` (casting the keys to symbols, which is how we write them in the parsers) were to change we are insulated from that change.

Related to:

- https://github.com/samvera-labs/bulkrax/pull/765