### PR TITLE
Adding quotes around candidate_file_set_ids

### DIFF
--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -141,7 +141,7 @@ module Bulkrax
         @file_sets ||= if candidate_file_set_ids.empty?
                          []
                        else
-                         ActiveFedora::SolrService.query(file_sets_query, **file_set_query_kwargs)
+                         ActiveFedora::SolrService.query(file_sets_query, **file_sets_query_kwargs)
                        end
       end
 
@@ -153,10 +153,10 @@ module Bulkrax
       # @see https://github.com/scientist-softserv/britishlibrary/issues/289
       # @see https://github.com/samvera/hyrax/blob/64c0bbf0dc0d3e1b49f040b50ea70d177cc9d8f6/app/indexers/hyrax/work_indexer.rb#L15-L18
       def file_sets_query
-        "has_model_ssim:#{Bulkrax.file_model_class} AND id:(#{candidate_file_set_ids.join(' OR ')}) #{extra_filters}"
+        %(has_model_ssim:#{Bulkrax.file_model_class} AND id:("#{candidate_file_set_ids.join('" OR "')}") #{extra_filters})
       end
 
-      def file_set_query_kwargs
+      def file_sets_query_kwargs
         { fl: "id", method: :post, rows: candidate_file_set_ids.size }
       end
 
@@ -256,7 +256,7 @@ module Bulkrax
       #
       # @see Bulkrax::ParserExportRecordSet::Base#file_sets
       def file_sets
-        @file_sets ||= ActiveFedora::SolrService.query(file_sets_query, **file_set_query_kwargs)
+        @file_sets ||= ActiveFedora::SolrService.query(file_sets_query, **file_sets_query_kwargs)
       end
 
       def file_sets_query_kwargs


### PR DESCRIPTION
Prior to this commit, we were not wrapping the file_sets_query in quotes.

If we look at other instances of querying on ID, we're wrapping the identifiers in quotes (e.g. `id:("ONE" OR "TWO" OR "THREE")`).

With this commit, we normalize this query to be the same as other similar queries.

One particular challenge is that Bulkrax does not have a Solr nor Fedora instance for testing.

I verified the fix by running, in the Rails console, the following:

```ruby
switch!('kew')
work_id = Article.first.id
file_sets_query = %(has_model_ssim:FileSet AND id:("0bd95381-0d3e-4df6-a0fc-8876e94369bc" OR "989a736d-17b7-472f-b5fd-d544af2b74f4" OR "#{work_id}"))
file_sets_query_kwargs = { fl: "id", method: :post, rows: 3 }
ActiveFedora::SolrService.query(file_sets_query, **file_sets_query_kwargs)
```

<img width="1182" alt="Screen Shot of the results of the above ruby code; hint it works" src="https://user-images.githubusercontent.com/2130/228868793-2883d838-ad47-4396-ba34-84d849b5a62f.png">

See: https://kew.iro.bl.uk/exporters/146?locale=en

Related to:

- https://github.com/scientist-softserv/britishlibrary/issues/289
- https://github.com/samvera-labs/bulkrax/pull/749