### PR TITLE
fix bagit exporting

### DIFF
--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -95,9 +95,9 @@ module Bulkrax
 
       folder_count = 1
       records_in_folder = 0
-      work_entries = importerexporter.entries.where(identifier: @work_ids)
-      collection_entries = importerexporter.entries.where(identifier: @collection_ids)
-      file_set_entries = importerexporter.entries.where(identifier: @file_set_ids)
+      work_entries = importerexporter.entries.where(type: work_entry_class.to_s)
+      collection_entries = importerexporter.entries.where(type: collection_entry_class.to_s)
+      file_set_entries = importerexporter.entries.where(type: file_set_entry_class.to_s)
 
       work_entries[0..limit || total].each do |entry|
         record = ActiveFedora::Base.find(entry.identifier)


### PR DESCRIPTION
# story
while testing bagit exporting for https://github.com/scientist-softserv/atla-hyku/issues/16, I was able to complete an export...but the zip file wouldn't show up. after some debugging I noticed that `work_entries`, `collection_entries` and `file_set_entries` all came back as an empty array inside of `BagitParser#write_files`.

the change happened in #749 when we removed the `current_record_ids` method from `CsvParser`. that method was setting the `@work_ids`, `@collection_ids` and `@file_set_ids` values.

# expected behavior
- find the correct entry type by the entry class when exporting with bagit

# demo
![Screenshot 2023-04-21 at 4 29 26 PM](https://user-images.githubusercontent.com/29032869/233740852-c6f6c028-9b64-4ec3-8e2d-f316ccff4216.png)

# notes
we don't have to worry about back porting the fix as it was just released in `v5.2.0` (latest) last week