### PR TITLE
🐛 Reindex child work after adding relationship

### DIFF
--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -22,6 +22,7 @@ module Bulkrax
       allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])
       allow(parent_record).to receive(:save!)
       allow(child_record).to receive(:save!)
+      allow(child_record).to receive(:update_index)
       allow(child_record).to receive(:member_of_collections).and_return([])
       allow(parent_record).to receive(:ordered_members).and_return([])
 
@@ -96,6 +97,11 @@ module Bulkrax
 
         it 'assigns the child to the parent\'s #ordered_members' do
           expect { perform }.to change(parent_record, :ordered_members).from([]).to([child_record])
+        end
+
+        it 'reindexes the child work' do
+          perform
+          expect(child_record).to have_received(:update_index)
         end
 
         it 'increments the processed relationships counter on the importer run' do


### PR DESCRIPTION
Changes child `save!` to `update_index` and moves it to after the parent record is saved.

Parent/child relationships are stored on the parent, but indexed onto the child. A child work will not have the correct relationships saved in the index if not reindexed after the parent is saved with the relationship.

Refs https://github.com/samvera-labs/bulkrax/issues/810