### PR TITLE
Show existing on hierarchy validation

### DIFF
--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_hierarchy.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_hierarchy.rb
@@ -57,6 +57,7 @@ module Bulkrax
           id: item_id,
           title: title,
           type: type,
+          existing: find_record&.call(item_id) || false,
           parentIds: (resolvable_ids(parents, all_ids) + resolvable_ids(child_to_parents[item_id] || [], all_ids)).uniq,
           childIds: resolvable_ids(children, all_ids),
           existingParentIds: external_ids(parents, all_ids, find_record),

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_hierarchy_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_hierarchy_spec.rb
@@ -204,6 +204,28 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHierarchy do
         expect(hash[:existingParentIds]).to include('repo_col')
       end
     end
+
+    context 'existing flag' do
+      it 'sets existing to true when find_record returns true for the item' do
+        find_record = ->(id) { id == 'work1' }
+        item = make_item(source_identifier: 'work1', raw_row: { 'title' => 'Work One' })
+        hash = host.build_item_hash(item, {}, all_ids, type: 'work', find_record: find_record)
+        expect(hash[:existing]).to be true
+      end
+
+      it 'sets existing to false when find_record returns false for the item' do
+        find_record = ->(_id) { false }
+        item = make_item(source_identifier: 'work1', raw_row: { 'title' => 'Work One' })
+        hash = host.build_item_hash(item, {}, all_ids, type: 'work', find_record: find_record)
+        expect(hash[:existing]).to be false
+      end
+
+      it 'sets existing to false when find_record is nil' do
+        item = make_item(source_identifier: 'work1', raw_row: { 'title' => 'Work One' })
+        hash = host.build_item_hash(item, {}, all_ids, type: 'work')
+        expect(hash[:existing]).to be false
+      end
+    end
   end
 
   # ─── custom split patterns ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Prior to this fix, the validations included existing data but the hierarchy list showed only existing data when the items were NOT in the CSV.

This fix also shows `existing` in the hierarchy list when the items are in the CSV.

<img width="642" height="538" alt="Screenshot 2026-04-09 at 12 32 58 PM" src="https://github.com/user-attachments/assets/95d4791e-1aed-4a74-8c85-fcafc6d1fd4d" />
