### PR TITLE
add #create_relationships to ::OaiDcParser

### DIFF
--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -110,7 +110,7 @@ module Bulkrax
     end
 
     def create_relationships
-      ScheduleRelationshipsJob.set(wait: 2.minutes).perform_later(importer_id: importerexporter.id)
+      ScheduleRelationshipsJob.set(wait: 5.minutes).perform_later(importer_id: importerexporter.id)
     end
 
     def create_file_sets; end

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -32,10 +32,6 @@ module Bulkrax
 
     def file_set_entry_class; end
 
-    def create_relationships; end
-
-    def create_file_sets; end
-
     def records(opts = {})
       opts[:metadata_prefix] ||= importerexporter.parser_fields['metadata_prefix']
       opts[:set] = collection_name unless collection_name == 'all'
@@ -116,6 +112,8 @@ module Bulkrax
     def create_relationships
       ScheduleRelationshipsJob.set(wait: 2.minutes).perform_later(importer_id: importerexporter.id)
     end
+
+    def create_file_sets; end
 
     def collections
       @collections ||= list_sets

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -113,6 +113,10 @@ module Bulkrax
       importer.record_status
     end
 
+    def create_relationships
+      ScheduleRelationshipsJob.set(wait: 2.minutes).perform_later(importer_id: importerexporter.id)
+    end
+
     def collections
       @collections ||= list_sets
     end


### PR DESCRIPTION
co-author: @summer-cook 
ref: https://github.com/scientist-softserv/atla_digital_library/issues/280

# story
creating relationships through the oai parser appears to be missing since the relationships refactor. at the time I believe only atla was using it, and they had their own custom branch to work from.

`#create_relationships` isn't in the oai dc parser in `v5.2.0` either,  but since other projects may be using it now or in the future, I don't want to add it there without knowing their implementations.