### PR TITLE
Validate model column

### DIFF
--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -24,27 +24,16 @@ module Bulkrax
           raw_csv, headers, mapping_manager, mappings, source_id_key, csv_data, field_metadata, field_analyzer =
             parse_csv_inputs(csv_file, admin_set_id)
 
-          all_ids = csv_data.map { |r| r[:source_identifier] }.compact.to_set
-
+          all_ids          = csv_data.map { |r| r[:source_identifier] }.compact.to_set
           header_issues    = check_headers(headers, raw_csv, mapping_manager, mappings, field_metadata, field_analyzer)
           missing_required = header_issues[:missing_required]
-          find_record      = build_find_record
-          row_errors       = run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record)
-          file_validator   = CsvTemplate::FileValidator.new(csv_data, zip_file, admin_set_id)
-          collections, works, file_sets = extract_hierarchy_items(csv_data, all_ids, find_record, mappings)
-
-          append_missing_source_id!(missing_required, headers, source_id_key, csv_data.map { |r| r[:model] }.compact.uniq)
+          notices, row_errors, file_validator, collections, works, file_sets =
+            run_validations(csv_data, all_ids, headers, source_id_key, mappings, field_metadata, missing_required, zip_file, admin_set_id)
 
           result = assemble_result(
-            headers: headers,
-            missing_required: missing_required,
-            header_issues: header_issues,
-            row_errors: row_errors,
-            csv_data: csv_data,
-            file_validator: file_validator,
-            collections: collections,
-            works: works,
-            file_sets: file_sets
+            headers: headers, missing_required: missing_required, header_issues: header_issues,
+            row_errors: row_errors, csv_data: csv_data, file_validator: file_validator,
+            collections: collections, works: works, file_sets: file_sets, notices: notices
           )
           apply_rights_statement_validation_override!(result, missing_required)
           result[:raw_csv_data] = csv_data
@@ -52,6 +41,20 @@ module Bulkrax
         end
 
         private
+
+        # Builds notices, runs row validators, file validator, and hierarchy extraction.
+        # Returns [notices, row_errors, file_validator, collections, works, file_sets].
+        def run_validations(csv_data, all_ids, headers, source_id_key, mappings, field_metadata, missing_required, zip_file, admin_set_id) # rubocop:disable Metrics/ParameterLists
+          find_record = build_find_record
+          notices     = []
+          append_missing_source_id!(missing_required, headers, source_id_key, csv_data.map { |r| r[:model] }.compact.uniq)
+          append_missing_model_notice!(notices, headers, csv_data)
+
+          row_errors                       = run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record, notices)
+          file_validator                   = CsvTemplate::FileValidator.new(csv_data, zip_file, admin_set_id)
+          collections, works, file_sets    = extract_hierarchy_items(csv_data, all_ids, find_record, mappings)
+          [notices, row_errors, file_validator, collections, works, file_sets]
+        end
 
         # Reads the CSV, resolves mappings, parses rows, and builds field metadata.
         # Returns the values needed by all subsequent validation steps.
@@ -70,6 +73,7 @@ module Bulkrax
 
           csv_data       = parse_validation_rows(raw_csv, source_id_key, parent_key, children_key, file_key)
           all_models     = csv_data.map { |r| r[:model] }.compact.uniq
+          all_models    |= [Bulkrax.default_work_type] if Bulkrax.default_work_type.present?
           field_analyzer = CsvTemplate::FieldAnalyzer.new(mappings, admin_set_id)
           field_metadata = build_validation_field_metadata(all_models, field_analyzer)
 
@@ -100,7 +104,7 @@ module Bulkrax
         end
 
         # Runs all registered row validators and returns the collected errors.
-        def run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record) # rubocop:disable Metrics/ParameterLists
+        def run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record, notices = []) # rubocop:disable Metrics/ParameterLists
           context = {
             errors: [],
             warnings: [],
@@ -114,7 +118,8 @@ module Bulkrax
             mappings: mappings,
             field_metadata: field_metadata,
             find_record_by_source_identifier: find_record,
-            relationship_graph: build_relationship_graph(csv_data, mappings)
+            relationship_graph: build_relationship_graph(csv_data, mappings),
+            notices: notices
           }
           csv_data.each_with_index do |record, index|
             row_number = index + 2 # 1-indexed, plus header row

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
@@ -96,6 +96,29 @@ module Bulkrax
         all_models.each { |model| missing_required << { model: model, field: source_id_key.to_s } }
       end
 
+      # Adds a file-level notice when the model column is absent or every row has a blank
+      # model value, indicating that the default work type will be used for all rows.
+      # When this notice is present the per-row default_work_type_used warnings are
+      # suppressed in the formatter — no need to repeat the same message for every row.
+      def append_missing_model_notice!(notices, headers, csv_data)
+        default_model = Bulkrax.default_work_type
+        return if default_model.blank?
+
+        model_column_present = headers.map(&:to_s).include?('model')
+        all_rows_blank = model_column_present && csv_data.all? { |r| r[:model].blank? }
+
+        return if model_column_present && !all_rows_blank
+
+        key_suffix = all_rows_blank ? 'column_empty' : 'column_missing'
+        base_key   = 'bulkrax.importer.guided_import.validation.default_work_type_notice'
+        notices << {
+          field: 'model',
+          default_work_type: default_model,
+          message: I18n.t("#{base_key}.message_#{key_suffix}", default_work_type: default_model),
+          suggestion: I18n.t("#{base_key}.suggestion_#{key_suffix}")
+        }
+      end
+
       def apply_rights_statement_validation_override!(result, missing_required)
         only_rights = missing_required.present? &&
                       missing_required.all? { |h| h[:field].to_s == 'rights_statement' }
@@ -108,17 +131,18 @@ module Bulkrax
       end
 
       # Assembles the final result hash returned to the guided import UI.
-      def assemble_result(headers:, missing_required:, header_issues:, row_errors:, csv_data:, file_validator:, collections:, works:, file_sets:) # rubocop:disable Metrics/ParameterLists
+      def assemble_result(headers:, missing_required:, header_issues:, row_errors:, csv_data:, file_validator:, collections:, works:, file_sets:, notices: []) # rubocop:disable Metrics/ParameterLists
         row_error_entries   = row_errors.select { |e| e[:severity] == 'error' }
         row_warning_entries = row_errors.select { |e| e[:severity] == 'warning' }
         has_errors   = missing_required.any? || headers.blank? || csv_data.empty? ||
                        file_validator.missing_files.any? || row_error_entries.any?
         has_warnings = header_issues[:unrecognized].any? || header_issues[:empty_columns].any? ||
-                       file_validator.possible_missing_files? || row_warning_entries.any?
+                       file_validator.possible_missing_files? || row_warning_entries.any? || notices.any?
 
         {
           headers: headers,
           missingRequired: missing_required,
+          notices: notices,
           unrecognized: header_issues[:unrecognized],
           emptyColumns: header_issues[:empty_columns],
           rowCount: csv_data.length,

--- a/app/services/bulkrax/stepper_response_formatter.rb
+++ b/app/services/bulkrax/stepper_response_formatter.rb
@@ -119,6 +119,7 @@ module Bulkrax
     def build_messages
       issues = []
       issues << missing_required_issue if @data[:missingRequired]&.any?
+      issues << notices_issue if @data[:notices]&.any?
       issues << unrecognized_fields_issue if @data[:unrecognized]&.any? || @data[:emptyColumns]&.any?
       issues << file_references_issue if @data[:fileReferences]&.positive?
       issues << row_errors_issue if @data[:rowErrors]&.any? { |e| e[:severity] == 'error' }
@@ -311,9 +312,24 @@ module Bulkrax
       }
     end
 
+    def notices_issue
+      {
+        type: 'notices',
+        severity: 'warning',
+        icon: 'fa-info-circle',
+        title: I18n.t('bulkrax.importer.guided_import.validation.notices_title'),
+        count: @data[:notices].length,
+        description: I18n.t('bulkrax.importer.guided_import.validation.notices_desc'),
+        items: @data[:notices].map { |n| { field: n[:field], message: [n[:message], n[:suggestion]].compact.join(' ') } },
+        defaultOpen: false
+      }
+    end
+
     def filtered_row_errors
       missing_required_columns = @data[:missingRequired]&.map { |h| h[:field].to_s } || []
-      @data[:rowErrors].reject { |e| missing_required_columns.include?(e[:column].to_s) }
+      notice_columns = @data[:notices]&.map { |n| n[:field].to_s } || []
+      suppressed_columns = (missing_required_columns + notice_columns).uniq
+      @data[:rowErrors].reject { |e| suppressed_columns.include?(e[:column].to_s) }
     end
 
     def row_error_items(errors)

--- a/app/validators/bulkrax/csv_row/required_values.rb
+++ b/app/validators/bulkrax/csv_row/required_values.rb
@@ -11,12 +11,35 @@ module Bulkrax
         field_metadata = context[:field_metadata]
         return if field_metadata.blank?
 
-        model = record[:model]
-        metadata = field_metadata[model]
+        using_default = record[:model].blank?
+        model         = record[:model].presence || Bulkrax.default_work_type
+        metadata      = field_metadata[model]
         return if metadata.blank?
 
-        required_terms = metadata[:required_terms] || []
-        required_terms.each do |field|
+        add_default_work_type_warning(context, record, row_index, model) if using_default
+        add_missing_required_value_errors(context, record, row_index, metadata)
+      end
+
+      def self.add_default_work_type_warning(context, record, row_index, model)
+        # Suppress per-row warning when a file-level notice already covers all rows.
+        return if context[:notices]&.any? { |n| n[:field] == 'model' }
+
+        context[:errors] << {
+          row: row_index,
+          source_identifier: record[:source_identifier],
+          severity: 'warning',
+          category: 'default_work_type_used',
+          column: 'model',
+          value: nil,
+          message: I18n.t('bulkrax.importer.guided_import.validation.default_work_type_validator.warnings.message',
+                          default_work_type: model),
+          suggestion: I18n.t('bulkrax.importer.guided_import.validation.default_work_type_validator.warnings.suggestion')
+        }
+      end
+      private_class_method :add_default_work_type_warning
+
+      def self.add_missing_required_value_errors(context, record, row_index, metadata)
+        (metadata[:required_terms] || []).each do |field|
           next if record[:raw_row].any? { |key, value| normalize_header(key.to_s) == field && value.present? }
 
           context[:errors] << {
@@ -31,6 +54,7 @@ module Bulkrax
           }
         end
       end
+      private_class_method :add_missing_required_value_errors
 
       def self.normalize_header(header)
         header.sub(/_\d+\z/, '')

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -328,11 +328,22 @@ de:
           passed: Validierung erfolgreich
           passed_warnings: Validierung mit Warnungen bestanden
           recognized_fields: 'Erkannte Felder: %{fields}'
+          default_work_type_validator:
+            warnings:
+              message: "Kein Modell angegeben — diese Zeile wird als '%{default_work_type}' importiert."
+              suggestion: "Geben Sie in der 'model'-Spalte für diese Zeile einen Modellwert an, wenn Sie einen anderen Werktyp verwenden möchten."
+          default_work_type_notice:
+            message_column_missing: "Keine Modellspalte gefunden — alle Zeilen werden als '%{default_work_type}' importiert."
+            message_column_empty: "Kein Modell angegeben — alle Zeilen werden als '%{default_work_type}' importiert."
+            suggestion_column_empty: "Fügen Sie Modellwerte in die 'model'-Spalte Ihrer CSV-Datei ein, wenn Sie für einige Zeilen einen anderen Werktyp verwenden möchten."
+            suggestion_column_missing: "Fügen Sie Ihrer CSV-Datei eine 'model'-Spalte hinzu, wenn Sie für einige Zeilen einen anderen Werktyp verwenden möchten."
           required_field_validator:
             errors:
               message: "Das Feld '%{field}' ist erforderlich, ist aber für diese Zeile leer."
               suggestion: "Geben Sie einen Wert für '%{field}' ein."
           unable_to_process: Die Validierungsdateien konnten nicht verarbeitet werden.
+          notices_desc: 'Diese Hinweise können Auswirkungen auf den Import Ihrer CSV-Datei haben:'
+          notices_title: Importhinweise
           unrecognized_desc: 'Diese Spalten werden beim Import ignoriert:'
           unrecognized_title: Nicht anerkannte Felder
       validations:

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -363,12 +363,23 @@ en:
           passed: Validation Passed
           passed_warnings: Validation Passed with Warnings
           recognized_fields: 'Recognized fields: %{fields}'
+          default_work_type_notice:
+            message_column_missing: "No model column found — all rows will be imported as '%{default_work_type}'."
+            message_column_empty: "No model provided — all rows will be imported as '%{default_work_type}'."
+            suggestion_column_empty: "Add model values to the 'model' column in your CSV if you want to use a different work type for some rows."
+            suggestion_column_missing: "Add a 'model' column to your CSV if you want to use a different work type for some rows."
+          default_work_type_validator:
+            warnings:
+              message: "No model specified — this row will be imported as '%{default_work_type}'."
+              suggestion: "Specify a model value in the 'model' column for this row if you want to use a different work type."
           required_field_validator:
             errors:
               message: "Field '%{field}' is required but is empty for this row."
               suggestion: "Add a value for '%{field}'."
           unable_to_process: Unable to process files for validation
           empty_column: 'Column %{column} (no header)'
+          notices_desc: 'These notices may affect how your CSV is imported:'
+          notices_title: Import Notices
           unrecognized_desc: 'These columns will be ignored during import:'
           unrecognized_title: Unrecognized Fields
       validations:

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -328,11 +328,22 @@ es:
           passed: Validación aprobada
           passed_warnings: Validación aprobada con advertencias
           recognized_fields: 'Campos reconocidos: %{fields}'
+          default_work_type_validator:
+            warnings:
+              message: "No se especificó ningún modelo — esta fila se importará como '%{default_work_type}'."
+              suggestion: "Especifique un valor de modelo en la columna 'model' para esta fila si desea usar un tipo de trabajo diferente."
+          default_work_type_notice:
+            message_column_missing: "No se encontró columna de modelo — todas las filas se importarán como '%{default_work_type}'."
+            message_column_empty: "No se proporcionó ningún modelo — todas las filas se importarán como '%{default_work_type}'."
+            suggestion_column_empty: "Añada valores de modelo a la columna 'model' de su CSV si desea usar un tipo de trabajo diferente para algunas filas."
+            suggestion_column_missing: "Añada una columna 'model' a su CSV si desea usar un tipo de trabajo diferente para algunas filas."
           required_field_validator:
             errors:
               message: "El campo '%{field}' es obligatorio pero está vacío para esta fila."
               suggestion: "Añada un valor para '%{field}'."
           unable_to_process: No se pueden procesar archivos para su validación
+          notices_desc: 'Estos avisos pueden afectar cómo se importa su CSV:'
+          notices_title: Avisos de importación
           unrecognized_desc: 'Estas columnas se ignorarán durante la importación:'
           unrecognized_title: Campos no reconocidos
       validations:

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -328,11 +328,22 @@ fr:
           passed: Validation réussie
           passed_warnings: Validation réussie avec avertissements
           recognized_fields: 'Champs reconnus : %{fields}'
+          default_work_type_validator:
+            warnings:
+              message: "Aucun modèle spécifié — cette ligne sera importée en tant que '%{default_work_type}'."
+              suggestion: "Spécifiez une valeur de modèle dans la colonne 'model' pour cette ligne si vous souhaitez utiliser un type de travail différent."
+          default_work_type_notice:
+            message_column_missing: "Aucune colonne de modèle trouvée — toutes les lignes seront importées en tant que '%{default_work_type}'."
+            message_column_empty: "Aucun modèle fourni — toutes les lignes seront importées en tant que '%{default_work_type}'."
+            suggestion_column_empty: "Ajoutez des valeurs de modèle à la colonne 'model' de votre CSV si vous souhaitez utiliser un type de travail différent pour certaines lignes."
+            suggestion_column_missing: "Ajoutez une colonne 'model' à votre CSV si vous souhaitez utiliser un type de travail différent pour certaines lignes."
           required_field_validator:
             errors:
               message: "Le champ « %{field} » est obligatoire mais il est vide pour cette ligne."
               suggestion: "Ajoutez une valeur pour « %{field} »."
           unable_to_process: Impossible de traiter les fichiers pour validation
+          notices_desc: 'Ces avis peuvent affecter la façon dont votre CSV est importé :'
+          notices_title: Avis d'importation
           unrecognized_desc: 'Ces colonnes seront ignorées lors de l''importation :'
           unrecognized_title: Champs non reconnus
       validations:

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -328,11 +328,22 @@ it:
           passed: Validazione superata
           passed_warnings: Validazione superata con avvisi
           recognized_fields: 'Campi riconosciuti: %{fields}'
+          default_work_type_validator:
+            warnings:
+              message: "Nessun modello specificato — questa riga verrà importata come '%{default_work_type}'."
+              suggestion: "Specifica un valore modello nella colonna 'model' per questa riga se vuoi usare un tipo di lavoro diverso."
+          default_work_type_notice:
+            message_column_missing: "Nessuna colonna modello trovata — tutte le righe verranno importate come '%{default_work_type}'."
+            message_column_empty: "Nessun modello fornito — tutte le righe verranno importate come '%{default_work_type}'."
+            suggestion_column_empty: "Aggiungi valori modello alla colonna 'model' del tuo CSV se vuoi usare un tipo di lavoro diverso per alcune righe."
+            suggestion_column_missing: "Aggiungi una colonna 'model' al tuo CSV se vuoi usare un tipo di lavoro diverso per alcune righe."
           required_field_validator:
             errors:
               message: "Il campo '%{field}' è obbligatorio ma è vuoto per questa riga."
               suggestion: "Aggiungi un valore per '%{field}'."
           unable_to_process: Impossibile elaborare i file per la convalida
+          notices_desc: 'Questi avvisi potrebbero influire sul modo in cui il tuo CSV viene importato:'
+          notices_title: Avvisi di importazione
           unrecognized_desc: 'Queste colonne verranno ignorate durante l''importazione:'
           unrecognized_title: Campi non riconosciuti
       validations:

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -328,11 +328,22 @@ pt-BR:
           passed: Validação aprovada
           passed_warnings: Validação aprovada com advertências.
           recognized_fields: 'Campos reconhecidos: %{fields}'
+          default_work_type_validator:
+            warnings:
+              message: "Nenhum modelo especificado — esta linha será importada como '%{default_work_type}'."
+              suggestion: "Especifique um valor de modelo na coluna 'model' para esta linha se quiser usar um tipo de trabalho diferente."
+          default_work_type_notice:
+            message_column_missing: "Nenhuma coluna de modelo encontrada — todas as linhas serão importadas como '%{default_work_type}'."
+            message_column_empty: "Nenhum modelo fornecido — todas as linhas serão importadas como '%{default_work_type}'."
+            suggestion_column_empty: "Adicione valores de modelo à coluna 'model' do seu CSV se quiser usar um tipo de trabalho diferente para algumas linhas."
+            suggestion_column_missing: "Adicione uma coluna 'model' ao seu CSV se quiser usar um tipo de trabalho diferente para algumas linhas."
           required_field_validator:
             errors:
               message: "O campo '%{field}' é obrigatório, mas está vazio para esta linha."
               suggestion: "Adicione um valor para '%{field}'."
           unable_to_process: Não foi possível processar os arquivos para validação.
+          notices_desc: 'Estes avisos podem afetar como o seu CSV é importado:'
+          notices_title: Avisos de importação
           unrecognized_desc: 'Estas colunas serão ignoradas durante a importação:'
           unrecognized_title: Campos não reconhecidos
       validations:

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -327,11 +327,22 @@ zh:
           passed: 验证通过
           passed_warnings: 验证通过，但存在警告
           recognized_fields: 已识别字段：%{fields}
+          default_work_type_validator:
+            warnings:
+              message: "未指定模型 — 此行将以 '%{default_work_type}' 导入。"
+              suggestion: "如果要为此行使用不同的作品类型，请在 'model' 列中指定一个模型值。"
+          default_work_type_notice:
+            message_column_missing: "未找到模型列 — 所有行将以 '%{default_work_type}' 导入。"
+            message_column_empty: "未提供模型 — 所有行将以 '%{default_work_type}' 导入。"
+            suggestion_column_empty: "如果您想为某些行使用不同的作品类型，请在 CSV 的 'model' 列中添加模型值。"
+            suggestion_column_missing: "如果您想为某些行使用不同的作品类型，请在 CSV 中添加 'model' 列。"
           required_field_validator:
             errors:
               message: "字段 '%{field}' 是必填项，但此行中该字段为空。"
               suggestion: "请为 '%{field}' 添加一个值。"
           unable_to_process: 无法处理文件进行验证
+          notices_desc: '这些通知可能会影响您的 CSV 的导入方式：'
+          notices_title: 导入通知
           unrecognized_desc: 导入过程中将忽略以下列：
           unrecognized_title: 未识别字段
       validations:

--- a/spec/validators/bulkrax/csv_row/required_values_spec.rb
+++ b/spec/validators/bulkrax/csv_row/required_values_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Bulkrax::CsvRow::RequiredValues do
-  def make_context(required_terms: ['title'])
+  def make_context(required_terms: ['title'], notices: [])
     {
       errors: [],
       warnings: [],
+      notices: notices,
       field_metadata: { 'GenericWork' => { required_terms: required_terms, controlled_vocab_terms: [] } }
     }
   end
@@ -37,5 +38,71 @@ RSpec.describe Bulkrax::CsvRow::RequiredValues do
     context = make_context
     described_class.call(make_record('title_1' => 'My Title'), 2, context)
     expect(context[:errors]).to be_empty
+  end
+
+  context 'when model is blank' do
+    def make_blank_model_record(raw_row_hash = {})
+      {
+        source_identifier: 'work1',
+        model: nil,
+        raw_row: raw_row_hash
+      }
+    end
+
+    context 'and default_work_type is configured' do
+      before do
+        allow(Bulkrax).to receive(:default_work_type).and_return('GenericWork')
+      end
+
+      it 'emits a default_work_type_used warning' do
+        context = make_context
+        described_class.call(make_blank_model_record('title' => 'My Title'), 2, context)
+        warning = context[:errors].find { |e| e[:category] == 'default_work_type_used' }
+        expect(warning).to be_present
+        expect(warning[:severity]).to eq('warning')
+        expect(warning[:column]).to eq('model')
+      end
+
+      it 'also emits a missing_required_value error when a required field is absent' do
+        context = make_context
+        described_class.call(make_blank_model_record({}), 2, context)
+        categories = context[:errors].map { |e| e[:category] }
+        expect(categories).to include('default_work_type_used', 'missing_required_value')
+      end
+
+      it 'emits only the warning when all required fields are present' do
+        context = make_context
+        described_class.call(make_blank_model_record('title' => 'My Title'), 2, context)
+        expect(context[:errors].map { |e| e[:category] }).to eq(['default_work_type_used'])
+      end
+    end
+
+    context 'and a file-level notice already covers the missing model column' do
+      before { allow(Bulkrax).to receive(:default_work_type).and_return('GenericWork') }
+
+      it 'suppresses the per-row default_work_type_used warning' do
+        context = make_context(notices: [{ field: 'model', default_work_type: 'GenericWork' }])
+        described_class.call(make_blank_model_record('title' => 'My Title'), 2, context)
+        expect(context[:errors]).to be_empty
+      end
+
+      it 'still emits missing_required_value errors for blank required fields' do
+        context = make_context(notices: [{ field: 'model', default_work_type: 'GenericWork' }])
+        described_class.call(make_blank_model_record({}), 2, context)
+        expect(context[:errors].map { |e| e[:category] }).to eq(['missing_required_value'])
+      end
+    end
+
+    context 'and default_work_type is not configured' do
+      before do
+        allow(Bulkrax).to receive(:default_work_type).and_return(nil)
+      end
+
+      it 'adds no errors or warnings (cannot validate without knowing the model)' do
+        context = make_context
+        described_class.call(make_blank_model_record({}), 2, context)
+        expect(context[:errors]).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
# Summary

Checks for a model column and/or entries in it. Adds a warning that the default model of xxxx will be used. When there is no model column or all rows have no model, only a file level warning is given.

# Screenshots

<img width="895" height="405" alt="Screenshot 2026-04-03 at 2 48 47 PM" src="https://github.com/user-attachments/assets/fff0971a-b66f-4ccf-bc6f-ed5ac452a231" />

<img width="913" height="469" alt="Screenshot 2026-04-03 at 2 49 46 PM" src="https://github.com/user-attachments/assets/458c76a7-75d9-472a-ae8c-83d2bcdffdd1" />

<img width="898" height="545" alt="Screenshot 2026-04-03 at 3 23 30 PM" src="https://github.com/user-attachments/assets/1c6f0a89-1230-4807-8f77-56c673ce1e87" />
