### PR TITLE
add require bagit to bagit parser file

### DIFF
--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -3,6 +3,7 @@
 module Bulkrax
   class BagitParser < CsvParser # rubocop:disable Metrics/ClassLength
     include ExportBehavior
+    require 'bagit'
 
     def self.export_supported?
       true


### PR DESCRIPTION
closes #794  

Adds `require 'bagit'` to the bagit_parser.rb file to prevent `Error: NameError - uninitialized constant Bulkrax::BagitParser::BagIt` errors during BagIt imports

