### PR TITLE
Nav-tabs event scoping

### DIFF
--- a/app/assets/javascripts/bulkrax/navtabs.js.erb
+++ b/app/assets/javascripts/bulkrax/navtabs.js.erb
@@ -1,7 +1,7 @@
 <% unless defined?(::Hyku) %>
   // enables the tabs in the importers/exporters pages.
   $(document).ready(function() {
-    $('.nav-tabs a').click(function (e) {
+    $('.bulkrax-nav-tab-top-margin.nav-tabs a').click(function (e) {
       e.preventDefault();
       $(this).tab('show');
     });


### PR DESCRIPTION
We've recently encountered issues where some of our non-bulkrax pages with tabbed content are attempting to switch content via javascript when they are actually supposed to trigger a page reload. It appears that an event in bulkrax is being bound to all bootstrap "nav-tab" objects, and is interfering with the expected behavior. 

This PR just scopes the event binding to bulkrax related content to prevent the event from leaking to other unrelated pages. `bulkrax-nav-tab-top-margin` was the best class I could find, but I'm definitely open to suggestions.