### PR TITLE
:bug: Add lock to child record

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -158,9 +158,11 @@ module Bulkrax
     end
 
     def add_to_collection(child_record, parent_record)
-      parent_record.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
-      child_record.member_of_collections << parent_record
-      child_record.save!
+      conditionally_acquire_lock_for(child_record.id) do
+        parent_record.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
+        child_record.member_of_collections << parent_record
+        child_record.save!
+      end
     end
 
     def add_to_work(child_record, parent_record)


### PR DESCRIPTION
We are adding a lock to child record due to odd
race-condition-like behaviors seen when collections are forming relations. Reindexing would fail because #ordered_works is not returning anything.

- Issue: https://github.com/scientist-softserv/utk-hyku/issues/500
- Related to: https://github.com/samvera-labs/bulkrax/issues/804