### PR TITLE
:lipstick: fix cause of NoMethodError due to typo

### DIFF
--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -282,7 +282,7 @@ module Bulkrax
       def file_sets
         @file_sets ||= ParserExportRecordSet.in_batches(complete_entry_identifiers) do |ids|
           ActiveFedora::SolrService.query(
-            extra_filers,
+            extra_filters,
             query_kwargs.merge(
               fq: [
                 %(#{solr_name(work_identifier)}:("#{ids.join('" OR "')}")),


### PR DESCRIPTION
I noticed a typo when trying to export a csv: 

![Screenshot 2023-06-13 at 10-21-37 Show Exporter __ Hyku](https://github.com/samvera-labs/bulkrax/assets/10081604/173c0841-ea95-4049-b9cb-f0231bca1ba6)

![Screenshot 2023-06-13 at 10-21-26 Show Exporter __ Hyku](https://github.com/samvera-labs/bulkrax/assets/10081604/e64b57fb-3f0d-44aa-a03c-69ad9a25a7eb)

