### PR TITLE
do-not-duplicate-source-identifier-on-export

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -107,7 +107,9 @@ module Bulkrax
     # Metadata required by Bulkrax for round-tripping
     def build_system_metadata
       self.parsed_metadata['id'] = hyrax_record.id
-      self.parsed_metadata[source_identifier] = hyrax_record.send(work_identifier)
+      source_id = hyrax_record.send(work_identifier)
+      source_id = source_id.to_a.first if source_id.is_a?(ActiveTriples::Relation)
+      self.parsed_metadata[source_identifier] = source_id
       self.parsed_metadata[key_for_export('model')] = hyrax_record.has_model.first
     end
 
@@ -149,7 +151,7 @@ module Bulkrax
       mapping = fetch_field_mapping
       mapping.each do |key, value|
         # these keys are handled by other methods
-        next if ['model', 'file', related_parents_parsed_mapping, related_children_parsed_mapping].include?(key)
+        next if ['model', 'file', related_parents_parsed_mapping, related_children_parsed_mapping, source_identifier].include?(key)
         next if value['excluded']
         next if Bulkrax.reserved_properties.include?(key) && !field_supported?(key)
 


### PR DESCRIPTION
- ref: https://github.com/scientist-softserv/atla_digital_library/issues/295

# story
when exporting from ATLA on the `v4-4-patch` branch, we would have an `identifier` column **and** `identifier_1` column. one would be an array, while the other would be a string

# expected behavior
- Do not duplicate source identifier on export 
- backport `#build_system_metadata fix` from `v5.0.0` (#712)

# demo
<img width="936" alt="image" src="https://user-images.githubusercontent.com/29032869/236550406-61cef21c-1a72-4fd6-aed3-09fba9e38638.png">
