### PR TITLE
🐛 Normalizing export column names

### DIFF
--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -916,6 +916,7 @@ module Bulkrax
           allow(work_obj).to receive(:member_work_ids).and_return([])
           allow(work_obj).to receive(:multiple_objects).and_return(source_id_rel)
           allow(source_id_rel).to receive(:is_a?).with(ActiveTriples::Relation).and_return(true)
+          allow(source_id_rel).to receive(:is_a?).with(Enumerable).and_return(true)
           allow(source_id_rel).to receive(:to_a).and_return(['test_work_source_id'])
           allow(source_id_rel).to receive(:each_with_index).and_return(['test_work_source_id', 0])
         end


### PR DESCRIPTION
Prior to this commit, when exporting a FileSet and GenericWork we'd see a "creator_1" and "creator" column.  The "creator" column might look as follows: `["Sandra Samvera"]`.  Which meant that creator was not an `ActiveTriples::Relation` (based on the prior logic).  Yet the "creator" field was stored as multi-value.  Perhaps having been previously coerced into an Array.

With this commit, we're favoring the Bulkrax parser field mapping `"join"` configuration over whether or not the object is an =ActiveTriples::Relation=.  That is to say, if you told us to join the field, we're going to do that regardless of the data we have.

Likewise, if the field's value is not an enumerable, we're not going to introduce an ordinal suffix (e.g. "creator_1" when we have a scalar creator).

In other words don't do the join logic if we don't have an "array" or we weren't told to join arrays.

Perhaps we could interrogate the model to ask if it's single value or not?  But this reduces the implementation knowledge of the properties by looking at a more primitive level (is the data multi-valued or not).

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/624
- https://github.com/samvera-labs/bulkrax/pull/839

# From Adventist's Export

<details>
<summary>Screenshot of exported CSV before the Change</summary>
<img width="527" alt="Screenshot 2023-08-02 at 1 14 26 PM" src="https://github.com/samvera-labs/bulkrax/assets/2130/413c0c94-6cbb-483f-a906-5a8c0f937e09">
</details>

<details>
<summary>Screenshot of exported CSV after the Change</summary>
<img width="513" alt="Screenshot 2023-08-02 at 1 14 13 PM" src="https://github.com/samvera-labs/bulkrax/assets/2130/bf6e435c-c970-41bb-bf5b-653432ad982d">
</details>

