### PR TITLE
:gear: upgrade dry-monads dependency to ~> 1.5.0

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -18,7 +18,7 @@ module Bulkrax
     validates :admin_set_id, presence: true if defined?(::Hyrax)
     validates :parser_klass, presence: true
 
-    delegate :valid_import?, :write_errored_entries_file, :visibility, to: :parser
+    delegate :create_parent_child_relationships, :valid_import?, :write_errored_entries_file, :visibility, to: :parser
 
     attr_accessor :only_updates, :file_style, :file
     attr_writer :current_run

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -252,10 +252,10 @@ module Bulkrax
     end
 
     # @return [TrueClass,FalseClass]
-    def record_has_source_identifier(record, index, key_count = nil)
+    def record_has_source_identifier(record, index)
       if record[source_identifier].blank?
         if Bulkrax.fill_in_blank_source_identifiers.present?
-          record[source_identifier] = Bulkrax.fill_in_blank_source_identifiers.call(self, index, key_count)
+          record[source_identifier] = Bulkrax.fill_in_blank_source_identifiers.call(self, index)
         else
           invalid_record("Missing #{source_identifier} for #{record.to_h}\n")
           false

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -252,10 +252,10 @@ module Bulkrax
     end
 
     # @return [TrueClass,FalseClass]
-    def record_has_source_identifier(record, index)
+    def record_has_source_identifier(record, index, key_count = nil)
       if record[source_identifier].blank?
         if Bulkrax.fill_in_blank_source_identifiers.present?
-          record[source_identifier] = Bulkrax.fill_in_blank_source_identifiers.call(self, index)
+          record[source_identifier] = Bulkrax.fill_in_blank_source_identifiers.call(self, index, key_count)
         else
           invalid_record("Missing #{source_identifier} for #{record.to_h}\n")
           false

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 5.1.6'
   s.add_dependency 'bagit', '~> 0.4'
   s.add_dependency 'coderay'
-  s.add_dependency 'dry-monads', '~> 1.4.0'
+  s.add_dependency 'dry-monads', '~> 1.5.0'
   s.add_dependency 'iso8601', '~> 0.9.0'
   s.add_dependency 'kaminari'
   s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'

--- a/db/migrate/20230608153601_add_indices_to_bulkrax.rb
+++ b/db/migrate/20230608153601_add_indices_to_bulkrax.rb
@@ -1,3 +1,4 @@
+# This migration comes from bulkrax (originally 20230608153601)
 class AddIndicesToBulkrax < ActiveRecord::Migration[5.1]
   def change
     check_and_add_index :bulkrax_entries, :identifier
@@ -10,7 +11,15 @@ class AddIndicesToBulkrax < ActiveRecord::Migration[5.1]
     check_and_add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'
   end
 
-  def check_and_add_index(table_name, column_name, options = {})
-    add_index(table_name, column_name, options) unless index_exists?(table_name, column_name, options)
+  if RUBY_VERSION =~ /^2/
+    def check_and_add_index(table_name, column_name, options = {})
+      add_index(table_name, column_name, options) unless index_exists?(table_name, column_name, options)
+    end
+  elsif RUBY_VERSION =~ /^3/
+    def check_and_add_index(table_name, column_name, **options)
+      add_index(table_name, column_name, **options) unless index_exists?(table_name, column_name, **options)
+    end
+  else
+    raise "Ruby version #{RUBY_VERSION} is unknown"
   end
 end


### PR DESCRIPTION
Hyrax 4.0.0 requires a dependency upgrade for
dry-monads. I could not upgrade GBH's bulkrax without doing this change.

- Issue: https://github.com/scientist-softserv/ams/issues/77
- Ref: https://github.com/samvera/hyrax/blob/cbe9278b919485f90a37630d3f3157ecef59cd7c/hyrax.gemspec#L48