### PR TITLE
🐛 Match JavaScript listener Bulkrax form ID

### DIFF
--- a/app/assets/javascripts/bulkrax/importers_stepper.js
+++ b/app/assets/javascripts/bulkrax/importers_stepper.js
@@ -330,7 +330,7 @@
     })
 
     // Settings form changes
-    $('#bulkrax_importer_name').on('input', debounce(function () {
+    $('#importer_name').on('input', debounce(function () {
       StepperState.settings.name = $(this).val()
       updateStepNavigation()
     }, CONSTANTS.DEBOUNCE_DELAY))
@@ -1950,7 +1950,7 @@
     var dateStr =
       today.getMonth() + 1 + '/' + today.getDate() + '/' + today.getFullYear()
     var defaultName = t('import_name_prefix') + dateStr
-    $('#bulkrax_importer_name').val(defaultName)
+    $('importer_name').val(defaultName)
     StepperState.settings.name = defaultName
   }
 


### PR DESCRIPTION
This commit changes the name of the JavaScript listener that updates the state values of the Import Name form field to match the actual ID of the form field rendered by Rails. This ensures changes to the name value are updated in state and reflected in the summary on Step 3.

Actual ID:
<img width="1245" height="583" alt="Screenshot 2026-02-26 at 4 06 20 PM" src="https://github.com/user-attachments/assets/c195b812-1899-42fc-9f38-23dd958b02fc" />
