### PR TITLE
use the `GlobalID` library tooling to determine global id

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -247,7 +247,7 @@ module Bulkrax
     def collection_type(attrs)
       return attrs if attrs['collection_type_gid'].present?
 
-      attrs['collection_type_gid'] = Hyrax::CollectionType.find_or_create_default_collection_type.gid
+      attrs['collection_type_gid'] = Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id.to_s
       attrs
     end
 

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -15,7 +15,7 @@ module Bulkrax
     def add_collection_type_gid
       return if self.parsed_metadata['collection_type_gid'].present?
 
-      self.parsed_metadata['collection_type_gid'] = ::Hyrax::CollectionType.find_or_create_default_collection_type.gid
+      self.parsed_metadata['collection_type_gid'] = ::Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id.to_s
     end
   end
 end

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -65,7 +65,7 @@ module Bulkrax
       metadata = {
         visibility: 'open'
       }
-      metadata[:collection_type_gid] = Hyrax::CollectionType.find_or_create_default_collection_type.gid if defined?(::Hyrax)
+      metadata[:collection_type_gid] = Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id.to_s if defined?(::Hyrax)
 
       collections.each_with_index do |set, index|
         next unless collection_name == 'all' || collection_name == set.spec


### PR DESCRIPTION
the old `#gid` method was weird and breaking for users expecting things to work with `GlobalID` tools: https://github.com/samvera/hyrax/issues/4696

Hyrax has provided a mechanism for updating "gid" references since the 3.0 line, and will drop `#gid` in 5.0.0. use `#to_global_id` to get global ids instead.