### PR TITLE
Test Bulkrax against Hyrax 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,17 @@ on:
 
 jobs:
   rspec:
+    env:
+      HYRAX_VERSION: "${{ matrix.hyrax }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby: ['2.7', '3.2']
-    name: Run specs with ruby ${{ matrix.ruby }}
+        hyrax: ['~> 4.0', '~> 5.0.1']
+        exclude:
+          - ruby: '2.7'
+            hyrax: '~> 5.0.1'
+    name: Run specs with ruby ${{ matrix.ruby }} and hyrax ${{ matrix.hyrax }}
     steps:
       - uses: actions/checkout@v2
 
@@ -21,7 +27,7 @@ jobs:
         uses: actions/cache@v4.2.0
         with:
           path: vendor/bundle
-          key: ${{ matrix.ruby }}
+          key: ${{ matrix.ruby }} ${{ matrix.hyrax }}
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.204.0
@@ -35,6 +41,7 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install
+          echo bundle info hyrax
 
       - name: Migrate test database
         run: bundle exec rake db:migrate db:test:prepare
@@ -43,9 +50,10 @@ jobs:
         run: bundle exec rake spec
 
       - name: Upload coverage results
+        if: ${{ matrix.ruby == '2.7' }}
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: coverage-report-${{ matrix.ruby }}
+          name: coverage-report
           path: coverage/**
           include-hidden-files: true
 
@@ -59,7 +67,7 @@ jobs:
       - name: Download coverage report
         uses: actions/download-artifact@v4.1.8
         with:
-          name: coverage-report-2.7
+          name: coverage-report
           path: coverage
 
       - name: SimpleCov Check

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ spec/test_app/tmp/
 tmp/**
 *~undo-tree~
 /vendor
+.tool-versions

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,9 @@ gem 'coderay'
 gem 'concurrent-ruby', '1.3.4'
 gem 'factory_bot_rails'
 
-# Bulkrax supports Hyrax 2.3 through 4.x only.
-# Hyrax 5+ requires Rails 7.2 and is not yet supported.
-gem 'hyrax', '>= 2.3', '< 5.0'
+# Bulkrax supports Hyrax 2.3 through 5.0.x only.
+# Hyrax 5.1+ requires Rails 7.2 and is not yet supported.
+gem 'hyrax', ENV['HYRAX_VERSION'] || '~> 5.0.0'
 
 gem 'oai'
 gem 'pg'

--- a/README.md
+++ b/README.md
@@ -208,6 +208,28 @@ We encourage everyone to help improve this project.  Bug reports and pull reques
 
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](https://contributor-covenant.org) code of conduct.
 
+### Running tests
+- The tests use sqlite as the database, so no extra dependencies are required. 
+- Ensure you are using a supported version of Ruby (`ruby -v` should be greater or equal to 2.7) 
+- Decide on your version of Hyrax to test against and export it to your environment, then bundle install. The Hyrax version should be greater or equal to 2.3.
+```bash
+export HYRAX_VERSION="~> 4.0.0"
+bundle install
+```
+- Run the test migrations
+```bash
+bundle exec bin/rails db:migrate RAILS_ENV=test
+```
+- Run the tests
+```bash
+bundle exec rspec
+```
+
+- Run the style checker / linter
+```bash
+bundle exec rubocop
+```
+
 ## Questions
 Questions can be sent to support@notch8.com. Please make sure to include "Bulkrax" in the subject line of your email.
 

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency 'rails', '>= 5.1.6'
+  s.add_dependency 'rails', '>= 5.1.6', '< 7.0.0'
   s.add_dependency 'bagit', '~> 0.6.0'
   s.add_dependency 'coderay'
   s.add_dependency 'denormalize_fields'


### PR DESCRIPTION
Hyku is currently using a branch of Hyrax 5.0.x, so we should test Bulkrax on Hyrax `~> 5.0.0`

Discovered while working on https://github.com/samvera/bulkrax/issues/1046