### PR TITLE
Remove jquery and bootstrap from bulkrax

### DIFF
--- a/app/assets/javascripts/bulkrax/application.js
+++ b/app/assets/javascripts/bulkrax/application.js
@@ -10,7 +10,5 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
-//= require jquery_ujs
+
 //= require_tree .
-//= require bootstrap


### PR DESCRIPTION
This commit reverts a previous commit where jQuery and bootstrap were added to application.js so Hydra can use them.  This caused issues in Hyku applications so Hydra is going to need to require jQuery and bootstrap in their application.js file instead.

Ref:
- https://github.com/samvera-labs/bulkrax/pull/836