### PR TITLE
:bug: add guard clauses to add_indices_to_bulkrax migration

### DIFF
--- a/db/migrate/20230608153601_add_indices_to_bulkrax.rb
+++ b/db/migrate/20230608153601_add_indices_to_bulkrax.rb
@@ -1,16 +1,14 @@
 class AddIndicesToBulkrax < ActiveRecord::Migration[5.1]
   def change
-    check_and_add_index :bulkrax_entries, :identifier
-    check_and_add_index :bulkrax_entries, :type
-    check_and_add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx'
-    check_and_add_index :bulkrax_pending_relationships, :child_id
-    check_and_add_index :bulkrax_pending_relationships, :parent_id
-    check_and_add_index :bulkrax_statuses, :error_class
-    check_and_add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx'
-    check_and_add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx'
-  end
+    add_index :bulkrax_entries, :identifier unless index_exists?(:bulkrax_entries, :identifier)
+    add_index :bulkrax_entries, :type unless index_exists?(:bulkrax_entries, :type)
+    add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx' unless index_exists?(:bulkrax_entries, [:importerexporter_id, :importerexporter_type], name: 'bulkrax_entries_importerexporter_idx')
 
-  def check_and_add_index(table_name, column_name, options = {})
-    add_index(table_name, column_name, options) unless index_exists?(table_name, column_name, options)
+    add_index :bulkrax_pending_relationships, :parent_id unless index_exists?(:bulkrax_pending_relationships, :parent_id)
+    add_index :bulkrax_pending_relationships, :child_id unless index_exists?(:bulkrax_pending_relationships, :child_id) 
+
+    add_index :bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx' unless index_exists?(:bulkrax_statuses, [:statusable_id, :statusable_type], name: 'bulkrax_statuses_statusable_idx')
+    add_index :bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx' unless index_exists?(:bulkrax_statuses, [:runnable_id, :runnable_type], name: 'bulkrax_statuses_runnable_idx')
+    add_index :bulkrax_statuses, :error_class unless index_exists?(:bulkrax_statuses, :error_class)
   end
 end


### PR DESCRIPTION
Add guard clauses to add_indices_to_bulkrax migration:

Not doing so produced the following error in Adventist, when trying to run migrations: `ArgumentError: Index name 'index_bulkrax_entries_on_identifier' on table 'bulkrax_entries' already exists`