### PR TITLE
5.4.0-bug-fixes

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -103,7 +103,11 @@ module Bulkrax
     end
 
     def search_by_identifier
-      work_index = ::ActiveFedora.index_field_mapper.solr_name(work_identifier, :facetable)
+      # TODO(alishaevn): return the proper `work_index` value below
+      # ref: https://github.com/samvera-labs/bulkrax/issues/866
+      # ref:https://github.com/samvera-labs/bulkrax/issues/867
+      # work_index = ::ActiveFedora.index_field_mapper.solr_name(work_identifier, :facetable)
+      work_index = work_identifier
       query = { work_index =>
                 source_identifier_value }
       # Query can return partial matches (something6 matches both something6 and something68)

--- a/app/views/bulkrax/importers/_oai_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_fields.html.erb
@@ -11,7 +11,7 @@
       ['Public', 'open'],
       ['Private', 'restricted'],
       ['Institution', 'authenticated']
-    ],x
+    ],
     selected: importer.parser_fields['visibility'] || 'open',
     input_html: { class: 'form-control' }
   %>


### PR DESCRIPTION
# story
### 030103d
restore the ability to load the "/importers" page.
there was an extra "x" in the app/views/bulkrax/importers/_oai_fields.html.erb file. it threw a syntax error when trying to create a new importer.
<details>
<summary>error</summary>
<img width="1412" alt="Screenshot 2023-10-03 at 9 11 32 AM" src="https://github.com/samvera-labs/bulkrax/assets/29032869/778769a8-7d34-4920-952e-f44b8c9bcc11">
</details>

### 99e6716
restore our ability to properly look up works by their work_identifier

- ref: https://github.com/samvera-labs/bulkrax/issues/866
- ref:https://github.com/samvera-labs/bulkrax/issues/867

<details>
<summary>error</summary>

<img width="1204" alt="image" src="https://github.com/samvera-labs/bulkrax/assets/29032869/89e7afa9-9538-4ea0-beb5-0deff1f2ef9b">
</details>