### PR TITLE
🐛 Fix tabs for Hydra application

### DIFF
--- a/app/assets/javascripts/bulkrax/navtabs.js.erb
+++ b/app/assets/javascripts/bulkrax/navtabs.js.erb
@@ -1,9 +1,26 @@
 <% unless defined?(::Hyku) %>
   // enables the tabs in the importers/exporters pages.
   $(document).ready(function() {
-    $('.bulkrax-nav-tab-top-margin.nav-tabs a').click(function (e) {
+    $('.bulkrax-nav-tab-top-margin.nav-tabs a').click(function(e) {
       e.preventDefault();
-      $(this).tab('show');
+
+      // Remove active class from all tabs and hide all tab content
+      $('.bulkrax-nav-tab-top-margin.nav-tabs a').parent().removeClass('active');
+      $('.tab-content .tab-pane').removeClass('active');
+
+      // Add active class to clicked tab and show its content
+      $(this).parent().addClass('active');
+      $($(this).attr('href')).addClass('active');
     });
+
+    $('#full-errors-tab, #full-errors-tab a').click(function(e) {
+      $('#raw-errors-tab, #bulkrax-raw-toggle-1').removeClass('active');
+      $('#full-errors-tab, #bulkrax-full-toggle-1').addClass('active');
+    })
+
+    $('#raw-errors-tab, #raw-errors-tab a').click(function(e) {
+      $('#full-errors-tab, #bulkrax-full-toggle-1').removeClass('active');
+      $('#raw-errors-tab, #bulkrax-raw-toggle-1').addClass('active');
+    })
   });
 <% end %>

--- a/app/views/bulkrax/shared/_bulkrax_errors.html.erb
+++ b/app/views/bulkrax/shared/_bulkrax_errors.html.erb
@@ -13,8 +13,8 @@
         <div class="bulkrax-nav-tab-bottom-margin">
           <!-- Toggle buttons -->
           <div class="btn-group pull-right" role="group" aria-label="...">
-            <button type="button" class="btn btn-default active"><a href="#bulkrax-full-toggle-1" aria-controls="bulkrax-full-toggle-1" role="tab" data-toggle="tab">Full</a></button>
-            <button type="button" class="btn btn-default"><a href="#bulkrax-raw-toggle-1" aria-controls="bulkrax-raw-toggle-1" role="tab" data-toggle="tab">Raw</a></button>
+            <button id="full-errors-tab" type="button" class="btn btn-default active"><a href="#bulkrax-full-toggle-1" aria-controls="bulkrax-full-toggle-1" role="tab" data-toggle="tab">Full</a></button>
+            <button id="raw-errors-tab" type="button" class="btn btn-default"><a href="#bulkrax-raw-toggle-1" aria-controls="bulkrax-raw-toggle-1" role="tab" data-toggle="tab">Raw</a></button>
           </div>
           <!-- Tab panes -->
           <div class="tab-content">


### PR DESCRIPTION
This commit will add logic for showing the correct tab in a Hydra application like WVU's.  We found that if we add the bootstrap require in their application.js then Blacklight's dropdown menu's stop working. However this then breaks Bulkrax tabs.  Because we're not adding bootstrap into the Hydra appilication, we mimic the behavior of the tabs function instead.

https://github.com/samvera-labs/bulkrax/assets/19597776/d5650038-fbc8-4181-982b-87cceaf76964

