### PR TITLE
🎁 Add title attribute

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_bulkrax_sidebar_additions.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_bulkrax_sidebar_additions.html.erb
@@ -1,10 +1,12 @@
 <% if current_ability.can_import_works? %>
-  <%= menu.nav_link(bulkrax.importers_path) do %>
+  <%= menu.nav_link(bulkrax.importers_path,
+                    title: t('bulkrax.admin.sidebar.importers')) do %>
     <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
   <% end %>
 <% end %>
 <% if current_ability.can_export_works? %>
-  <%= menu.nav_link(bulkrax.exporters_path) do %>
+  <%= menu.nav_link(bulkrax.exporters_path,
+                    title: t('bulkrax.admin.sidebar.exporters')) do %>
     <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
   <% end %>
 <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -3,14 +3,16 @@
 <%= menu.nav_link(hyrax.my_collections_path,
                   class: "nav-link",
                   onclick: "dontChangeAccordion(event);",
-                  also_active_for: hyrax.dashboard_collections_path) do %>
+                  also_active_for: hyrax.dashboard_collections_path,
+                  title: t('hyrax.admin.sidebar.collections')) do %>
   <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
 <% end %>
 
 <%= menu.nav_link(hyrax.my_works_path,
                   class: "nav-link",
                   onclick: "dontChangeAccordion(event);",
-                  also_active_for: hyrax.dashboard_works_path) do %>
+                  also_active_for: hyrax.dashboard_works_path,
+                  title: t('hyrax.admin.sidebar.works')) do %>
   <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
 <% end %>
 


### PR DESCRIPTION
This commit will add the `title` attribute to the list tags so when users hover over the links they will see the name of the link on the dashboard.

<img width="271" alt="image" src="https://github.com/samvera-labs/bulkrax/assets/19597776/8d101c4c-fc87-43e8-a795-6522000dd047">
<img width="192" alt="image" src="https://github.com/samvera-labs/bulkrax/assets/19597776/3e5e7471-3bad-454e-b023-0d8e9428702b">