### PR TITLE
🎁 Adding indices to Bulkrax Tables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,21 +48,22 @@ jobs:
           name: coverage-report-${{ matrix.ruby }}
           path: coverage
 
-  coverage:
-    runs-on: ubuntu-latest
+  # TODO: this needs investigation. ref: https://github.com/samvera-labs/bulkrax/actions/runs/5224017717/jobs/9534880441?pr=813
+  # coverage:
+  #   runs-on: ubuntu-latest
 
-    # This line will only run the coverage job if the test job passed
-    needs: rspec
+  #   # This line will only run the coverage job if the test job passed
+  #   needs: rspec
 
-    steps:
-      - name: Download coverage report
-        uses: actions/download-artifact@v2
-        with:
-          name: coverage-report-2.6
-          path: coverage
+    # steps:
+      # - name: Download coverage report
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: coverage-report-2.6
+      #     path: coverage
 
-      - name: SimpleCov Check
-        uses: vigetlabs/simplecov-check@1.0
-        with:
-          minimum_coverage: 80
-          coverage_path: coverage/.last_run.json
+      # - name: SimpleCov Check
+      #   uses: vigetlabs/simplecov-check@1.0
+      #   with:
+      #     minimum_coverage: 80
+      #     coverage_path: coverage/.last_run.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7'] # TODO add 3.0 compat , '3.0']
+        ruby: ['2.6', '2.7'] # TODO add 3.0 compat , '3.0']
     name: Run specs with ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2
@@ -48,22 +48,21 @@ jobs:
           name: coverage-report-${{ matrix.ruby }}
           path: coverage
 
-  # TODO: this needs investigation. ref: https://github.com/samvera-labs/bulkrax/actions/runs/5224017717/jobs/9534880441?pr=813
-  # coverage:
-  #   runs-on: ubuntu-latest
+  coverage:
+    runs-on: ubuntu-latest
 
-  #   # This line will only run the coverage job if the test job passed
-  #   needs: rspec
+    # This line will only run the coverage job if the test job passed
+    needs: rspec
 
-    # steps:
-      # - name: Download coverage report
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: coverage-report-2.6
-      #     path: coverage
+    steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-report-2.7
+          path: coverage
 
-      # - name: SimpleCov Check
-      #   uses: vigetlabs/simplecov-check@1.0
-      #   with:
-      #     minimum_coverage: 80
-      #     coverage_path: coverage/.last_run.json
+      - name: SimpleCov Check
+        uses: vigetlabs/simplecov-check@1.0
+        with:
+          minimum_coverage: 80
+          coverage_path: coverage/.last_run.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7'] # TODO add 3.0 compat , '3.0']
+        ruby: ['2.7'] # TODO add 3.0 compat , '3.0']
     name: Run specs with ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 5.1.6'
   s.add_dependency 'bagit', '~> 0.4'
   s.add_dependency 'coderay'
+  s.add_dependency 'dry-monads', '~> 1.4.0'
   s.add_dependency 'iso8601', '~> 0.9.0'
   s.add_dependency 'kaminari'
   s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3.13'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'redis', '~> 4.2'
+  s.add_development_dependency 'psych', '~> 3.3'
 end

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'sqlite3', '~> 1.3.13'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'redis', '~> 4.2'
 end

--- a/db/migrate/20230608153601_add_indices_to_bulkrax.rb
+++ b/db/migrate/20230608153601_add_indices_to_bulkrax.rb
@@ -1,0 +1,14 @@
+class AddIndicesToBulkrax < ActiveRecord::Migration[5.1]
+  def change
+    add_index :bulkrax_entries, :identifier
+    add_index :bulkrax_entries, :type
+    add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx'
+
+    add_index :bulkrax_pending_relationships, :parent_id
+    add_index :bulkrax_pending_relationships, :child_id
+
+    add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'
+    add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx'
+    add_index :bulkrax_statuses, :error_class
+  end
+end

--- a/spec/test_app/config/database.yml
+++ b/spec/test_app/config/database.yml
@@ -4,22 +4,23 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 #
-default: &default
+development:
   adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
-
-development:
-  <<: *default
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
   database: db/test.sqlite3
 
 production:
-  <<: *default
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
   database: db/production.sqlite3

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_26_164334) do
+ActiveRecord::Schema.define(version: 2023_06_08_153601) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "name"
@@ -41,6 +41,9 @@ ActiveRecord::Schema.define(version: 2022_07_26_164334) do
     t.datetime "last_succeeded_at"
     t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.integer "import_attempts", default: 0
+    t.index ["identifier"], name: "index_bulkrax_entries_on_identifier"
+    t.index ["importerexporter_id", "importerexporter_type"], name: "bulkrax_entries_importerexporter_idx"
+    t.index ["type"], name: "index_bulkrax_entries_on_type"
   end
 
   create_table "bulkrax_exporter_runs", force: :cascade do |t|
@@ -125,7 +128,9 @@ ActiveRecord::Schema.define(version: 2022_07_26_164334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order", default: 0
+    t.index ["child_id"], name: "index_bulkrax_pending_relationships_on_child_id"
     t.index ["importer_run_id"], name: "index_bulkrax_pending_relationships_on_importer_run_id"
+    t.index ["parent_id"], name: "index_bulkrax_pending_relationships_on_parent_id"
   end
 
   create_table "bulkrax_statuses", force: :cascade do |t|
@@ -139,6 +144,9 @@ ActiveRecord::Schema.define(version: 2022_07_26_164334) do
     t.string "runnable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["error_class"], name: "index_bulkrax_statuses_on_error_class"
+    t.index ["runnable_id", "runnable_type"], name: "bulkrax_statuses_runnable_idx"
+    t.index ["statusable_id", "statusable_type"], name: "bulkrax_statuses_statusable_idx"
   end
 
   create_table "checksum_audit_logs", force: :cascade do |t|


### PR DESCRIPTION
Note: this is a best guess of what could use indexing.  The guess is based on my recent querying.

- `add_index :bulkrax_entries, :identifier` :: because the identifier is an important concept for an import.
- `add_index :bulkrax_entries, :type` :: because filtering on the type of an entry is important.
- `add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx` :: this is a foreign key for the entries relationship to the importer/exporter.

- `add_index :bulkrax_pending_relationships, :parent_id` :: a foreign key
- `add_index :bulkrax_pending_relationships, :child_id`  :: a foreign key

- `add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'` :: a foreign key
- `add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx'` :: a foreign key
- `add_index :bulkrax_statuses, :error_class` :: when querying what's in error, this index is helpful; also one used for grouping.