### PR TITLE
:bug: Dynamically configure importer file size limit

### DIFF
--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -15,9 +15,11 @@ function prepBulkrax(event) {
   // Initialize the uploader only if hyraxUploader is defined
   if (typeof $.fn.hyraxUploader === 'function') {
     // Initialize the uploader
-    $('.fileupload-bulkrax').hyraxUploader({ 
+    var uploader = $('.fileupload-bulkrax');
+    var maxFileSize = uploader.data('max-file-size');
+    uploader.hyraxUploader({ 
       maxNumberOfFiles: 1,
-      maxFileSize: <%= (defined?(Hyrax) && Hyrax.config.uploader[:maxFileSize]) || 524288000 %>
+      maxFileSize: maxFileSize
     });
 
     // Function to toggle 'required' attribute based on uploaded files

--- a/app/views/bulkrax/importers/_file_uploader.html.erb
+++ b/app/views/bulkrax/importers/_file_uploader.html.erb
@@ -1,4 +1,4 @@
-<div class="fileupload-bulkrax">
+<div class="fileupload-bulkrax" data-max-file-size="<%= (defined?(Hyrax) && Hyrax.config.uploader[:maxFileSize]) || 524288000 %>">
   <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
   <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
   <div class="fileupload-buttonbar">


### PR DESCRIPTION
While the previous implementation worked locally, it did not work once deployed to staging.

ref original PR: https://github.com/samvera/bulkrax/pull/1060

It wasn't working because the file size limit for the Bulkrax importer was previously determined at asset compilation time, causing it to be static across all tenants. This prevented per-tenant configurations for file upload limits from taking effect.

This commit addresses the issue by:
- Embedding the `maxFileSize` as a `data` attribute in the file uploader's HTML, which is rendered dynamically for each request.
- Updating the corresponding JavaScript to read this `data` attribute, ensuring that the uploader is initialized with the correct file size limit for the current tenant.

The original implementation did not work once deployed to staging.


- https://github.com/samvera/bulkrax/pull/1063/commits/c6ad23efe54c81f663cdbe1f8279caa3546193c5

## BEFORE

<img width="673" height="397" alt="image" src="https://github.com/user-attachments/assets/9ddc4470-47f4-4935-81cf-6a89ec8e66e9" />



<img width="696" height="251" alt="image" src="https://github.com/user-attachments/assets/4ddc67f3-62ee-4b03-872a-509c1d7a9afc" />


## AFTER

(this would instantly say File Too Large)

<img width="677" height="398" alt="image" src="https://github.com/user-attachments/assets/7e731a71-f568-457d-b21b-136a0c48f495" />

<img width="562" height="240" alt="image" src="https://github.com/user-attachments/assets/8873df1d-b4f8-42a9-a2f2-a0cc72e951b9" />

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/8979ae6a-4a79-4245-ad89-90d6cf7e9ac8" />
