### PR TITLE
Set turbolinks to false for the exporter index page

### DIFF
--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -1,7 +1,7 @@
 <% provide :page_header do %>
   <h1><span class="fa fa-cloud-download" aria-hidden="true"></span> Exporters</h1>
   <div class="pull-right">
-    <%= link_to new_exporter_path, class: 'btn btn-primary' do %>
+    <%= link_to new_exporter_path, class: 'btn btn-primary', data: { turbolinks: false } do %>
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.exporter.new') %>
     <% end %>
   </div>
@@ -42,7 +42,7 @@
                   <% end%>
                 </td>
                 <td><%= link_to raw('<span class="glyphicon glyphicon-info-sign"></span>'), exporter_path(exporter) %></td>
-                <td><%= link_to raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(exporter) %></td>
+                <td><%= link_to raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(exporter), data: { turbolinks: false } %></td>
                 <td><%= link_to raw('<span class="glyphicon glyphicon-remove"></span>'), exporter, method: :delete, data: { confirm: 'Are you sure?' } %></td>
               </tr>
             <% end %>


### PR DESCRIPTION
This commit sets turbolinks to false for exporters because sometimes the form page does not load the correct fields when choosing something from `Export From`.

In this screenshot, under the `Export From` _should_ have another field where you search for the collection, but it doesn't... 
![image](https://user-images.githubusercontent.com/19597776/232918290-ddf939b5-11d4-42bb-899d-fe5f7acb5441.png)
