### PR TITLE
Avoid NoMethodError in Bulkrax::Importers::Controller#create.

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -33,9 +33,10 @@ module Bulkrax
           model_field_mappings.map(&:to_sym).each do |model_mapping|
             next unless r.key?(model_mapping)
 
-            if r[model_mapping].strip.casecmp('collection').zero?
+            model = r[model_mapping].nil? ? "" : r[model_mapping].strip
+            if model.casecmp('collection').zero?
               @collections << r
-            elsif r[model_mapping].strip.casecmp('fileset').zero?
+            elsif model.casecmp('fileset').zero?
               @file_sets << r
             else
               @works << r


### PR DESCRIPTION
Import CSV [GAM-Test004.csv](https://github.com/samvera-labs/bulkrax/files/12848386/GAM-Test004.csv) with empty model value to comet (currently using hyrax-4-rails-6 branch) will trigger NoMethodError in Bulkrax::Importers::Controller#create: undefined method `casecmp` for nil:NilCLass. 

The pull request will avoid the error.
