### PR TITLE
Fix "Export errored entries" button not rendering

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -330,7 +330,7 @@ module Bulkrax
       return @object_names if @object_names
 
       @object_names = mapping.values.map { |value| value['object'] }
-      @object_names.uniq!.delete(nil)
+      @object_names.uniq!&.delete(nil)
 
       @object_names
     end

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -1,6 +1,6 @@
 <div class="col-xs-12 main-header">
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importer: <%= @importer.name %></h1>
-  <% if @importer.parser_klass == 'Bulkrax::CsvParser' && @work_entries.map { |e| e.status == 'failed' }.any? %>
+  <% if @importer.parser_klass == 'Bulkrax::CsvParser' && @work_entries.map { |e| e.status&.downcase == 'failed' }.any? %>
     <div class="pull-right">
       <%= link_to 'Export Errored Entries', importer_export_errors_path(@importer.id), class: 'btn btn-primary' %>
       <%= link_to 'Upload Corrected Entries', importer_upload_corrected_entries_path(@importer.id), class: 'btn btn-primary' %>


### PR DESCRIPTION
## Summary

Changes:

- Fix bug caused by case mismatch that prevented the "Export errored entries" button from rendering on an importer's show page that has failed work entries  
- Prevent `NoMethodError #delete` when running an importer on an app that has not specified field mappings 