### PR TITLE
HotFix: Patching Marcel MimeType sniffing

### DIFF
--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -51,7 +51,7 @@ module Bulkrax
 
     # Is this a zip file?
     def zip?
-      parser_fields&.[]('import_file_path') && ::Marcel::MimeType.for(parser_fields['import_file_path']).include?('application/zip')
+      parser_fields&.[]('import_file_path') && ::Marcel::MimeType.for(File.new(parser_fields['import_file_path'])).include?('application/zip')
     end
   end
 end

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -365,7 +365,7 @@ module Bulkrax
 
     # Is this a zip file?
     def zip?
-      parser_fields&.[]('import_file_path') && ::Marcel::MimeType.for(parser_fields['import_file_path']).include?('application/zip')
+      parser_fields&.[]('import_file_path') && ::Marcel::MimeType.for(File.new(parser_fields['import_file_path'])).include?('application/zip')
     end
 
     # Path for the import


### PR DESCRIPTION
Note: This does not included tests, which is something that #744  also did not.  However, we have verified the behavior.

Reading the [documentation for the Marcel gem][1], it requires a file handle (e.g. `File.new` or `File.open`) instead of a String.

When given a `String` for `::Marcel::MimeType.for` the returned value is `application/octet-stream`.

Related to:

- https://github.com/samvera-labs/bulkrax/issues/777

[1]: https://github.com/rails/marcel