### PR TITLE
Handle suffixes in row validations

### DIFF
--- a/app/services/bulkrax/csv_validation_service/row_validator_service/required_values_validator.rb
+++ b/app/services/bulkrax/csv_validation_service/row_validator_service/required_values_validator.rb
@@ -21,7 +21,7 @@ module Bulkrax
 
         required_terms = metadata[:required_terms] || []
         required_terms.each do |field|
-          next if row[:raw_row][field].present?
+          next if row[:raw_row].any? { |key, value| normalize_header(key) == field && value.present? }
 
           errors << {
             row: row_number,
@@ -35,6 +35,12 @@ module Bulkrax
           }
         end
       end
+    end
+
+    private
+
+    def normalize_header(header)
+      header.sub(/_\d+\z/, '')
     end
   end
 end

--- a/spec/services/bulkrax/csv_validation_service/row_validator_service_spec.rb
+++ b/spec/services/bulkrax/csv_validation_service/row_validator_service_spec.rb
@@ -359,6 +359,37 @@ RSpec.describe Bulkrax::CsvValidationService::RowValidatorService do
         expect(required_errors).to be_empty
       end
 
+      it 'does not error when required field is satisfied by a suffixed column (e.g. title_1)' do
+        data = [{
+          source_identifier: 'work1',
+          model: 'GenericWork',
+          parent: nil,
+          children: nil,
+          raw_row: { 'title_1' => 'Work 1' }
+        }]
+        validator = described_class.new(data, field_metadata, mapping_manager)
+        required_errors = validator.errors.select { |e| e[:category] == 'missing_required_value' }
+        expect(required_errors).to be_empty
+      end
+
+      it 'errors when required field is present only as a blank suffixed column (e.g. title_1 is empty)' do
+        data = [{
+          source_identifier: 'work1',
+          model: 'GenericWork',
+          parent: nil,
+          children: nil,
+          raw_row: { 'title_1' => '' }
+        }]
+        validator = described_class.new(data, field_metadata, mapping_manager)
+        expect(validator.errors).to include(
+          hash_including(
+            category: 'missing_required_value',
+            severity: 'error',
+            column: 'title'
+          )
+        )
+      end
+
       it 'skips required check when model is not in field_metadata' do
         data = [{
           source_identifier: 'work1',


### PR DESCRIPTION
## Summary

Column headings with suffixes were recognized as valid headers but were not considered valid values for the required fields. This caused the row validation to fail when the suffixes were included in the CSV file.

Fixes https://github.com/samvera/bulkrax/issues/1142