### PR TITLE
Fix modal for hydra apps

### DIFF
--- a/app/views/bulkrax/importers/edit.html.erb
+++ b/app/views/bulkrax/importers/edit.html.erb
@@ -10,7 +10,9 @@
         <%= render 'form', importer: @importer, form: form %>
         <div class="panel-footer">
           <div class='pull-right'>
-            <%= link_to 'Update Importer', '#bulkraxModal', class: "btn btn-primary", data: { toggle: 'modal' } %>
+            <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#bulkraxModal">
+              Update Importer
+            </button>
             <%= render 'edit_form_buttons', form: form %>
            <% cancel_path = form.object.persisted? ? importer_path(form.object) : importers_path %>
             | <%= link_to t('.cancel'), cancel_path, class: 'btn btn-default ' %>


### PR DESCRIPTION
# Summary
The update importer modal was not opening in wvu hydra, likely because it used a regular link instead of a button. The button_to rails tag also didn't work as expected, so it needed to just render as a normal button. This PR fixes it so it will open in all apps

**Note**: this was tested in both wvu hydra & atla hyrax to ensure it works across both

# Related
- https://github.com/scientist-softserv/west-virginia-university/issues/65

# Video
https://share.getcloudapp.com/Z4uG1JEd

# Acceptance criteria
- As a user, i can click the update importer button from the update importer form. It opens to a modal, where i have several options to select how I would like to update my importer. 