### PR TITLE
🐛 Add record locking for create_relationships_job

### DIFF
--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -34,6 +34,15 @@ module Bulkrax
                   :required_elements,
                   :reserved_properties,
                   :server_name
+
+    attr_writer :use_locking
+
+    def use_locking
+      return @use_locking if defined?(@use_locking)
+
+      ENV.key?("REDIS_HOST")
+    end
+    alias use_locking? use_locking
   end
 
   def config
@@ -87,7 +96,10 @@ module Bulkrax
                  :reserved_properties,
                  :reserved_properties=,
                  :server_name,
-                 :server_name=
+                 :server_name=,
+                 :use_locking,
+                 :use_locking=,
+                 :use_locking?
 
   config do |conf|
     conf.parsers = [


### PR DESCRIPTION
With this commit we're adding two major concepts:

- Conditional locking of records (when locking is available)
- Checking that a parent_record exists before proceeding on further
  checks/tests that could raise errors

Further, I've taken the liberty to move the increment failed
relationships out of the general error handling and instead to happen
only if we had a parent record; with the assumption that when we don't
have a parent, we only want to report one error instead of reporting one
error per child.

Closes: #804

- https://github.com/samvera-labs/bulkrax/issues/804

Co-authored-by: LaRita Robinson <larita@scientist.com>
