### PR TITLE
default-fs-entry-class

### DIFF
--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -30,6 +30,8 @@ module Bulkrax
       OaiSetEntry
     end
 
+    def file_set_entry_class; end
+
     def records(opts = {})
       opts[:metadata_prefix] ||= importerexporter.parser_fields['metadata_prefix']
       opts[:set] = collection_name unless collection_name == 'all'


### PR DESCRIPTION
# story
while troubleshooting the hyku upgrade to `v5.2.0`, @labradford and I received an error from [ImportersController#show](https://github.com/samvera-labs/bulkrax/blob/09e8d2f05aa0822f544a8545cf263013ffd52d9a/app/controllers/bulkrax/importers_controller.rb#L41) that `file_set_entry_class` was undefined for the oai dc parser

![image](https://user-images.githubusercontent.com/29032869/233483321-abfc3557-82fe-467b-9e79-1bbd2626117e.png)

# expected behavior
- add `#file_set_entry_class` to the oai dc parser so imports do not fail