### PR TITLE
Ensuring closed file handle when testing zip file

### DIFF
--- a/app/models/concerns/bulkrax/importer_exporter_behavior.rb
+++ b/app/models/concerns/bulkrax/importer_exporter_behavior.rb
@@ -51,7 +51,14 @@ module Bulkrax
 
     # Is this a zip file?
     def zip?
-      parser_fields&.[]('import_file_path') && ::Marcel::MimeType.for(File.new(parser_fields['import_file_path'])).include?('application/zip')
+      filename = parser_fields&.[]('import_file_path')
+      return false unless filename
+      return false unless File.file?(filename)
+      returning_value = false
+      File.open(filename) do |file|
+        returning_value = ::Marcel::MimeType.for(file).include?('application/zip')
+      end
+      returning_value
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, when we run `File.new` we were opening the file. We did not, however, close the file.

With this commit, I've leverage the `File.open` with block behavior to open and ensure that we close the file.

Related to:

https://github.com/samvera-labs/bulkrax/pull/779
https://github.com/samvera-labs/bulkrax/pull/778
https://github.com/samvera-labs/bulkrax/issues/777