### PR TITLE
find existing records more often, leading to better round tripping experiance

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  class ObjectFactory
+  class ObjectFactory # rubocop:disable Metrics/ClassLength
     extend ActiveModel::Callbacks
     include Bulkrax::FileFactory
     include DynamicRecordLookup


### PR DESCRIPTION
ActiveFedora use to find objects with {field => value}. Now it only reliably works with {solr_name(field) => value} so we use that instead. Also if find by id fails we should _still_ check source_identifier to see if we can find it that way.