### PR TITLE
small pr to make all migrations skipable and updated last one to match existing pattern

### DIFF
--- a/db/migrate/20210806044408_remove_unused_last_error.rb
+++ b/db/migrate/20210806044408_remove_unused_last_error.rb
@@ -1,7 +1,7 @@
 class RemoveUnusedLastError < ActiveRecord::Migration[5.1]
   def change
-    remove_column :bulkrax_entries, :last_error
-    remove_column :bulkrax_exporters, :last_error
-    remove_column :bulkrax_importers, :last_error
+    remove_column :bulkrax_entries, :last_error if column_exists?(:bulkrax_entries, :last_error)
+    remove_column :bulkrax_exporters, :last_error if column_exists?(:bulkrax_exporters, :last_error)
+    remove_column :bulkrax_importers, :last_error if column_exists?(:bulkrax_importers, :last_error)
   end
 end

--- a/db/migrate/20230608153601_add_indices_to_bulkrax.rb
+++ b/db/migrate/20230608153601_add_indices_to_bulkrax.rb
@@ -1,44 +1,16 @@
 class AddIndicesToBulkrax < ActiveRecord::Migration[5.1]
   def change
-    begin
-      add_index :bulkrax_entries, :identifier
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
-    begin
-      add_index :bulkrax_entries, :type
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
-    begin
-      add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx'
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
-    begin
-      add_index :bulkrax_pending_relationships, :parent_id
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
-    begin
-      add_index :bulkrax_pending_relationships, :child_id
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
-    begin
-      add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
-    begin
-      add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx'
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
-    begin
-      add_index :bulkrax_statuses, :error_class
-    rescue => e
-      Rails.logger.info("Encountered #{e}; moving on.")
-    end
+    check_and_add_index :bulkrax_entries, :identifier
+    check_and_add_index :bulkrax_entries, :type
+    check_and_add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx'
+    check_and_add_index :bulkrax_pending_relationships, :child_id
+    check_and_add_index :bulkrax_pending_relationships, :parent_id
+    check_and_add_index :bulkrax_statuses, :error_class
+    check_and_add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx'
+    check_and_add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'
+  end
+
+  def check_and_add_index(table_name, column_name, options = {})
+    add_index(table_name, column_name, options) unless index_exists?(table_name, column_name, options)
   end
 end


### PR DESCRIPTION
this doesn't actually change the function of the last migration. it just makes it work the same as all the other ones so we don't accidentally establish a new pattern. 