### PR TITLE
🐛 Remove navtabs.js

### DIFF
--- a/app/assets/javascripts/bulkrax/navtabs.js
+++ b/app/assets/javascripts/bulkrax/navtabs.js
@@ -1,7 +1,0 @@
-// enables the tabs in the importers/exporters pages.
-$(document).ready(function() {
-  $('.nav-tabs a').click(function (e) {
-    e.preventDefault();
-    $(this).tab('show');
-  });
-});


### PR DESCRIPTION
This commit will revert a previous change introducing the navtabs.js file to make the nav tabs work for Hydra because it inadvertently broke things for Hyku.