### PR TITLE
💄 Warning colors

### DIFF
--- a/app/assets/javascripts/bulkrax/importers_stepper.js
+++ b/app/assets/javascripts/bulkrax/importers_stepper.js
@@ -877,7 +877,7 @@
     )
 
     // Render all issues - FROM BACKEND
-    // Use main status severity for all issue accordions to maintain consistent coloring
+    // Each issue uses its own severity for independent coloring
     if (data.messages.issues && data.messages.issues.length > 0) {
       data.messages.issues.forEach(function (issue) {
         var content = ''
@@ -908,7 +908,7 @@
           createAccordion(
             issue.title,
             issue.icon,
-            status.severity,
+            issue.severity,
             issue.count,
             issue.defaultOpen,
             content


### PR DESCRIPTION
# Story: All warning messages render in yellow

Updates the warning notifications to render in yellow
instead of the color of the overall import status. Since warnings are
not necessarily indicative of an overall failed import.

Ref:
- https://github.com/notch8/hyku-community-issues/issues/48