### PR TITLE
🐛 fix i18n locale setting for validation

### DIFF
--- a/app/assets/javascripts/bulkrax/importers_stepper.js
+++ b/app/assets/javascripts/bulkrax/importers_stepper.js
@@ -138,6 +138,8 @@
       return
     }
 
+    eventsInitialized = false
+
     bindEvents()
     initAdminSetState()
     updateDownloadTemplateLink()
@@ -1319,7 +1321,8 @@
             import_file_path: filePath
           },
           admin_set_id: StepperState.adminSetId
-        }
+        },
+        locale: $('input[name="locale"]').val()
       },
       timeout: CONSTANTS.AJAX_TIMEOUT_LONG
     })
@@ -1429,7 +1432,8 @@
           .map(function (f) { return f.uploadId }),
         importer: {
           admin_set_id: StepperState.adminSetId
-        }
+        },
+        locale: $('input[name="locale"]').val()
       }
     }
 
@@ -2284,5 +2288,5 @@
   }
 
   // Initialize on document ready and turbolinks load
-  $(document).on('ready turbolinks:load', initBulkImportStepper)
+  $(document).on('turbolinks:load', initBulkImportStepper)
 })(jQuery, window.BulkraxUtils || {})

--- a/app/controllers/concerns/bulkrax/guided_import.rb
+++ b/app/controllers/concerns/bulkrax/guided_import.rb
@@ -15,6 +15,8 @@ module Bulkrax
 
     # AJAX endpoint to validate uploaded files
     def guided_import_validate
+      set_locale_from_params
+
       files, error = resolve_validation_files
       return render json: error, status: :ok if error
       return render json: StepperResponseFormatter.error(message: I18n.t('bulkrax.importer.guided_import.validation.no_files_uploaded')), status: :ok unless files.any?
@@ -458,6 +460,10 @@ module Bulkrax
 
     def import_file_path
       @file_path ||= params[:importer]&.[](:parser_fields)&.[](:import_file_path)
+    end
+
+    def set_locale_from_params
+      I18n.locale = params[:locale] if params[:locale].present? && I18n.available_locales.include?(params[:locale].to_sym)
     end
   end
   # rubocop:enable Metrics/ModuleLength

--- a/app/views/bulkrax/importers/guided_import_new.html.erb
+++ b/app/views/bulkrax/importers/guided_import_new.html.erb
@@ -62,6 +62,7 @@
     <!-- Main Form -->
     <div class="stepper-content-wrapper">
       <%= form_for [:bulkrax, Bulkrax::Importer.new], url: guided_import_create_importers_path, method: :post, html: { id: 'bulk-import-stepper-form', multipart: true } do |f| %>
+        <%= hidden_field_tag 'locale', I18n.locale %>
         <!-- ====== STEP 1: Upload & Validate ====== -->
         <div class="step-content" data-step="1">
           <div class="step-title">


### PR DESCRIPTION
Previously, the validation was not setting the locale bcause we had no params with locale present.  This commit will add a hidden field to the form which contains the current locale and pass it to the javascript and then the controller where it can be set accordingly.  Also fixed a turbo reload issue where if you pick the language, the javascript breaks.