### PR TITLE
Move js require higher in the install generator

### DIFF
--- a/lib/generators/bulkrax/install_generator.rb
+++ b/lib/generators/bulkrax/install_generator.rb
@@ -47,11 +47,21 @@ class Bulkrax::InstallGenerator < Rails::Generators::Base
   def add_javascripts
     file = 'app/assets/javascripts/application.js'
     file_text = File.read(file)
-    js = '//= require bulkrax/application'
+    js = "\n// This line needs to be above the dataTables require in Hyku applications otherwise there will be jquery errors\n//= require bulkrax/application\n"
 
     return if file_text.include?(js)
-    insert_into_file file, before: /\/\/= require_tree ./ do
-      "#{js}\n"
+
+    data_tables_rgx = /\/\/= require dataTables\/jquery.dataTables/
+    require_tree_rgx = /\/\/= require_tree/
+
+    if file_text.match?(data_tables_rgx)
+      insert_into_file file, before: data_tables_rgx do
+        "#{js}\n"
+      end
+    else
+      insert_into_file file, before: require_tree_rgx do
+        "#{js}\n"
+      end
     end
   end
 


### PR DESCRIPTION
# Summary
In order to make Bulkrax's javascript work in Hydra, we needed to add bootstrap's JS to bulkrax, along with jquery since bootstrap depends on jquery. 
In hyku apps, this caused unintended behavior with the dataTables in the dashboard. 
The data tables needed to be required AFTER bulkrax in order to keep their functionality in hyku.

This commit will alter the install generator to insert the require for `bulkrax/application` above dataTables require. 

co-author: @summer-cook 

Ref:
  - https://github.com/samvera-labs/bulkrax/pull/836

# Screenshots

<details><summary>generated require</summary>
<img width="926" alt="image" src="https://github.com/samvera-labs/bulkrax/assets/19597776/6abf8cd6-e2f9-4ba6-83bb-8d7fc6f29400">

</details>

# Note
This may need to be changed for existing hyku applications with Bulkrax. 
adding bootstrap javascript was a potential breaking change for some applications: existing hyku applications will need to change the order of these requires. 