### PR TITLE
Re-enables nav-tabs for hydra apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gemspec
 # your gem to rubygems.org.
 
 gem 'blacklight', '~> 6.25.0'
-gem 'bootstrap-sass', '~> 3.0'
+gem 'bootstrap-sass', '~> 3.4.1'
 gem 'coderay'
 gem 'factory_bot_rails'
 gem 'hyrax', '>= 2.3'

--- a/app/assets/javascripts/bulkrax/application.js
+++ b/app/assets/javascripts/bulkrax/application.js
@@ -10,5 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-
+//= require jquery
+//= require jquery_ujs
 //= require_tree .
+//= require bootstrap

--- a/app/assets/javascripts/bulkrax/navtabs.js
+++ b/app/assets/javascripts/bulkrax/navtabs.js
@@ -1,0 +1,7 @@
+// enables the tabs in the importers/exporters pages.
+$(document).ready(function() {
+  $('.nav-tabs a').click(function (e) {
+    e.preventDefault();
+    $(this).tab('show');
+  });
+});


### PR DESCRIPTION
# Summary
Bootstrap's javascript files were not included by default and bulkrax was relying on the parent application for some of its js to work.
this PR includes bootstrap (and jquery dependency), makes sure they all load in the same order, and activates the nav tabs on the importer/show page. 

<details><summary>likely reason the tabs need to be initialized separately in this case </summary>
Bootstrap's JavaScript components, including the tabs functionality, require manual initialization in certain cases. This is because the default behavior of Bootstrap's JavaScript is to automatically initialize the components on page load. However, when using frameworks like Turbolinks or loading content dynamically, the JavaScript initialization may not occur automatically.

In your case, since you mentioned that you are working within a Rails gem, which is inside another Rails project, it's possible that the application's JavaScript files are not being loaded or initialized correctly due to the structure of the project or the usage of Turbolinks.

By explicitly adding the JavaScript initialization code, you ensure that the tab functionality is properly triggered when the page is loaded or when the tab links are clicked. This approach bypasses any potential conflicts or issues that may be preventing the automatic initialization.

So, while Bootstrap's tabs.js file is present in your app, adding the initialization code manually guarantees that the tab functionality is consistently applied, regardless of the project's structure or other factors that may affect the automatic initialization.

It's worth noting that Bootstrap's JavaScript components are designed to be flexible and work with different frameworks and setups. This means that manual initialization may be necessary in certain scenarios to ensure proper functionality.
</details>

# Related
https://github.com/scientist-softserv/west-virginia-university/issues/82

# Acceptance Criteria
- [ ] Navtabs work for on the importers/:id & exporters/:id pages

# Videos
Before: https://share.getcloudapp.com/E0uLgQL9
After: https://share.getcloudapp.com/E0uLgQR9