### PR TITLE
🐛 Improving error tolerance of migration

### DIFF
--- a/db/migrate/20230608153601_add_indices_to_bulkrax.rb
+++ b/db/migrate/20230608153601_add_indices_to_bulkrax.rb
@@ -1,14 +1,44 @@
 class AddIndicesToBulkrax < ActiveRecord::Migration[5.1]
   def change
-    add_index :bulkrax_entries, :identifier
-    add_index :bulkrax_entries, :type
-    add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx'
-
-    add_index :bulkrax_pending_relationships, :parent_id
-    add_index :bulkrax_pending_relationships, :child_id
-
-    add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'
-    add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx'
-    add_index :bulkrax_statuses, :error_class
+    begin
+      add_index :bulkrax_entries, :identifier
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
+    begin
+      add_index :bulkrax_entries, :type
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
+    begin
+      add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx'
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
+    begin
+      add_index :bulkrax_pending_relationships, :parent_id
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
+    begin
+      add_index :bulkrax_pending_relationships, :child_id
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
+    begin
+      add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
+    begin
+      add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx'
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
+    begin
+      add_index :bulkrax_statuses, :error_class
+    rescue => e
+      Rails.logger.info("Encountered #{e}; moving on.")
+    end
   end
 end


### PR DESCRIPTION
If this migration has already been run, but not properly registered, it should handle the cases where the index does or does not exist.

This is a kludge to ensure that behavior.  Namely resque any error and proceed.

I encountered it while jumping between branches in PALS.