### PR TITLE
Favor += over << to avoid frozen array issues

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -108,7 +108,7 @@ module Bulkrax
     def self.add_child_to_parent_work(parent:, child:)
       parent = self.find(parent.id)
       return true if parent.member_ids.include?(child.id)
-      parent.member_ids << child.id
+      parent.member_ids += [child.id]
       Hyrax.persister.save(resource: parent)
     end
 
@@ -116,7 +116,7 @@ module Bulkrax
     # The resource added to a collection can be either a work or another collection.
     def self.add_resource_to_collection(collection:, resource:, user:)
       resource = self.find(resource.id)
-      resource.member_of_collection_ids << collection.id
+      resource.member_of_collection_ids += [collection.id]
       save!(resource: resource, user: user)
     end
 


### PR DESCRIPTION
Valkyrie resource properties sometimes default to frozen empty arrays. Using `<<` to insert will result in an error. Using `+=` avoids the issue.