### PR TITLE
Source identifier validations

### DIFF
--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -28,7 +28,7 @@ module Bulkrax
 
           header_issues    = check_headers(headers, raw_csv, mapping_manager, mappings, field_metadata, field_analyzer)
           missing_required = header_issues[:missing_required]
-          find_record      = build_find_record(mapping_manager, mappings)
+          find_record      = build_find_record
           row_errors       = run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record)
           file_validator   = CsvTemplate::FileValidator.new(csv_data, zip_file, admin_set_id)
           collections, works, file_sets = extract_hierarchy_items(csv_data, all_ids, find_record, mappings)

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
@@ -135,26 +135,30 @@ module Bulkrax
       end
 
       # Builds the find_record lambda used by row validators and hierarchy extraction.
-      def build_find_record(mapping_manager, mappings)
-        work_identifier        = mapping_manager.resolve_column_name(flag: 'source_identifier', default: 'source').first&.to_s || 'source'
-        work_identifier_search = Array.wrap(mappings.dig(work_identifier, 'search_field')).first&.to_s ||
+      # Builds the find_record lambda used by row validators and hierarchy extraction.
+      # Reads the full (unfiltered) field mappings directly since MappingManager strips
+      # entries with "generated"=>true (e.g. bulkrax_identifier), which is typically the
+      # entry flagged with source_identifier:true and carries the correct search_field.
+      def build_find_record
+        all_mappings = Bulkrax.field_mappings['Bulkrax::CsvParser'] || {}
+        work_identifier = all_mappings.find { |_k, v| v['source_identifier'] == true }&.first || 'source'
+        work_identifier_search = Array.wrap(all_mappings.dig(work_identifier, 'search_field')).first&.to_s ||
                                  "#{work_identifier}_sim"
         ->(id) { find_record_by_source_identifier(id, work_identifier, work_identifier_search) }
       end
 
       # Attempt to locate an existing repository record by its identifier.
-      # The identifier may be a Bulkrax source_identifier or a repository object ID.
-      # This mimics the find behavior of the actual import process, which checks for existing records to determine whether to create or update.
-      # Since we don't have the full importer context here, we check both the Entry model and the repository directly.
+      # The identifier may be a repository object ID or a source_identifier property value.
+      # Checks the repository directly (by ID, then by Solr property search) — a Bulkrax
+      # Entry record alone is not sufficient, as the object may never have been created.
       #
       # @param identifier [String]
       # @param work_identifier [String] the source_identifier property name (e.g. "source")
       # @param work_identifier_search [String] the Solr field for source_identifier (e.g. "source_sim")
-      # @return [Boolean] true if a matching Entry or repository object is found
+      # @return [Boolean] true if a matching repository object is found
       def find_record_by_source_identifier(identifier, work_identifier, work_identifier_search)
         return false if identifier.blank?
 
-        return true if Entry.exists?(identifier: identifier, importerexporter_type: 'Bulkrax::Importer')
         return true if Bulkrax.object_factory.find_or_nil(identifier).present?
 
         [Bulkrax.collection_model_class, *Bulkrax.curation_concerns].any? do |klass|

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
@@ -109,10 +109,12 @@ module Bulkrax
 
       # Assembles the final result hash returned to the guided import UI.
       def assemble_result(headers:, missing_required:, header_issues:, row_errors:, csv_data:, file_validator:, collections:, works:, file_sets:) # rubocop:disable Metrics/ParameterLists
+        row_error_entries   = row_errors.select { |e| e[:severity] == 'error' }
+        row_warning_entries = row_errors.select { |e| e[:severity] == 'warning' }
         has_errors   = missing_required.any? || headers.blank? || csv_data.empty? ||
-                       file_validator.missing_files.any? || row_errors.any?
+                       file_validator.missing_files.any? || row_error_entries.any?
         has_warnings = header_issues[:unrecognized].any? || header_issues[:empty_columns].any? ||
-                       file_validator.possible_missing_files?
+                       file_validator.possible_missing_files? || row_warning_entries.any?
 
         {
           headers: headers,
@@ -135,10 +137,6 @@ module Bulkrax
       end
 
       # Builds the find_record lambda used by row validators and hierarchy extraction.
-      # Builds the find_record lambda used by row validators and hierarchy extraction.
-      # Reads the full (unfiltered) field mappings directly since MappingManager strips
-      # entries with "generated"=>true (e.g. bulkrax_identifier), which is typically the
-      # entry flagged with source_identifier:true and carries the correct search_field.
       def build_find_record
         all_mappings = Bulkrax.field_mappings['Bulkrax::CsvParser'] || {}
         work_identifier = all_mappings.find { |_k, v| v['source_identifier'] == true }&.first || 'source'

--- a/app/services/bulkrax/stepper_response_formatter.rb
+++ b/app/services/bulkrax/stepper_response_formatter.rb
@@ -121,7 +121,8 @@ module Bulkrax
       issues << missing_required_issue if @data[:missingRequired]&.any?
       issues << unrecognized_fields_issue if @data[:unrecognized]&.any? || @data[:emptyColumns]&.any?
       issues << file_references_issue if @data[:fileReferences]&.positive?
-      issues << row_errors_issue if @data[:rowErrors]&.any?
+      issues << row_errors_issue if @data[:rowErrors]&.any? { |e| e[:severity] == 'error' }
+      issues << row_warnings_issue if @data[:rowErrors]&.any? { |e| e[:severity] == 'warning' }
 
       {
         validationStatus: validation_status,
@@ -279,20 +280,33 @@ module Bulkrax
     end
 
     def row_errors_issue
-      filtered = filtered_row_errors
-      return nil if filtered.empty?
-
-      severity = filtered.any? { |e| e[:severity] == 'error' } ? 'error' : 'warning'
-      icon = severity == 'error' ? 'fa-times-circle' : 'fa-exclamation-triangle'
+      entries = filtered_row_errors.select { |e| e[:severity] == 'error' }
+      return nil if entries.empty?
 
       {
         type: 'row_level_errors',
-        severity: severity,
-        icon: icon,
-        title: I18n.t('bulkrax.importer.guided_import.stepper_response_formatter.row_errors_issue.title'),
-        count: filtered.length,
+        severity: 'error',
+        icon: 'fa-times-circle',
+        title: I18n.t('bulkrax.importer.guided_import.stepper_response_formatter.row_errors_issue.title_errors'),
+        count: entries.length,
         description: I18n.t('bulkrax.importer.guided_import.stepper_response_formatter.row_errors_issue.description'),
-        items: row_error_items(filtered),
+        items: row_error_items(entries),
+        defaultOpen: false
+      }
+    end
+
+    def row_warnings_issue
+      entries = filtered_row_errors.select { |e| e[:severity] == 'warning' }
+      return nil if entries.empty?
+
+      {
+        type: 'row_level_warnings',
+        severity: 'warning',
+        icon: 'fa-exclamation-triangle',
+        title: I18n.t('bulkrax.importer.guided_import.stepper_response_formatter.row_errors_issue.title_warnings'),
+        count: entries.length,
+        description: I18n.t('bulkrax.importer.guided_import.stepper_response_formatter.row_errors_issue.description'),
+        items: row_error_items(entries),
         defaultOpen: false
       }
     end

--- a/app/validators/bulkrax/csv_row/duplicate_identifier.rb
+++ b/app/validators/bulkrax/csv_row/duplicate_identifier.rb
@@ -14,40 +14,50 @@ module Bulkrax
         first_row = context[:seen_ids][source_id]
 
         if first_row
-          context[:errors] << {
-            row: row_index,
-            source_identifier: source_id,
-            severity: 'error',
-            category: 'duplicate_source_identifier',
-            column: source_id_label,
-            value: source_id,
-            message: I18n.t('bulkrax.importer.guided_import.validation.duplicate_identifier_validator.errors.message',
-                            value: source_id,
-                            field: source_id_label,
-                            original_row: first_row),
-            suggestion: I18n.t('bulkrax.importer.guided_import.validation.duplicate_identifier_validator.errors.suggestion',
-                               field: source_id_label)
-          }
+          add_duplicate_error(context, row_index, source_id, source_id_label, first_row)
         else
           context[:seen_ids][source_id] = row_index
-          find_record = context[:find_record_by_source_identifier]
-          if find_record&.call(source_id)
-            context[:errors] << {
-              row: row_index,
-              source_identifier: source_id,
-              severity: 'warning',
-              category: 'existing_source_identifier',
-              column: source_id_label,
-              value: source_id,
-              message: I18n.t('bulkrax.importer.guided_import.validation.existing_source_identifier_validator.warnings.message',
-                              value: source_id,
-                              field: source_id_label),
-              suggestion: I18n.t('bulkrax.importer.guided_import.validation.existing_source_identifier_validator.warnings.suggestion',
-                                 field: source_id_label)
-            }
-          end
+          add_existing_warning(context, row_index, source_id, source_id_label)
         end
       end
+
+      def self.add_duplicate_error(context, row_index, source_id, source_id_label, first_row)
+        context[:errors] << {
+          row: row_index,
+          source_identifier: source_id,
+          severity: 'error',
+          category: 'duplicate_source_identifier',
+          column: source_id_label,
+          value: source_id,
+          message: I18n.t('bulkrax.importer.guided_import.validation.duplicate_identifier_validator.errors.message',
+                          value: source_id,
+                          field: source_id_label,
+                          original_row: first_row),
+          suggestion: I18n.t('bulkrax.importer.guided_import.validation.duplicate_identifier_validator.errors.suggestion',
+                             field: source_id_label)
+        }
+      end
+      private_class_method :add_duplicate_error
+
+      def self.add_existing_warning(context, row_index, source_id, source_id_label)
+        find_record = context[:find_record_by_source_identifier]
+        return unless find_record&.call(source_id)
+
+        context[:errors] << {
+          row: row_index,
+          source_identifier: source_id,
+          severity: 'warning',
+          category: 'existing_source_identifier',
+          column: source_id_label,
+          value: source_id,
+          message: I18n.t('bulkrax.importer.guided_import.validation.existing_source_identifier_validator.warnings.message',
+                          value: source_id,
+                          field: source_id_label),
+          suggestion: I18n.t('bulkrax.importer.guided_import.validation.existing_source_identifier_validator.warnings.suggestion',
+                             field: source_id_label)
+        }
+      end
+      private_class_method :add_existing_warning
     end
   end
 end

--- a/app/validators/bulkrax/csv_row/duplicate_identifier.rb
+++ b/app/validators/bulkrax/csv_row/duplicate_identifier.rb
@@ -30,6 +30,22 @@ module Bulkrax
           }
         else
           context[:seen_ids][source_id] = row_index
+          find_record = context[:find_record_by_source_identifier]
+          if find_record&.call(source_id)
+            context[:errors] << {
+              row: row_index,
+              source_identifier: source_id,
+              severity: 'warning',
+              category: 'existing_source_identifier',
+              column: source_id_label,
+              value: source_id,
+              message: I18n.t('bulkrax.importer.guided_import.validation.existing_source_identifier_validator.warnings.message',
+                              value: source_id,
+                              field: source_id_label),
+              suggestion: I18n.t('bulkrax.importer.guided_import.validation.existing_source_identifier_validator.warnings.suggestion',
+                                 field: source_id_label)
+            }
+          end
         end
       end
     end

--- a/app/validators/bulkrax/csv_row/missing_source_identifier.rb
+++ b/app/validators/bulkrax/csv_row/missing_source_identifier.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  module CsvRow
+    ##
+    # Validates that each row has a value for source_identifier unless
+    # fill_in_blank_source_identifiers is configured (in which case Bulkrax
+    # will generate one automatically).
+    module MissingSourceIdentifier
+      def self.call(record, row_index, context)
+        return if Bulkrax.fill_in_blank_source_identifiers.present?
+        return if record[:source_identifier].present?
+
+        source_id_label = context[:source_identifier] || 'source_identifier'
+
+        context[:errors] << {
+          row: row_index,
+          source_identifier: nil,
+          severity: 'error',
+          category: 'missing_source_identifier',
+          column: source_id_label,
+          value: nil,
+          message: I18n.t('bulkrax.importer.guided_import.validation.missing_source_identifier_validator.errors.message',
+                          field: source_id_label),
+          suggestion: I18n.t('bulkrax.importer.guided_import.validation.missing_source_identifier_validator.errors.suggestion',
+                             field: source_id_label)
+        }
+      end
+    end
+  end
+end

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -277,7 +277,8 @@ de:
           row_errors_issue:
             description: "Die folgenden Probleme bestehen bei den Daten in Ihrer CSV-Datei:"
             row_label: "Zeile %{row} · %{column}"
-            title: Zeilenvalidierungsfehler
+            title_errors: Zeilenvalidierungsfehler
+            title_warnings: Zeilenvalidierungswarnungen
         success:
           message: Ihr Importvorgang wird derzeit im Hintergrund verarbeitet. Sie werden benachrichtigt, sobald er abgeschlossen ist.
           start_another: Einen weiteren Import starten

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -295,6 +295,10 @@ de:
             errors:
               message: "Doppelter %{field} '%{value}' — erscheint auch in Zeile %{original_row}."
               suggestion: "Jeder %{field} muss innerhalb der CSV-Datei eindeutig sein."
+          existing_source_identifier_validator:
+            warnings:
+              message: "'%{value}' entspricht einem vorhandenen Repository-Datensatz — diese Zeile wird ihn aktualisieren."
+              suggestion: "Falls Sie keinen bestehenden Datensatz aktualisieren wollten, ändern Sie den Wert für %{field}."
           failed: Validierung fehlgeschlagen
           file_path_not_exist: Der Dateipfad existiert nicht.
           file_references_title: Dateiverweise
@@ -302,6 +306,10 @@ de:
           files_missing_from_zip: "%{count} %{files_word} werden in Ihrer CSV-Datei referenziert, fehlen aber in der ZIP-Datei:"
           files_referenced: Die in der CSV-Datei referenzierten %{count}-Dateien wurden beim Import nicht gefunden.
           missing_from_zip: fehlt in der Postleitzahl
+          missing_source_identifier_validator:
+            errors:
+              message: "In der Zeile fehlt ein Wert für '%{field}'."
+              suggestion: "Fügen Sie dieser Zeile einen '%{field}'-Wert hinzu oder konfigurieren Sie Bulkrax, um Quellkennungen automatisch zu generieren."
           missing_required_desc: 'Folgende erforderliche Spalten müssen Ihrer CSV-Datei hinzugefügt werden:'
           missing_required_hint: Fügen Sie diese Spalte zu Ihrer CSV-Datei hinzu.
           missing_required_title: Fehlende Pflichtfelder

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -322,6 +322,10 @@ en:
             errors:
               message: "Duplicate %{field} '%{value}' — also appears in row %{original_row}."
               suggestion: "Each %{field} must be unique within the CSV."
+          existing_source_identifier_validator:
+            warnings:
+              message: "'%{value}' matches an existing repository record — this row will update it."
+              suggestion: "If you did not intend to update an existing record, change the %{field} value."
           failed: Validation Failed
           file_path_not_exist: File path does not exist
           file_references_title: File References
@@ -329,6 +333,10 @@ en:
           files_missing_from_zip: "%{count} %{files_word} referenced in your CSV but missing from the ZIP:"
           files_referenced: "%{count} files referenced in CSV not found in import."
           missing_from_zip: missing from ZIP
+          missing_source_identifier_validator:
+            errors:
+              message: "Row is missing a value for '%{field}'."
+              suggestion: "Add a '%{field}' value to this row, or configure Bulkrax to generate source identifiers automatically."
           missing_required_desc: 'These required columns must be added to your CSV:'
           missing_required_hint: add this column to your CSV
           missing_required_title: Missing Required Fields

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -304,7 +304,8 @@ en:
           row_errors_issue:
             description: "The following issues exist with data in your CSV:"
             row_label: "Row %{row} · %{column}"
-            title: Row Validation Errors
+            title_errors: Row Validation Errors
+            title_warnings: Row Validation Warnings
         success:
           message: Your import is now processing in the background. You'll be notified when it's complete.
           start_another: Start Another Import

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -277,7 +277,8 @@ es:
           row_errors_issue:
             description: "Existen los siguientes problemas con los datos en su CSV:"
             row_label: "Fila %{row} · %{column}"
-            title: Errores de validación de filas
+            title_errors: Errores de validación de filas
+            title_warnings: Advertencias de validación de filas
         success:
           message: Tu importación se está procesando en segundo plano. Recibirás una notificación cuando finalice.
           start_another: Iniciar otra importación

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -295,6 +295,10 @@ es:
             errors:
               message: "%{field} duplicado '%{value}': también aparece en la fila %{original_row}."
               suggestion: "Cada %{field} debe ser único dentro del CSV."
+          existing_source_identifier_validator:
+            warnings:
+              message: "'%{value}' coincide con un registro existente en el repositorio — esta fila lo actualizará."
+              suggestion: "Si no tenía intención de actualizar un registro existente, cambie el valor de %{field}."
           failed: Validación fallida
           file_path_not_exist: La ruta del archivo no existe
           file_references_title: Referencias de archivos
@@ -302,6 +306,10 @@ es:
           files_missing_from_zip: "%{count} %{files_word} referenciado en su CSV pero falta en el ZIP:"
           files_referenced: Los archivos %{count} referenciados en CSV no se encontraron en la importación.
           missing_from_zip: Falta en el código postal
+          missing_source_identifier_validator:
+            errors:
+              message: "Falta un valor para '%{field}' en esta fila."
+              suggestion: "Añada un valor de '%{field}' a esta fila o configure Bulkrax para generar identificadores de origen automáticamente."
           missing_required_desc: 'Estas columnas obligatorias deben agregarse a su CSV:'
           missing_required_hint: Añade esta columna a tu CSV
           missing_required_title: Campos obligatorios faltantes

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -295,6 +295,10 @@ fr:
             errors:
               message: "%{field} en double « %{value} » — apparaît également à la ligne %{original_row}."
               suggestion: "Chaque %{field} doit être unique dans le CSV."
+          existing_source_identifier_validator:
+            warnings:
+              message: "« %{value} » correspond à un enregistrement existant dans le dépôt — cette ligne le mettra à jour."
+              suggestion: "Si vous ne souhaitiez pas mettre à jour un enregistrement existant, modifiez la valeur de %{field}."
           failed: Échec de la validation
           file_path_not_exist: Le chemin d'accès au fichier n'existe pas.
           file_references_title: Références de fichiers
@@ -302,6 +306,10 @@ fr:
           files_missing_from_zip: "%{count} %{files_word} référencé dans votre fichier CSV mais absent du fichier ZIP :"
           files_referenced: "%{count} fichiers référencés dans le fichier CSV sont introuvables lors de l'importation."
           missing_from_zip: manquant dans le fichier ZIP
+          missing_source_identifier_validator:
+            errors:
+              message: "Il manque une valeur pour '%{field}' dans cette ligne."
+              suggestion: "Ajoutez une valeur '%{field}' à cette ligne ou configurez Bulkrax pour générer automatiquement des identifiants source."
           missing_required_desc: 'Les colonnes suivantes doivent être ajoutées à votre fichier CSV :'
           missing_required_hint: Ajoutez cette colonne à votre fichier CSV.
           missing_required_title: Champs obligatoires manquants

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -277,7 +277,8 @@ fr:
           row_errors_issue:
             description: "Les problèmes suivants existent avec les données de votre CSV :"
             row_label: "Ligne %{row} · %{column}"
-            title: Erreurs de validation de ligne
+            title_errors: Erreurs de validation de ligne
+            title_warnings: Avertissements de validation de ligne
         success:
           message: Votre importation est en cours de traitement en arrière-plan. Vous serez averti(e) lorsqu'elle sera terminée.
           start_another: Lancer une autre importation

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -277,7 +277,8 @@ it:
           row_errors_issue:
             description: "Sussistono i seguenti problemi con i dati nel file CSV:"
             row_label: "Riga %{row} · %{column}"
-            title: Errori di validazione delle righe
+            title_errors: Errori di validazione delle righe
+            title_warnings: Avvisi di validazione delle righe
         success:
           message: L'importazione è in corso di elaborazione in background. Riceverai una notifica al termine dell'operazione.
           start_another: Avvia un'altra importazione

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -295,6 +295,10 @@ it:
             errors:
               message: "%{field} duplicato '%{value}' — appare anche nella riga %{original_row}."
               suggestion: "Ogni %{field} deve essere univoco all'interno del CSV."
+          existing_source_identifier_validator:
+            warnings:
+              message: "'%{value}' corrisponde a un record esistente nel repository — questa riga lo aggiornerà."
+              suggestion: "Se non intendevi aggiornare un record esistente, modifica il valore di %{field}."
           failed: Convalida fallita
           file_path_not_exist: Il percorso del file non esiste
           file_references_title: Riferimenti ai file
@@ -302,6 +306,10 @@ it:
           files_missing_from_zip: "%{count} %{files_word} a cui si fa riferimento nel CSV ma che non è presente nel file ZIP:"
           files_referenced: "%{count} file referenziati nel CSV non trovati durante l'importazione."
           missing_from_zip: mancante dal codice postale
+          missing_source_identifier_validator:
+            errors:
+              message: "Nella riga manca un valore per '%{field}'."
+              suggestion: "Aggiungi un valore '%{field}' a questa riga o configura Bulkrax per generare automaticamente gli identificatori sorgente."
           missing_required_desc: 'Queste colonne obbligatorie devono essere aggiunte al tuo CSV:'
           missing_required_hint: aggiungi questa colonna al tuo CSV
           missing_required_title: Campi obbligatori mancanti

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -295,6 +295,10 @@ pt-BR:
             errors:
               message: "%{field} duplicado '%{value}' — também aparece na linha %{original_row}."
               suggestion: "Cada %{field} deve ser exclusivo no CSV."
+          existing_source_identifier_validator:
+            warnings:
+              message: "'%{value}' corresponde a um registro existente no repositório — esta linha irá atualizá-lo."
+              suggestion: "Se você não pretendia atualizar um registro existente, altere o valor de %{field}."
           failed: Validação falhou
           file_path_not_exist: O caminho do arquivo não existe.
           file_references_title: Referências de arquivos
@@ -302,6 +306,10 @@ pt-BR:
           files_missing_from_zip: "%{count} %{files_word} referenciado no seu CSV, mas ausente no ZIP:"
           files_referenced: "%{count} arquivos referenciados no CSV não foram encontrados na importação."
           missing_from_zip: ausente do CEP
+          missing_source_identifier_validator:
+            errors:
+              message: "A linha não tem um valor para '%{field}'."
+              suggestion: "Adicione um valor '%{field}' a esta linha ou configure o Bulkrax para gerar identificadores de origem automaticamente."
           missing_required_desc: 'Estas colunas obrigatórias devem ser adicionadas ao seu arquivo CSV:'
           missing_required_hint: Adicione esta coluna ao seu arquivo CSV.
           missing_required_title: Campos obrigatórios ausentes

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -277,7 +277,8 @@ pt-BR:
           row_errors_issue:
             description: "Existem os seguintes problemas com os dados no seu CSV:"
             row_label: "Linha %{row} · %{column}"
-            title: Erros de validação de linha
+            title_errors: Erros de validação de linha
+            title_warnings: Avisos de validação de linha
         success:
           message: Sua importação está sendo processada em segundo plano. Você será notificado quando ela for concluída.
           start_another: Iniciar outra importação

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -294,6 +294,10 @@ zh:
             errors:
               message: "重复的 %{field} '%{value}' — 也出现在第 %{original_row} 行。"
               suggestion: "每个 %{field} 在 CSV 中必须是唯一的。"
+          existing_source_identifier_validator:
+            warnings:
+              message: "'%{value}' 与仓库中的现有记录匹配 — 此行将更新该记录。"
+              suggestion: "如果您不打算更新现有记录，请更改 %{field} 的值。"
           failed: 验证失败
           file_path_not_exist: 文件路径不存在
           file_references_title: 文件引用
@@ -301,6 +305,10 @@ zh:
           files_missing_from_zip: CSV 文件中引用了 %{count} %{files_word}，但 ZIP 文件中缺少该 %{files_word}：
           files_referenced: 导入时未找到 CSV 文件中引用的 %{count} 文件。
           missing_from_zip: ZIP 文件中缺少
+          missing_source_identifier_validator:
+            errors:
+              message: "该行缺少 '%{field}' 的值。"
+              suggestion: "为此行添加 '%{field}' 值，或配置 Bulkrax 以自动生成源标识符。"
           missing_required_desc: 您必须在 CSV 文件中添加以下必填列：
           missing_required_hint: 将此列添加到您的 CSV 文件中
           missing_required_title: 缺少必填字段

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -276,7 +276,8 @@ zh:
           row_errors_issue:
             description: "您的 CSV 数据中存在以下问题："
             row_label: "第 %{row} 行 · %{column}"
-            title: 行校验错误
+            title_errors: 行校验错误
+            title_warnings: 行校验警告
         success:
           message: 您的导入操作正在后台处理中。完成后您将收到通知。
           start_another: 开始另一次导入

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -181,6 +181,7 @@ module Bulkrax
     #   Defaults to the four built-in CsvRow:: validators.
     def csv_row_validators
       @csv_row_validators ||= [
+        Bulkrax::CsvRow::MissingSourceIdentifier,
         Bulkrax::CsvRow::DuplicateIdentifier,
         Bulkrax::CsvRow::ParentReference,
         Bulkrax::CsvRow::ChildReference,

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -133,7 +133,11 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
 
     context 'when an exception is raised during lookup' do
       before do
-        allow(Hyrax.query_service).to receive(:find_by).and_raise(StandardError, 'DB unavailable')
+        allow(Bulkrax).to receive(:collection_model_class).and_return(Collection)
+        allow(Bulkrax).to receive(:curation_concerns).and_return([Work])
+        # Simulate an unexpected error in search_by_property that bypasses find_or_nil's rescue
+        allow(Bulkrax::ValkyrieObjectFactory).to receive(:search_by_property).and_raise(StandardError, 'Solr unavailable')
+        allow(Hyrax.query_service).to receive(:find_by).and_raise(Hyrax::ObjectNotFoundError)
       end
 
       it 'returns false instead of propagating the error' do

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -32,15 +32,19 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       end
     end
 
-    context 'when a matching Bulkrax::Entry exists in the database' do
+    context 'when a matching Bulkrax::Entry exists in the database but no repository object does' do
       let!(:importer) { FactoryBot.create(:bulkrax_importer) }
       let!(:entry)    { FactoryBot.create(:bulkrax_csv_entry, identifier: 'entry_id_001', importerexporter: importer) }
 
-      it 'returns true without querying the repository' do
-        # ValkyrieObjectFactory.find delegates to Hyrax.query_service.find_by;
-        # the Entry short-circuit means it should never be reached.
-        expect(Hyrax.query_service).not_to receive(:find_by)
-        expect(find('entry_id_001')).to be true
+      before do
+        allow(Hyrax.query_service).to receive(:find_by).and_raise(Hyrax::ObjectNotFoundError)
+        allow(Bulkrax).to receive(:collection_model_class).and_return(Collection)
+        allow(Bulkrax).to receive(:curation_concerns).and_return([Work])
+        allow(Bulkrax::ValkyrieObjectFactory).to receive(:search_by_property).and_return(nil)
+      end
+
+      it 'returns false — a Bulkrax Entry alone does not confirm the object exists in the repo' do
+        expect(find('entry_id_001')).to be false
       end
     end
 
@@ -129,7 +133,7 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
 
     context 'when an exception is raised during lookup' do
       before do
-        allow(Bulkrax::Entry).to receive(:exists?).and_raise(StandardError, 'DB unavailable')
+        allow(Hyrax.query_service).to receive(:find_by).and_raise(StandardError, 'DB unavailable')
       end
 
       it 'returns false instead of propagating the error' do
@@ -277,9 +281,6 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
   end
 
   describe '#build_find_record' do
-    let(:mapping_manager) { instance_double(Bulkrax::CsvTemplate::MappingManager) }
-    let(:mappings)        { {} }
-
     before do
       allow(Hyrax.query_service).to receive(:find_by).and_raise(Hyrax::ObjectNotFoundError)
       allow(Bulkrax).to receive(:collection_model_class).and_return(Collection)
@@ -287,20 +288,17 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       allow(Bulkrax::ValkyrieObjectFactory).to receive(:search_by_property).and_return(nil)
     end
 
-    context 'with default source_identifier mapping' do
+    context 'when no source_identifier entry exists in the raw mappings' do
       before do
-        allow(mapping_manager).to receive(:resolve_column_name)
-          .with(flag: 'source_identifier', default: 'source')
-          .and_return(['source'])
+        allow(Bulkrax).to receive(:field_mappings).and_return({ 'Bulkrax::CsvParser' => {} })
       end
 
       it 'returns a callable lambda' do
-        lam = host.build_find_record(mapping_manager, mappings)
-        expect(lam).to respond_to(:call)
+        expect(host.build_find_record).to respond_to(:call)
       end
 
-      it 'defaults the search field to <identifier>_sim when no search_field mapping is present' do
-        lam = host.build_find_record(mapping_manager, mappings)
+      it 'falls back to "source" with "source_sim" search field' do
+        lam = host.build_find_record
         expect(Bulkrax::ValkyrieObjectFactory).to receive(:search_by_property).with(
           hash_including(search_field: 'source_sim', name_field: 'source')
         ).and_return(nil)
@@ -308,17 +306,17 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       end
     end
 
-    context 'when the mapping provides a custom search_field' do
-      let(:mappings) { { 'local_id' => { 'search_field' => 'local_id_tesim' } } }
-
+    context 'when a non-generated source_identifier mapping exists' do
       before do
-        allow(mapping_manager).to receive(:resolve_column_name)
-          .with(flag: 'source_identifier', default: 'source')
-          .and_return(['local_id'])
+        allow(Bulkrax).to receive(:field_mappings).and_return({
+                                                                'Bulkrax::CsvParser' => {
+                                                                  'local_id' => { 'from' => ['source_identifier'], 'source_identifier' => true, 'search_field' => 'local_id_tesim' }
+                                                                }
+                                                              })
       end
 
-      it 'uses the mapped search_field instead of the default _sim suffix' do
-        lam = host.build_find_record(mapping_manager, mappings)
+      it 'uses the mapped search_field' do
+        lam = host.build_find_record
         expect(Bulkrax::ValkyrieObjectFactory).to receive(:search_by_property).with(
           hash_including(search_field: 'local_id_tesim', name_field: 'local_id')
         ).and_return(nil)
@@ -326,19 +324,24 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       end
     end
 
-    context 'when resolve_column_name returns nothing' do
+    context 'when the source_identifier mapping is a generated entry (e.g. bulkrax_identifier)' do
       before do
-        allow(mapping_manager).to receive(:resolve_column_name)
-          .with(flag: 'source_identifier', default: 'source')
-          .and_return([])
+        allow(Bulkrax).to receive(:field_mappings).and_return({
+                                                                'Bulkrax::CsvParser' => {
+                                                                  'bulkrax_identifier' => {
+                                                                    'from' => ['source_identifier'], 'source_identifier' => true,
+                                                                    'generated' => true, 'search_field' => 'bulkrax_identifier_tesim'
+                                                                  }
+                                                                }
+                                                              })
       end
 
-      it 'falls back to "source" as the work_identifier' do
-        lam = host.build_find_record(mapping_manager, mappings)
+      it 'resolves the identifier and search_field despite generated:true' do
+        lam = host.build_find_record
         expect(Bulkrax::ValkyrieObjectFactory).to receive(:search_by_property).with(
-          hash_including(search_field: 'source_sim', name_field: 'source')
+          hash_including(search_field: 'bulkrax_identifier_tesim', name_field: 'bulkrax_identifier')
         ).and_return(nil)
-        lam.call('anything')
+        lam.call('star_wars_movie_collection')
       end
     end
   end

--- a/spec/services/bulkrax/stepper_response_formatter_spec.rb
+++ b/spec/services/bulkrax/stepper_response_formatter_spec.rb
@@ -466,12 +466,12 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
         expect(issue[:items]).to be_empty
       end
 
-      it 'generates row errors issue with error severity when any row error is an error' do
+      it 'generates separate error and warning boxes when both are present' do
         data = {
           headers: ['source_identifier', 'title', 'creator', 'model'],
           rowCount: 5,
           isValid: false,
-          hasWarnings: false,
+          hasWarnings: true,
           missingRequired: [],
           unrecognized: {},
           fileReferences: 0,
@@ -479,26 +479,31 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
             { row: 1, source_identifier: 'ABC', severity: 'error', category: 'missing_required_value',
               column: 'creator', value: nil, message: "Field 'creator' is required but is empty for this row.",
               suggestion: "Add a value for 'creator' in row 1." },
-            { row: 2, source_identifier: 'DEF', severity: 'warning', category: 'missing_required_value',
-              column: 'title', value: nil, message: "Field 'title' is recommended.",
-              suggestion: "Add a value for 'title' in row 2." }
+            { row: 2, source_identifier: 'DEF', severity: 'warning', category: 'existing_source_identifier',
+              column: 'source_identifier', value: 'DEF', message: "'DEF' matches an existing repository record.",
+              suggestion: "If you did not intend to update an existing record, change the source_identifier value." }
           ]
         }
 
         result = described_class.new(data).format
-        issue = result[:messages][:issues].find { |i| i[:type] == 'row_level_errors' }
+        error_issue   = result[:messages][:issues].find { |i| i[:type] == 'row_level_errors' }
+        warning_issue = result[:messages][:issues].find { |i| i[:type] == 'row_level_warnings' }
 
-        expect(issue[:severity]).to eq('error')
-        expect(issue[:icon]).to eq('fa-times-circle')
-        expect(issue[:title]).to eq('Row Validation Errors')
-        expect(issue[:count]).to eq(2)
-        expect(issue[:items]).to contain_exactly(
-          { field: 'Row 1 · creator', message: "Field 'creator' is required but is empty for this row. Add a value for 'creator' in row 1." },
-          { field: 'Row 2 · title', message: "Field 'title' is recommended. Add a value for 'title' in row 2." }
+        expect(error_issue[:severity]).to eq('error')
+        expect(error_issue[:icon]).to eq('fa-times-circle')
+        expect(error_issue[:title]).to eq('Row Validation Errors')
+        expect(error_issue[:count]).to eq(1)
+        expect(error_issue[:items]).to contain_exactly(
+          { field: 'Row 1 · creator', message: "Field 'creator' is required but is empty for this row. Add a value for 'creator' in row 1." }
         )
+
+        expect(warning_issue[:severity]).to eq('warning')
+        expect(warning_issue[:icon]).to eq('fa-exclamation-triangle')
+        expect(warning_issue[:title]).to eq('Row Validation Warnings')
+        expect(warning_issue[:count]).to eq(1)
       end
 
-      it 'generates row errors issue with warning severity when all row errors are warnings' do
+      it 'generates only a warnings box when all row entries are warnings' do
         data = {
           headers: ['source_identifier', 'title', 'creator', 'model'],
           rowCount: 5,
@@ -508,18 +513,21 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
           unrecognized: {},
           fileReferences: 0,
           rowErrors: [
-            { row: 1, source_identifier: 'ABC', severity: 'warning', category: 'missing_recommended_value',
-              column: 'creator', value: nil, message: "Field 'creator' is recommended.",
-              suggestion: "Add a value for 'creator' in row 1." }
+            { row: 1, source_identifier: 'ABC', severity: 'warning', category: 'existing_source_identifier',
+              column: 'source_identifier', value: 'ABC', message: "'ABC' matches an existing repository record.",
+              suggestion: "If you did not intend to update an existing record, change the source_identifier value." }
           ]
         }
 
         result = described_class.new(data).format
-        issue = result[:messages][:issues].find { |i| i[:type] == 'row_level_errors' }
+        error_issue   = result[:messages][:issues].find { |i| i[:type] == 'row_level_errors' }
+        warning_issue = result[:messages][:issues].find { |i| i[:type] == 'row_level_warnings' }
 
-        expect(issue[:severity]).to eq('warning')
-        expect(issue[:icon]).to eq('fa-exclamation-triangle')
-        expect(issue[:count]).to eq(1)
+        expect(error_issue).to be_nil
+        expect(warning_issue[:severity]).to eq('warning')
+        expect(warning_issue[:icon]).to eq('fa-exclamation-triangle')
+        expect(warning_issue[:title]).to eq('Row Validation Warnings')
+        expect(warning_issue[:count]).to eq(1)
       end
 
       it 'suppresses row errors for columns already flagged in missingRequired' do
@@ -550,7 +558,7 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
         )
       end
 
-      it 'omits row errors issue entirely when all row errors are suppressed by missingRequired' do
+      it 'omits row issues entirely when all row entries are suppressed by missingRequired' do
         data = {
           headers: ['source_identifier', 'title', 'model'],
           rowCount: 3,
@@ -567,9 +575,9 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
         }
 
         result = described_class.new(data).format
-        issue = result[:messages][:issues].find { |i| i[:type] == 'row_level_errors' }
 
-        expect(issue).to be_nil
+        expect(result[:messages][:issues].find { |i| i[:type] == 'row_level_errors' }).to be_nil
+        expect(result[:messages][:issues].find { |i| i[:type] == 'row_level_warnings' }).to be_nil
       end
 
       it 'does not generate file references issue when no files are referenced' do

--- a/spec/support/model_stubbing_helpers.rb
+++ b/spec/support/model_stubbing_helpers.rb
@@ -109,6 +109,10 @@ module ModelStubbingHelpers
     stub_const('Collection', collection_model)
     stub_const('FileSet', fileset_model)
 
+    # Redirect object_factory to the stubbed ValkyrieObjectFactory so that
+    # find_record_by_source_identifier does not hit the real ObjectFactory.
+    allow(Bulkrax).to receive(:object_factory).and_return(Bulkrax::ValkyrieObjectFactory)
+
     # Stub Hyrax configuration
     allow(Hyrax).to receive(:config).and_return(double(curation_concerns: [GenericWork]))
     allow(Bulkrax).to receive(:collection_model_class).and_return(Collection)

--- a/spec/support/model_stubbing_helpers.rb
+++ b/spec/support/model_stubbing_helpers.rb
@@ -37,6 +37,14 @@ module ModelStubbingHelpers
         # Just return the properties as-is
         klass.properties.keys.map(&:to_s)
       end
+
+      def self.find_or_nil(_id)
+        nil
+      end
+
+      def self.search_by_property(**_kwargs)
+        nil
+      end
     end)
 
     # Create GenericWork model (commonly used in examples)

--- a/spec/validators/bulkrax/csv_row/duplicate_identifier_spec.rb
+++ b/spec/validators/bulkrax/csv_row/duplicate_identifier_spec.rb
@@ -3,19 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe Bulkrax::CsvRow::DuplicateIdentifier do
-  def make_context
-    { errors: [], warnings: [], seen_ids: {}, source_identifier: 'source_identifier' }
+  def make_context(find_record: nil)
+    { errors: [], warnings: [], seen_ids: {}, source_identifier: 'source_identifier',
+      find_record_by_source_identifier: find_record }
   end
 
   def make_record(source_id)
     { source_identifier: source_id, model: 'GenericWork', parent: nil, children: nil, file: nil, raw_row: {} }
   end
 
-  it 'adds nothing for a unique identifier' do
-    context = make_context
+  it 'adds nothing for a unique identifier that does not exist in the repo' do
+    context = make_context(find_record: ->(_id) { false })
     described_class.call(make_record('work1'), 2, context)
     expect(context[:errors]).to be_empty
     expect(context[:seen_ids]).to eq('work1' => 2)
+  end
+
+  it 'adds a warning for a unique identifier that already exists in the repo' do
+    context = make_context(find_record: ->(_id) { true })
+    described_class.call(make_record('work1'), 2, context)
+    expect(context[:errors].length).to eq(1)
+    warning = context[:errors].first
+    expect(warning[:severity]).to eq('warning')
+    expect(warning[:category]).to eq('existing_source_identifier')
+    expect(warning[:row]).to eq(2)
+    expect(warning[:value]).to eq('work1')
+  end
+
+  it 'adds no warning when find_record is not provided' do
+    context = make_context
+    described_class.call(make_record('work1'), 2, context)
+    expect(context[:errors]).to be_empty
   end
 
   it 'records an error for a duplicate identifier' do

--- a/spec/validators/bulkrax/csv_row/missing_source_identifier_spec.rb
+++ b/spec/validators/bulkrax/csv_row/missing_source_identifier_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::CsvRow::MissingSourceIdentifier do
+  def make_context
+    { errors: [], warnings: [], source_identifier: 'source_identifier' }
+  end
+
+  def make_record(source_id)
+    { source_identifier: source_id, model: 'GenericWork', parent: nil, children: nil, file: nil, raw_row: {} }
+  end
+
+  context 'when fill_in_blank_source_identifiers is not configured' do
+    before { allow(Bulkrax).to receive(:fill_in_blank_source_identifiers).and_return(nil) }
+
+    it 'adds no error when source_identifier is present' do
+      context = make_context
+      described_class.call(make_record('work1'), 2, context)
+      expect(context[:errors]).to be_empty
+    end
+
+    it 'adds an error when source_identifier is blank' do
+      context = make_context
+      described_class.call(make_record(nil), 2, context)
+      expect(context[:errors].length).to eq(1)
+      error = context[:errors].first
+      expect(error[:category]).to eq('missing_source_identifier')
+      expect(error[:row]).to eq(2)
+      expect(error[:column]).to eq('source_identifier')
+    end
+
+    it 'adds an error when source_identifier is an empty string' do
+      context = make_context
+      described_class.call(make_record(''), 2, context)
+      expect(context[:errors].length).to eq(1)
+    end
+
+    it 'uses the source_identifier label from context' do
+      context = make_context.merge(source_identifier: 'source_id')
+      described_class.call(make_record(nil), 2, context)
+      expect(context[:errors].first[:column]).to eq('source_id')
+    end
+  end
+
+  context 'when fill_in_blank_source_identifiers is configured' do
+    before do
+      allow(Bulkrax).to receive(:fill_in_blank_source_identifiers)
+        .and_return(->(_parser, _index) { SecureRandom.uuid })
+    end
+
+    it 'adds no error even when source_identifier is blank' do
+      context = make_context
+      described_class.call(make_record(nil), 2, context)
+      expect(context[:errors]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
# Validates source identifiers

- validate & report row validation warnings and errors separately
- correct method of finding in repository... finding in the entries table is not adequate to ensure the record exists, and finding in the repo by source identifier wasn't working correctly.

# Screenshot
<img width="904" height="304" alt="Screenshot 2026-04-03 at 2 11 28 PM" src="https://github.com/user-attachments/assets/9ff62f6b-8b35-469b-900c-01b467ed5ceb" />

<img width="1050" height="419" alt="Screenshot 2026-04-03 at 2 18 12 PM" src="https://github.com/user-attachments/assets/a21ef1df-daae-40db-8400-015cc6b1233b" />

# Exported as file

[row-errors-and-warnings_errors (1).csv](https://github.com/user-attachments/files/26468841/row-errors-and-warnings_errors.1.csv)
