### PR TITLE
Fixes error with unzipping for CSV import

### DIFF
--- a/app/controllers/concerns/bulkrax/importer_file_handler.rb
+++ b/app/controllers/concerns/bulkrax/importer_file_handler.rb
@@ -121,12 +121,7 @@ module Bulkrax
       csv_by_depth = get_directory_depth_for_each_csv(csv_entries)
       csvs_at_level = determine_csvs_at_shallowest_level(csv_by_depth)
 
-      csvs_by_directory = csvs_at_level.group_by { |entry| File.dirname(entry.name) }
-      csvs_by_directory.each do |_dir, csvs|
-        return StepperResponseFormatter.error(message: I18n.t('bulkrax.importer.guided_import.validation.multiple_csv_same_dir')) if csvs.count > 1
-      end
-
-      return StepperResponseFormatter.error(message: I18n.t('bulkrax.importer.guided_import.validation.multiple_csv_same_level')) if csvs_at_level.size > 1
+      return StepperResponseFormatter.error(message: I18n.t('bulkrax.importer.guided_import.validation.multiple_csv')) if csvs_at_level.size > 1
 
       csvs_at_level.first
     end

--- a/app/errors/bulkrax/unzip_error.rb
+++ b/app/errors/bulkrax/unzip_error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  # Raised when a zip cannot be safely or meaningfully extracted during
+  # import. Covered scenarios include:
+  #
+  # - A single upload zip has no CSV at any level.
+  # - A single upload zip has multiple CSVs at its shallowest level
+  #   (primary CSV cannot be determined).
+  # - A zip entry's name would escape the destination directory
+  #   (Zip Slip: absolute paths, `..` traversal, etc.).
+  #
+  # Defined in its own file so Zeitwerk can autoload the constant by name
+  # from any parser or job that raises or rescues it.
+  class UnzipError < StandardError; end
+end

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -26,9 +26,17 @@ module Bulkrax
       importer.import_objects
     end
 
-    # Populates `importer_unzip_path` with the primary CSV at its root and
-    # any attachment files under `files/`, regardless of how the user
-    # uploaded them. See docs/UNZIP_FIX_PLAN.md for the full contract.
+    # Populates `importer_unzip_path` with the uploaded file(s), leaving
+    # the working directory in the shape each parser expects.
+    #
+    # Dispatch by parser capability rather than class name:
+    # - CsvParser (and subclasses that replicate its shape) implements
+    #   `#unzip_with_primary_csv` and `#unzip_attachments_only`, which
+    #   place the primary CSV at root and attachments under `files/`.
+    # - Other parsers (XML, raw BagIt) inherit the base-class `#unzip`,
+    #   which extracts the zip verbatim.
+    # - The separate attachments-zip flow is CSV-only (guided import is
+    #   the only UI that produces it).
     #
     # A retry of this job gets a clean working directory: any prior
     # extraction state from an earlier attempt is wiped, so nothing runs
@@ -38,13 +46,20 @@ module Bulkrax
 
       reset_unzip_path(parser)
 
+      import_file_path = parser.parser_fields['import_file_path']
+      attachments_zip_path = parser.parser_fields['attachments_zip_path']
+
       if parser.zip?
-        parser.unzip_with_primary_csv(parser.parser_fields['import_file_path'])
-      elsif parser.zip_file?(parser.parser_fields['attachments_zip_path'])
-        parser.copy_file(parser.parser_fields['import_file_path'])
-        parser.unzip_attachments_only(parser.parser_fields['attachments_zip_path'])
+        if parser.respond_to?(:unzip_with_primary_csv)
+          parser.unzip_with_primary_csv(import_file_path)
+        else
+          parser.unzip(import_file_path)
+        end
+      elsif parser.respond_to?(:unzip_attachments_only) && parser.zip_file?(attachments_zip_path)
+        parser.copy_file(import_file_path)
+        parser.unzip_attachments_only(attachments_zip_path)
       else
-        parser.copy_file(parser.parser_fields['import_file_path'])
+        parser.copy_file(import_file_path)
       end
 
       parser.remove_spaces_from_filenames if parser.respond_to?(:remove_spaces_from_filenames)

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -13,7 +13,7 @@ module Bulkrax
       import(importer, only_updates_since_last_import)
       update_current_run_counters(importer)
       schedule(importer) if importer.schedulable?
-    rescue ::CSV::MalformedCSVError => e
+    rescue ::CSV::MalformedCSVError, Bulkrax::UnzipError => e
       importer.set_status_info(e)
     end
 
@@ -26,18 +26,34 @@ module Bulkrax
       importer.import_objects
     end
 
+    # Populates `importer_unzip_path` with the primary CSV at its root and
+    # any attachment files under `files/`, regardless of how the user
+    # uploaded them. See docs/UNZIP_FIX_PLAN.md for the full contract.
+    #
+    # A retry of this job gets a clean working directory: any prior
+    # extraction state from an earlier attempt is wiped, so nothing runs
+    # against partially-populated state.
     def unzip_imported_file(parser)
       return unless parser.file?
+
+      reset_unzip_path(parser)
+
       if parser.zip?
-        # we have a zip file, and we need to unzip it before we can import the files
-        parser.unzip(parser.parser_fields['import_file_path'])
-        parser.remove_spaces_from_filenames
+        parser.unzip_with_primary_csv(parser.parser_fields['import_file_path'])
       elsif parser.zip_file?(parser.parser_fields['attachments_zip_path'])
-        # we have a separate csv and zip file. We need to unzip the zip file, and move the csv file to the unzip location before we can import the files
-        parser.unzip(parser.parser_fields['attachments_zip_path'])
         parser.copy_file(parser.parser_fields['import_file_path'])
-        parser.remove_spaces_from_filenames
+        parser.unzip_attachments_only(parser.parser_fields['attachments_zip_path'])
+      else
+        parser.copy_file(parser.parser_fields['import_file_path'])
       end
+
+      parser.remove_spaces_from_filenames if parser.respond_to?(:remove_spaces_from_filenames)
+    end
+
+    def reset_unzip_path(parser)
+      path = parser.importer_unzip_path
+      FileUtils.rm_rf(path) if Dir.exist?(path)
+      FileUtils.mkdir_p(path)
     end
 
     def update_current_run_counters(importer)

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -266,22 +266,9 @@ module Bulkrax
     # end
 
     def importer_unzip_path(mkdir: false)
-      entry = parser_fields&.[]('import_file_path')
-      if entry.is_a?(String) && entry.end_with?('.zip') && File.file?(entry) && parser_fields["file_style"] != I18n.t('bulkrax.importer.xml.file_style.server_path')
-        unzip_dir = File.dirname(entry)
-        FileUtils.mkdir_p(unzip_dir) if mkdir
-        return unzip_dir
-      end
-
-      @importer_unzip_path ||= File.join(parser.base_path, "import_#{path_string}")
-      return @importer_unzip_path if Dir.exist?(@importer_unzip_path) || mkdir == true
-
-      # turns "tmp/imports/tenant/import_1_20250122035229_1" to "tmp/imports/tenant/import_1_20250122035229"
-      base_importer_unzip_path = @importer_unzip_path.split('_')[0...-1].join('_')
-
-      # If we don't have an existing unzip path, we'll try and find it.
-      # Just in case there are multiple paths, we sort by the number at the end of the path and get the last one
-      @importer_unzip_path = Dir.glob(base_importer_unzip_path + '*').sort_by { |path| path.split(base_importer_unzip_path).last[1..-1].to_i }.last
+      path = File.join(parser.base_path, "import_#{path_string}")
+      FileUtils.mkdir_p(path) if mkdir
+      path
     end
 
     def errored_entries_csv_path

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -443,7 +443,8 @@ module Bulkrax
         zip_file.each do |entry|
           next unless entry.file?
           next if macos_junk_entry?(entry.name)
-          dest_path = File.join(dest_dir, entry.name)
+          reject_unsafe_entry!(entry.name)
+          dest_path = safe_extract_path(dest_dir, entry.name)
           FileUtils.mkdir_p(File.dirname(dest_path))
           next if File.exist?(dest_path)
           extract_zip_entry(zip_file, entry, dest_dir, entry.name, dest_path)
@@ -453,9 +454,12 @@ module Bulkrax
 
     # rubyzip 2.x: extract(entry, absolute_dest_path)
     # rubyzip 3.x: extract(entry, relative_name, destination_directory: dir)
-    def extract_zip_entry(zip_file, entry, dest_dir, relative_name, absolute_path)
+    #
+    # Callers are responsible for passing a `dest_path` produced by
+    # {#safe_extract_path} so the write can't escape `dest_dir`.
+    def extract_zip_entry(zip_file, entry, dest_dir, relative_name, dest_path)
       if zip_file.method(:extract).arity == 2
-        zip_file.extract(entry, absolute_path)
+        zip_file.extract(entry, dest_path)
       else
         zip_file.extract(entry, relative_name, destination_directory: dest_dir)
       end
@@ -463,6 +467,33 @@ module Bulkrax
 
     def macos_junk_entry?(name)
       name.start_with?('__MACOSX/') || name.split('/').any? { |part| part == '.DS_Store' || part.start_with?('._') }
+    end
+
+    # Zip Slip preflight — reject entries whose names are obviously unsafe
+    # (absolute paths, `..` segments) before we touch the filesystem.
+    # {#safe_extract_path} is the final line of defense; this check just
+    # fails fast with a clear message.
+    #
+    # @raise [Bulkrax::UnzipError] if the entry name is unsafe
+    def reject_unsafe_entry!(name)
+      return unless name.start_with?('/') || name.split('/').include?('..')
+      raise Bulkrax::UnzipError, I18n.t('bulkrax.importer.unzip.errors.unsafe_entry', name: name)
+    end
+
+    # Zip Slip chokepoint. Resolves `relative_dest` against `dest_dir` and
+    # returns the absolute destination path — but only if it stays inside
+    # `dest_dir`. Callers must use this value rather than building their
+    # own path with `File.join`, so the path returned is always safe by
+    # construction.
+    #
+    # @return [String] absolute destination path, validated to be inside `dest_dir`
+    # @raise  [Bulkrax::UnzipError] if `relative_dest` escapes `dest_dir`
+    def safe_extract_path(dest_dir, relative_dest)
+      expanded_dest_dir = File.expand_path(dest_dir)
+      dest_path = File.expand_path(relative_dest.to_s, expanded_dest_dir)
+      return dest_path if dest_path == expanded_dest_dir
+      return dest_path if dest_path.start_with?("#{expanded_dest_dir}#{File::SEPARATOR}")
+      raise Bulkrax::UnzipError, I18n.t('bulkrax.importer.unzip.errors.unsafe_entry', name: relative_dest)
     end
 
     def copy_file(file_to_copy)

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -430,32 +430,34 @@ module Bulkrax
       zip
     end
 
+    # Extracts a zip verbatim into {#importer_unzip_path}, preserving the zip's
+    # internal structure. Filters macOS junk (`__MACOSX/`, `.DS_Store`, `._*`).
+    # Parser subclasses that need to interpret the zip's structure (e.g.
+    # {Bulkrax::CsvParser#unzip_with_primary_csv}) should call a more specific
+    # method rather than this one.
     def unzip(file_to_unzip)
       return untar(file_to_unzip) if file_to_unzip.end_with?('.tar.gz')
 
+      dest_dir = importer_unzip_path(mkdir: true)
       Zip::File.open(file_to_unzip) do |zip_file|
-        real_entries = zip_file.reject { |e| macos_junk_entry?(e.name) }
-        top_level_dirs = real_entries.map { |e| e.name.split('/').first }.uniq
-        strip_prefix = top_level_dirs.size == 1 ? "#{top_level_dirs.first}/" : nil
-
-        dest_dir = importer_unzip_path(mkdir: true)
         zip_file.each do |entry|
           next unless entry.file?
           next if macos_junk_entry?(entry.name)
-          name = strip_prefix ? entry.name.delete_prefix(strip_prefix) : entry.name
-          next if name.empty?
-          dest_path = File.join(dest_dir, name)
+          dest_path = File.join(dest_dir, entry.name)
           FileUtils.mkdir_p(File.dirname(dest_path))
-          unless File.exist?(dest_path)
-            # rubyzip 2.x: extract(entry, absolute_dest_path)
-            # rubyzip 3.x: extract(entry, relative_name, destination_directory: dir)
-            if zip_file.method(:extract).arity == 2
-              zip_file.extract(entry, dest_path)
-            else
-              zip_file.extract(entry, name, destination_directory: dest_dir)
-            end
-          end
+          next if File.exist?(dest_path)
+          extract_zip_entry(zip_file, entry, dest_dir, entry.name, dest_path)
         end
+      end
+    end
+
+    # rubyzip 2.x: extract(entry, absolute_dest_path)
+    # rubyzip 3.x: extract(entry, relative_name, destination_directory: dir)
+    def extract_zip_entry(zip_file, entry, dest_dir, relative_name, absolute_path)
+      if zip_file.method(:extract).arity == 2
+        zip_file.extract(entry, absolute_path)
+      else
+        zip_file.extract(entry, relative_name, destination_directory: dest_dir)
       end
     end
 
@@ -473,21 +475,6 @@ module Bulkrax
       command = "tar -xzf #{Shellwords.escape(file_to_untar)} -C #{Shellwords.escape(importer_unzip_path)}"
       result = system(command)
       raise "Failed to extract #{file_to_untar}" unless result
-    end
-
-    # File names referenced in CSVs have spaces replaced with underscores
-    # @see Bulkrax::CsvParser#file_paths
-    def remove_spaces_from_filenames
-      files = Dir.glob(File.join(importer_unzip_path, 'files', '*')).uniq
-      files_with_spaces = files.select { |f| f.split('/').last.match?(' ') }
-      return if files_with_spaces.blank?
-
-      files_with_spaces.map! { |path| Pathname.new(path) }
-      files_with_spaces.each do |path|
-        filename = path.basename
-        filename_without_spaces = filename.to_s.tr(' ', '_')
-        path.rename(File.join(path.dirname, filename_without_spaces))
-      end
     end
 
     def zip
@@ -515,7 +502,6 @@ module Bulkrax
 
     # @return [String]
     def real_import_file_path
-      return importer_unzip_path if file? && zip?
       parser_fields['import_file_path']
     end
   end

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -25,6 +25,18 @@ unless ENV.fetch('BULKRAX_NO_BAGIT', 'false').to_s == 'true'
         @path_to_files ||= Dir.glob(File.join(import_file_path, '**/data', filename)).first
       end
 
+      # BagIt archives are not CSV imports: they don't contain a primary
+      # CSV at a shallowest level, and their structure (bagit.txt + data/
+      # + manifests) must be preserved verbatim. Override both CSV-flavored
+      # unzip entry points to use the base-class verbatim extraction.
+      def unzip_with_primary_csv(file_to_unzip)
+        unzip(file_to_unzip)
+      end
+
+      def unzip_attachments_only(file_to_unzip)
+        unzip(file_to_unzip)
+      end
+
       # Take a random sample of 10 metadata_paths and work out the import fields from that
       def import_fields
         raise StandardError, 'No metadata files were found' if metadata_paths.blank?

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -3,8 +3,7 @@
 module Bulkrax
   # Raised when a zip cannot be interpreted during CSV import — for example,
   # when a single upload zip has no CSV or has ambiguous CSVs at its
-  # shallowest level, or when an attachments-only zip unexpectedly contains
-  # a CSV.
+  # shallowest level.
   class UnzipError < StandardError; end
 
   class CsvParser < ApplicationParser # rubocop:disable Metrics/ClassLength
@@ -391,17 +390,22 @@ module Bulkrax
     # import (the user specified a CSV file path with a sibling `files/`
     # directory on disk), resolve relative to the CSV's directory instead.
     #
-    # Returns nil when the computed path does not exist on disk so callers
-    # (e.g. `Bulkrax::FileSetEntryBehavior#add_path_to_file`) can fall back
-    # to the raw filename in their error messages.
+    # When called with `filename:`, returns the full path to that file if
+    # it exists on disk, or `nil` otherwise — callers like
+    # `Bulkrax::FileSetEntryBehavior#add_path_to_file` rely on the nil
+    # sentinel to fall back to the raw filename in their error messages.
+    #
+    # When called with no filename, returns the `files/` directory itself
+    # (only when that directory exists on disk — else `nil` so callers can
+    # raise a clear "no files directory" error).
     def path_to_files(**args)
       filename = args.fetch(:filename, '')
-      return @path_to_files if @path_to_files.present? && filename.blank?
+      base_dir = files_dir
+      return base_dir if filename.blank? && Dir.exist?(base_dir)
+      return nil if filename.blank?
 
-      has_attachments_zip = parser_fields['attachments_zip_path'].present? && zip_file?(parser_fields['attachments_zip_path'])
-      base = zip? || has_attachments_zip ? importer_unzip_path : File.dirname(import_file_path)
-      candidate = File.join(base, 'files', filename)
-      @path_to_files = candidate if File.exist?(candidate)
+      candidate = File.join(base_dir, filename)
+      candidate if File.exist?(candidate)
     end
 
     # Extracts a zip that contains a primary CSV. The primary CSV lands at
@@ -471,10 +475,24 @@ module Bulkrax
 
     private
 
+    # Memoized base directory under which import attachments live. Kept
+    # separate from `#path_to_files`' per-filename return value to avoid
+    # cross-contamination between directory lookups and file lookups.
+    def files_dir
+      @files_dir ||= begin
+        has_attachments_zip = parser_fields['attachments_zip_path'].present? && zip_file?(parser_fields['attachments_zip_path'])
+        base = zip? || has_attachments_zip ? importer_unzip_path : File.dirname(import_file_path)
+        File.join(base, 'files')
+      end
+    end
+
     # Returns zip entries filtered down to real files (no directories, no
-    # macOS junk).
+    # macOS junk). Raises {Bulkrax::UnzipError} if any entry's name would
+    # escape the destination directory (Zip Slip).
     def real_zip_entries(zip_file)
-      zip_file.entries.select { |e| e.file? && !macos_junk_entry?(e.name) }
+      entries = zip_file.entries.select { |e| e.file? && !macos_junk_entry?(e.name) }
+      entries.each { |e| reject_unsafe_entry!(e.name) }
+      entries
     end
 
     # Picks the single primary CSV from zip entries, enforcing the
@@ -512,8 +530,10 @@ module Bulkrax
 
     # Extracts a zip entry to `dest_dir/relative_dest`. Creates intermediate
     # directories and honors the rubyzip 2/3 extract-method signature.
+    # The destination path is validated by {#safe_extract_path} — an unsafe
+    # `relative_dest` raises {Bulkrax::UnzipError} before any write.
     def extract_to(zip_file, entry, dest_dir, relative_dest)
-      dest_path = File.join(dest_dir, relative_dest)
+      dest_path = safe_extract_path(dest_dir, relative_dest)
       FileUtils.mkdir_p(File.dirname(dest_path))
       return if File.exist?(dest_path)
       extract_zip_entry(zip_file, entry, dest_dir, relative_dest, dest_path)

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module Bulkrax
+  # Raised when a zip cannot be interpreted during CSV import — for example,
+  # when a single upload zip has no CSV or has ambiguous CSVs at its
+  # shallowest level, or when an attachments-only zip unexpectedly contains
+  # a CSV.
+  class UnzipError < StandardError; end
+
   class CsvParser < ApplicationParser # rubocop:disable Metrics/ClassLength
     include ErroredEntries
     include ExportBehavior
@@ -379,45 +385,138 @@ module Bulkrax
       end.flatten.compact.uniq
     end
 
-    # Retrieve the path where we expect to find the files
+    # Retrieve the path where we expect to find the files for this import.
+    # After {ImporterJob#unzip_imported_file} runs (zip cases), attachments
+    # live under `{importer_unzip_path}/files/`. For a server-path-style
+    # import (the user specified a CSV file path with a sibling `files/`
+    # directory on disk), resolve relative to the CSV's directory instead.
+    #
+    # Returns nil when the computed path does not exist on disk so callers
+    # (e.g. `Bulkrax::FileSetEntryBehavior#add_path_to_file`) can fall back
+    # to the raw filename in their error messages.
     def path_to_files(**args)
       filename = args.fetch(:filename, '')
-
       return @path_to_files if @path_to_files.present? && filename.blank?
-      # The zip file could be either the main import file, or a separate attachments zip file.
-      # We want to check for both of those before we determine the path to the files.
-      have_zip_file = zip? || (parser_fields['attachments_zip_path'] && zip_file?(parser_fields['attachments_zip_path']))
-      @path_to_files = File.join(
-          have_zip_file ? importer_unzip_path : File.dirname(import_file_path), 'files', filename
-        )
 
-      return @path_to_files if File.exist?(@path_to_files)
-
-      # TODO: This method silently returns nil if there is no file & no zip file
-      File.join(importer_unzip_path, 'files', filename) if file? && zip?
+      has_attachments_zip = parser_fields['attachments_zip_path'].present? && zip_file?(parser_fields['attachments_zip_path'])
+      base = zip? || has_attachments_zip ? importer_unzip_path : File.dirname(import_file_path)
+      candidate = File.join(base, 'files', filename)
+      @path_to_files = candidate if File.exist?(candidate)
     end
 
-    def unzip(file_to_unzip)
-      super
-      normalize_unzipped_files_structure(importer_unzip_path)
+    # Extracts a zip that contains a primary CSV. The primary CSV lands at
+    # the root of {#importer_unzip_path}; every other entry lands under
+    # {#importer_unzip_path}/files/, preserving its path relative to the
+    # primary CSV's directory.
+    #
+    # Primary-CSV selection matches the guided-import validator's rule
+    # (see {Bulkrax::ImporterFileHandler#locate_csv_entry_in_zip}): the CSV
+    # entry at the shallowest directory level. Visible errors are raised on
+    # zero CSVs or multiple CSVs at the shallowest level.
+    #
+    # @param file_to_unzip [String] absolute path to a .zip
+    # @raise [Bulkrax::UnzipError] on no CSV or ambiguous CSVs
+    def unzip_with_primary_csv(file_to_unzip)
+      dest_dir = importer_unzip_path(mkdir: true)
+      Zip::File.open(file_to_unzip) do |zip_file|
+        entries = real_zip_entries(zip_file)
+        primary = select_primary_csv!(entries)
+        primary_dir = File.dirname(primary.name)
+
+        entries.each do |entry|
+          if entry == primary
+            extract_to(zip_file, entry, dest_dir, File.basename(entry.name))
+          else
+            extract_to(zip_file, entry, dest_dir, File.join('files', relative_to(primary_dir, entry.name)))
+          end
+        end
+      end
+    end
+
+    # Extracts a zip that accompanies a separately-uploaded CSV. Every
+    # entry lands under {#importer_unzip_path}/files/ — including any
+    # CSVs inside the zip, which are treated as attachments since the
+    # primary CSV was uploaded outside the zip. Strips a single top-level
+    # wrapper directory if present, so users can zip either the contents
+    # or the enclosing folder.
+    #
+    # @param file_to_unzip [String] absolute path to a .zip
+    def unzip_attachments_only(file_to_unzip)
+      dest_dir = importer_unzip_path(mkdir: true)
+      Zip::File.open(file_to_unzip) do |zip_file|
+        entries = real_zip_entries(zip_file)
+        wrapper = single_top_level_wrapper(entries)
+
+        entries.each do |entry|
+          relative = wrapper ? entry.name.delete_prefix("#{wrapper}/") : entry.name
+          next if relative.empty?
+          extract_to(zip_file, entry, dest_dir, File.join('files', relative))
+        end
+      end
+    end
+
+    # File names referenced in CSVs have spaces replaced with underscores.
+    # @see #file_paths
+    def remove_spaces_from_filenames
+      files = Dir.glob(File.join(importer_unzip_path, 'files', '*'))
+      files_with_spaces = files.select { |f| f.split('/').last.match?(' ') }
+      return if files_with_spaces.blank?
+
+      files_with_spaces.map! { |path| Pathname.new(path) }
+      files_with_spaces.each do |path|
+        filename_without_spaces = path.basename.to_s.tr(' ', '_')
+        path.rename(File.join(path.dirname, filename_without_spaces))
+      end
     end
 
     private
 
-    # Ensure files extracted from a zip always land in a `files/` subdirectory
-    # regardless of how the zip was structured. If files were extracted directly
-    # into dest_dir (flat zip with no `files/` folder), move them into
-    # dest_dir/files/ so that path_to_files can reliably locate them.
-    def normalize_unzipped_files_structure(dest_dir)
-      flat_files = Dir.glob(File.join(dest_dir, '*')).select { |f| File.file?(f) && !f.end_with?('.csv') }
-      return if flat_files.empty?
+    # Returns zip entries filtered down to real files (no directories, no
+    # macOS junk).
+    def real_zip_entries(zip_file)
+      zip_file.entries.select { |e| e.file? && !macos_junk_entry?(e.name) }
+    end
 
-      files_dir = File.join(dest_dir, 'files')
-      FileUtils.mkdir_p(files_dir)
-      flat_files.each do |f|
-        dest = File.join(files_dir, File.basename(f))
-        FileUtils.mv(f, dest) unless File.exist?(dest)
-      end
+    # Picks the single primary CSV from zip entries, enforcing the
+    # shallowest-level rule. Raises {Bulkrax::UnzipError} on failure.
+    def select_primary_csv!(entries)
+      csvs = entries.select { |e| e.name.end_with?('.csv') }
+      raise Bulkrax::UnzipError, I18n.t('bulkrax.importer.unzip.errors.no_csv') if csvs.empty?
+
+      by_depth = csvs.group_by { |e| e.name.count('/') }
+      shallowest = by_depth[by_depth.keys.min]
+
+      raise Bulkrax::UnzipError, I18n.t('bulkrax.importer.unzip.errors.multiple_csv') if shallowest.size > 1
+
+      shallowest.first
+    end
+
+    # If every entry shares a single top-level directory, returns that
+    # directory name; otherwise nil.
+    def single_top_level_wrapper(entries)
+      tops = entries.map { |e| e.name.split('/').first }.uniq
+      return nil unless tops.size == 1
+      # If the single top segment is a file (no slashes in the entry), not a dir,
+      # there's no wrapper to strip.
+      return nil if entries.any? { |e| e.name == tops.first }
+      tops.first
+    end
+
+    # Returns `path` with `prefix/` removed from the front, if present, and
+    # a leading `files/` segment also stripped so callers can join under
+    # `files/` without doubling when the zip already uses that convention.
+    def relative_to(prefix, path)
+      remaining = prefix == '.' || prefix.empty? ? path : path.delete_prefix("#{prefix}/")
+      remaining.delete_prefix('files/')
+    end
+
+    # Extracts a zip entry to `dest_dir/relative_dest`. Creates intermediate
+    # directories and honors the rubyzip 2/3 extract-method signature.
+    def extract_to(zip_file, entry, dest_dir, relative_dest)
+      dest_path = File.join(dest_dir, relative_dest)
+      FileUtils.mkdir_p(File.dirname(dest_path))
+      return if File.exist?(dest_path)
+      extract_zip_entry(zip_file, entry, dest_dir, relative_dest, dest_path)
     end
 
     def unique_collection_identifier(collection_hash)
@@ -434,16 +533,13 @@ module Bulkrax
     # Override to return the first CSV in the path, if a zip file is supplied
     # We expect a single CSV at the top level of the zip in the CSVParser
     # but we are willing to go look for it if need be
+    # When the user uploaded a zip containing a CSV, the job extracts the
+    # primary CSV to the root of `importer_unzip_path` (see
+    # {#unzip_with_primary_csv}). Any non-primary CSVs live under `files/`
+    # and are treated as attachments, so a shallow glob suffices.
     def real_import_file_path
-      return Dir["#{importer_unzip_path}/**/*.csv"].reject { |path| in_files_dir?(path) }.first if file? && zip?
-
+      return Dir["#{importer_unzip_path}/*.csv"].first if file? && zip?
       parser_fields['import_file_path']
-    end
-
-    # If there are CSVs that are meant to be attachments in the files directory,
-    # we don't want to consider them as the import CSV
-    def in_files_dir?(path)
-      File.dirname(path).ends_with?('files')
     end
   end
 end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  # Raised when a zip cannot be interpreted during CSV import — for example,
-  # when a single upload zip has no CSV or has ambiguous CSVs at its
-  # shallowest level.
-  class UnzipError < StandardError; end
-
   class CsvParser < ApplicationParser # rubocop:disable Metrics/ClassLength
     include ErroredEntries
     include ExportBehavior
@@ -463,7 +458,7 @@ module Bulkrax
     # @see #file_paths
     def remove_spaces_from_filenames
       files = Dir.glob(File.join(importer_unzip_path, 'files', '*'))
-      files_with_spaces = files.select { |f| f.split('/').last.match?(' ') }
+      files_with_spaces = files.select { |f| f.split('/').last.include?(' ') }
       return if files_with_spaces.blank?
 
       files_with_spaces.map! { |path| Pathname.new(path) }

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -315,8 +315,7 @@ de:
           missing_required_hint: Fügen Sie diese Spalte zu Ihrer CSV-Datei hinzu.
           missing_required_title: Fehlende Pflichtfelder
           missing_rights_desc: Ihre CSV-Datei enthält keine Spalte „rights_statement“. Sie können diese entweder Ihrer CSV-Datei hinzufügen oder im nächsten Schritt eine Standard-Rechteerklärung auswählen.
-          multiple_csv_same_dir: Mehrere CSV-Dateien im selben Verzeichnis innerhalb der ZIP-Datei gefunden
-          multiple_csv_same_level: Mehrere CSV-Dateien auf derselben Ebene innerhalb der ZIP-Datei gefunden
+          multiple_csv: Mehrere CSV-Dateien befinden sich auf der obersten Ebene des ZIP-Archivs, sodass die primäre CSV nicht bestimmt werden kann. Belassen Sie genau eine CSV auf dieser Ebene; weitere CSVs müssen tiefer verschachtelt sein.
           no_csv_in_zip: Es wurden keine CSV-Dateien im ZIP-Archiv gefunden.
           no_csv_uploaded: Es wurde keine CSV-Metadatendatei hochgeladen.
           no_files_uploaded: Es wurden keine Dateien hochgeladen.
@@ -346,6 +345,10 @@ de:
           notices_title: Importhinweise
           unrecognized_desc: 'Diese Spalten werden beim Import ignoriert:'
           unrecognized_title: Nicht anerkannte Felder
+      unzip:
+        errors:
+          multiple_csv: Mehrere CSV-Dateien befinden sich auf der obersten Ebene des ZIP-Archivs, sodass die primäre CSV nicht bestimmt werden kann. Belassen Sie genau eine CSV auf dieser Ebene; weitere CSVs müssen tiefer verschachtelt sein.
+          no_csv: Es wurden keine CSV-Dateien im ZIP-Archiv gefunden.
       validations:
         errors_prohibited:
           one: 'Ein Fehler verhinderte das Speichern dieses Importers:'

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -349,6 +349,7 @@ de:
         errors:
           multiple_csv: Mehrere CSV-Dateien befinden sich auf der obersten Ebene des ZIP-Archivs, sodass die primäre CSV nicht bestimmt werden kann. Belassen Sie genau eine CSV auf dieser Ebene; weitere CSVs müssen tiefer verschachtelt sein.
           no_csv: Es wurden keine CSV-Dateien im ZIP-Archiv gefunden.
+          unsafe_entry: "Das ZIP enthält einen Eintrag mit unsicherem Pfad (%{name}). Einträge dürfen weder absolute Pfade noch Referenzen auf übergeordnete Verzeichnisse verwenden."
       validations:
         errors_prohibited:
           one: 'Ein Fehler verhinderte das Speichern dieses Importers:'

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -385,6 +385,7 @@ en:
         errors:
           multiple_csv: Multiple CSV files share the shallowest directory level in the ZIP, so the primary CSV cannot be determined. Keep exactly one CSV at that level; any additional CSVs must be nested deeper.
           no_csv: No CSV file found in the ZIP
+          unsafe_entry: "The ZIP contains an entry with an unsafe path (%{name}). Entries must not use absolute paths or parent-directory references."
       validations:
         errors_prohibited:
           one: '1 error prohibited this importer from being saved:'

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -342,8 +342,7 @@ en:
           missing_required_hint: add this column to your CSV
           missing_required_title: Missing Required Fields
           missing_rights_desc: Your CSV does not include a rights_statement column. You can add it to your CSV or select a Default Rights Statement in the next step.
-          multiple_csv_same_dir: Multiple CSV files found in the same directory within ZIP
-          multiple_csv_same_level: Multiple CSV files found at the same level within ZIP
+          multiple_csv: Multiple CSV files share the shallowest directory level in the ZIP, so the primary CSV cannot be determined. Keep exactly one CSV at that level; any additional CSVs must be nested deeper.
           no_csv_in_zip: No CSV files found in ZIP
           no_csv_uploaded: No CSV metadata file uploaded
           no_files_uploaded: No files uploaded

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -382,6 +382,10 @@ en:
           notices_title: Import Notices
           unrecognized_desc: 'These columns will be ignored during import:'
           unrecognized_title: Unrecognized Fields
+      unzip:
+        errors:
+          multiple_csv: Multiple CSV files share the shallowest directory level in the ZIP, so the primary CSV cannot be determined. Keep exactly one CSV at that level; any additional CSVs must be nested deeper.
+          no_csv: No CSV file found in the ZIP
       validations:
         errors_prohibited:
           one: '1 error prohibited this importer from being saved:'

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -349,6 +349,7 @@ es:
         errors:
           multiple_csv: Hay varios archivos CSV en el nivel menos profundo del ZIP, por lo que no se puede determinar el CSV principal. Mantén exactamente un CSV en ese nivel; cualquier CSV adicional debe estar anidado más profundamente.
           no_csv: No se encontraron archivos CSV en ZIP
+          unsafe_entry: "El ZIP contiene una entrada con una ruta no segura (%{name}). Las entradas no deben usar rutas absolutas ni referencias al directorio padre."
       validations:
         errors_prohibited:
           one: '1 error impidió que se guardara este importador:'

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -315,8 +315,7 @@ es:
           missing_required_hint: Añade esta columna a tu CSV
           missing_required_title: Campos obligatorios faltantes
           missing_rights_desc: Su archivo CSV no incluye la columna "rights_statement". Puede añadirla o seleccionar una "Declaración de derechos predeterminada" en el siguiente paso.
-          multiple_csv_same_dir: Se encontraron varios archivos CSV en el mismo directorio dentro de ZIP
-          multiple_csv_same_level: Se encontraron varios archivos CSV en el mismo nivel dentro de ZIP
+          multiple_csv: Hay varios archivos CSV en el nivel menos profundo del ZIP, por lo que no se puede determinar el CSV principal. Mantén exactamente un CSV en ese nivel; cualquier CSV adicional debe estar anidado más profundamente.
           no_csv_in_zip: No se encontraron archivos CSV en ZIP
           no_csv_uploaded: No se cargó ningún archivo de metadatos CSV
           no_files_uploaded: No hay archivos subidos
@@ -346,6 +345,10 @@ es:
           notices_title: Avisos de importación
           unrecognized_desc: 'Estas columnas se ignorarán durante la importación:'
           unrecognized_title: Campos no reconocidos
+      unzip:
+        errors:
+          multiple_csv: Hay varios archivos CSV en el nivel menos profundo del ZIP, por lo que no se puede determinar el CSV principal. Mantén exactamente un CSV en ese nivel; cualquier CSV adicional debe estar anidado más profundamente.
+          no_csv: No se encontraron archivos CSV en ZIP
       validations:
         errors_prohibited:
           one: '1 error impidió que se guardara este importador:'

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -315,8 +315,7 @@ fr:
           missing_required_hint: Ajoutez cette colonne à votre fichier CSV.
           missing_required_title: Champs obligatoires manquants
           missing_rights_desc: Votre fichier CSV ne contient pas de colonne « droits_statement ». Vous pouvez l'ajouter ou sélectionner une déclaration de droits par défaut à l'étape suivante.
-          multiple_csv_same_dir: Plusieurs fichiers CSV trouvés dans le même répertoire à l'intérieur du fichier ZIP
-          multiple_csv_same_level: Plusieurs fichiers CSV trouvés au même niveau dans le fichier ZIP
+          multiple_csv: Plusieurs fichiers CSV se trouvent au niveau le moins profond dans le ZIP, ce qui empêche d'identifier le CSV principal. Conservez exactement un fichier CSV à ce niveau ; les CSV supplémentaires doivent être imbriqués plus profondément.
           no_csv_in_zip: Aucun fichier CSV trouvé dans le fichier ZIP
           no_csv_uploaded: Aucun fichier de métadonnées CSV n'a été téléchargé.
           no_files_uploaded: Aucun fichier téléchargé
@@ -346,6 +345,10 @@ fr:
           notices_title: Avis d'importation
           unrecognized_desc: 'Ces colonnes seront ignorées lors de l''importation :'
           unrecognized_title: Champs non reconnus
+      unzip:
+        errors:
+          multiple_csv: Plusieurs fichiers CSV se trouvent au niveau le moins profond dans le ZIP, ce qui empêche d'identifier le CSV principal. Conservez exactement un fichier CSV à ce niveau ; les CSV supplémentaires doivent être imbriqués plus profondément.
+          no_csv: Aucun fichier CSV trouvé dans le fichier ZIP
       validations:
         errors_prohibited:
           one: 'Une erreur a empêché l''enregistrement de cet importateur :'

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -349,6 +349,7 @@ fr:
         errors:
           multiple_csv: Plusieurs fichiers CSV se trouvent au niveau le moins profond dans le ZIP, ce qui empêche d'identifier le CSV principal. Conservez exactement un fichier CSV à ce niveau ; les CSV supplémentaires doivent être imbriqués plus profondément.
           no_csv: Aucun fichier CSV trouvé dans le fichier ZIP
+          unsafe_entry: "Le ZIP contient une entrée avec un chemin non sûr (%{name}). Les entrées ne doivent pas utiliser de chemins absolus ni de références au répertoire parent."
       validations:
         errors_prohibited:
           one: 'Une erreur a empêché l''enregistrement de cet importateur :'

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -315,8 +315,7 @@ it:
           missing_required_hint: aggiungi questa colonna al tuo CSV
           missing_required_title: Campi obbligatori mancanti
           missing_rights_desc: Il tuo file CSV non include una colonna rights_statement. Puoi aggiungerla al tuo file CSV o selezionare una colonna "Default Rights Statement" nel passaggio successivo.
-          multiple_csv_same_dir: Sono stati trovati più file CSV nella stessa directory all'interno di ZIP
-          multiple_csv_same_level: Sono stati trovati più file CSV allo stesso livello all'interno dello ZIP
+          multiple_csv: Sono stati trovati più file CSV al livello meno profondo all'interno dello ZIP, quindi non è possibile determinare il CSV principale. Mantieni esattamente un CSV a quel livello; eventuali CSV aggiuntivi devono essere annidati più in profondità.
           no_csv_in_zip: Nessun file CSV trovato nello ZIP
           no_csv_uploaded: Nessun file di metadati CSV caricato
           no_files_uploaded: Nessun file caricato
@@ -346,6 +345,10 @@ it:
           notices_title: Avvisi di importazione
           unrecognized_desc: 'Queste colonne verranno ignorate durante l''importazione:'
           unrecognized_title: Campi non riconosciuti
+      unzip:
+        errors:
+          multiple_csv: Sono stati trovati più file CSV al livello meno profondo all'interno dello ZIP, quindi non è possibile determinare il CSV principale. Mantieni esattamente un CSV a quel livello; eventuali CSV aggiuntivi devono essere annidati più in profondità.
+          no_csv: Nessun file CSV trovato nello ZIP
       validations:
         errors_prohibited:
           one: '1 errore ha impedito il salvataggio di questo importatore:'

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -349,6 +349,7 @@ it:
         errors:
           multiple_csv: Sono stati trovati più file CSV al livello meno profondo all'interno dello ZIP, quindi non è possibile determinare il CSV principale. Mantieni esattamente un CSV a quel livello; eventuali CSV aggiuntivi devono essere annidati più in profondità.
           no_csv: Nessun file CSV trovato nello ZIP
+          unsafe_entry: "Lo ZIP contiene una voce con un percorso non sicuro (%{name}). Le voci non devono utilizzare percorsi assoluti né riferimenti alla directory superiore."
       validations:
         errors_prohibited:
           one: '1 errore ha impedito il salvataggio di questo importatore:'

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -349,6 +349,7 @@ pt-BR:
         errors:
           multiple_csv: Vários arquivos CSV estão no nível menos profundo dentro do ZIP, então não é possível determinar qual é o CSV principal. Mantenha exatamente um CSV nesse nível; CSVs adicionais devem estar aninhados em níveis mais profundos.
           no_csv: Nenhum arquivo CSV encontrado no arquivo ZIP.
+          unsafe_entry: "O ZIP contém uma entrada com caminho inseguro (%{name}). As entradas não devem usar caminhos absolutos nem referências ao diretório pai."
       validations:
         errors_prohibited:
           one: '1 erro impediu que este importador fosse salvo:'

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -315,8 +315,7 @@ pt-BR:
           missing_required_hint: Adicione esta coluna ao seu arquivo CSV.
           missing_required_title: Campos obrigatórios ausentes
           missing_rights_desc: Seu arquivo CSV não inclui uma coluna `rights_statement`. Você pode adicioná-la ao seu CSV ou selecionar uma Declaração de Direitos Padrão na próxima etapa.
-          multiple_csv_same_dir: Vários arquivos CSV encontrados no mesmo diretório dentro do arquivo ZIP.
-          multiple_csv_same_level: Vários arquivos CSV encontrados no mesmo nível dentro do arquivo ZIP.
+          multiple_csv: Vários arquivos CSV estão no nível menos profundo dentro do ZIP, então não é possível determinar qual é o CSV principal. Mantenha exatamente um CSV nesse nível; CSVs adicionais devem estar aninhados em níveis mais profundos.
           no_csv_in_zip: Nenhum arquivo CSV encontrado no arquivo ZIP.
           no_csv_uploaded: Nenhum arquivo de metadados CSV foi carregado.
           no_files_uploaded: Nenhum arquivo foi enviado.
@@ -346,6 +345,10 @@ pt-BR:
           notices_title: Avisos de importação
           unrecognized_desc: 'Estas colunas serão ignoradas durante a importação:'
           unrecognized_title: Campos não reconhecidos
+      unzip:
+        errors:
+          multiple_csv: Vários arquivos CSV estão no nível menos profundo dentro do ZIP, então não é possível determinar qual é o CSV principal. Mantenha exatamente um CSV nesse nível; CSVs adicionais devem estar aninhados em níveis mais profundos.
+          no_csv: Nenhum arquivo CSV encontrado no arquivo ZIP.
       validations:
         errors_prohibited:
           one: '1 erro impediu que este importador fosse salvo:'

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -348,6 +348,7 @@ zh:
         errors:
           multiple_csv: ZIP 文件中的同一最浅层级下发现了多个 CSV 文件，无法确定主 CSV。请在该层级仅保留一个 CSV，其他 CSV 必须位于更深的目录中。
           no_csv: ZIP 文件中未找到 CSV 文件
+          unsafe_entry: "ZIP 文件包含路径不安全的条目（%{name}）。条目不得使用绝对路径或父目录引用。"
       validations:
         errors_prohibited:
           one: 1 个错误导致此导入程序无法保存：

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -314,8 +314,7 @@ zh:
           missing_required_hint: 将此列添加到您的 CSV 文件中
           missing_required_title: 缺少必填字段
           missing_rights_desc: 您的 CSV 文件不包含 rights_statement 列。您可以在下一步中将其添加到 CSV 文件中，或选择默认的权利声明。
-          multiple_csv_same_dir: ZIP 文件中的同一目录下发现了多个 CSV 文件
-          multiple_csv_same_level: 在 ZIP 文件中的同一层级发现了多个 CSV 文件
+          multiple_csv: ZIP 文件中的同一最浅层级下发现了多个 CSV 文件，无法确定主 CSV。请在该层级仅保留一个 CSV，其他 CSV 必须位于更深的目录中。
           no_csv_in_zip: ZIP 文件中未找到 CSV 文件
           no_csv_uploaded: 未上传 CSV 元数据文件。
           no_files_uploaded: 未上传任何文件。
@@ -345,6 +344,10 @@ zh:
           notices_title: 导入通知
           unrecognized_desc: 导入过程中将忽略以下列：
           unrecognized_title: 未识别字段
+      unzip:
+        errors:
+          multiple_csv: ZIP 文件中的同一最浅层级下发现了多个 CSV 文件，无法确定主 CSV。请在该层级仅保留一个 CSV，其他 CSV 必须位于更深的目录中。
+          no_csv: ZIP 文件中未找到 CSV 文件
       validations:
         errors_prohibited:
           one: 1 个错误导致此导入程序无法保存：

--- a/docs/FILE_VALIDATION_FOLLOWUP.md
+++ b/docs/FILE_VALIDATION_FOLLOWUP.md
@@ -1,0 +1,294 @@
+# File Reference Validation — Follow-up Plan
+
+## Context
+
+Guided-import validation currently uses `Bulkrax::CsvTemplate::FileValidator` to
+check whether files referenced in a CSV exist inside an uploaded zip. The check
+compares **basenames only** (`File.basename`), ignoring relative paths.
+
+During the CSV unzip/extraction fix (issue #609, `i609-typeerror-on-unzip`), we
+established that `CsvParser#path_to_files` resolves CSV `file:` column values as
+**relative paths** under `files/`. So a CSV row with `file: "subdir/foo.jpg"`
+requires `importer_unzip_path/files/subdir/foo.jpg` at import time. The
+validator's basename-only comparison misses real errors:
+
+1. **Subdirectory mismatch** — CSV references `subdir_a/foo.jpg`; zip contains
+   `subdir_b/foo.jpg`. Basenames match, validator passes, import 404s.
+2. **Root/nested mismatch** — CSV references `foo.jpg`; zip contains
+   `deep/nested/foo.jpg`. Validator passes, import 404s.
+3. **Ambiguous basenames** — CSV references `foo.jpg`; zip contains both
+   `dir_a/foo.jpg` and `dir_b/foo.jpg`. Validator passes silently.
+4. **Case sensitivity** — `Foo.jpg` vs `foo.jpg` on case-sensitive filesystems
+   (most Hyku deployments).
+
+Validation gives a false-positive "valid" and the job fails later at import
+time with an unhelpful missing-file error.
+
+## Architectural decision
+
+File validation moves from the standalone `CsvTemplate::FileValidator` class
+into the existing `Bulkrax::CsvRow::*` row-validator framework. Reasoning:
+
+- Row validators are pluggable via `Bulkrax.csv_row_validators` — apps can
+  register custom validators. `FileValidator` is hard-referenced in
+  `CsvValidation#run_validations` with no extension point.
+- Row validators produce uniform errors `{row, source_identifier, severity,
+  category, column, value, message, suggestion}` that flow through
+  `StepperResponseFormatter` and `ValidationErrorCsvBuilder` consistently. The
+  current `FileValidator` has a parallel code path and a different output
+  shape (flat `missingFiles` basename list with no row attribution).
+- Per-row errors are strictly more informative than aggregated basename lists:
+  users see which row references which missing file, not just the union.
+- Path-awareness is natural: each row validator sees `record[:file]` and can
+  compare full relative paths against a shared plan passed in via `context`.
+
+## Prerequisites from the extraction fix
+
+The extraction fix (prior work on this branch) introduces a placement planner
+that, given a zip's entry list and a mode (`primary_csv` vs
+`attachments_only`), returns a mapping of `zip_entry_name →
+post_extraction_relative_path`. The planner is shared by:
+
+- `CsvParser#unzip_with_primary_csv` / `#unzip_attachments_only` — execute the
+  plan by extracting each entry to its planned path.
+- This follow-up — predicts the set of relative paths that will be available
+  under `files/`, for validation.
+
+The planner exposes a read-only method (shape tbd) like:
+
+```ruby
+plan.available_paths  # => Set<String> of relative paths under files/
+                       #    e.g. #<Set: {"foo.jpg", "subdir/bar.pdf"}>
+```
+
+If the extraction fix lands without a named planner class (inline logic in
+`CsvParser#unzip_*`), the first step of this follow-up is to extract it.
+
+## Plan
+
+### 1. Extract or expose the placement planner
+
+Ensure the zip-placement logic is accessible from outside the unzip methods.
+Expected interface:
+
+```ruby
+plan = Bulkrax::ZipPlacementPlanner.plan(zip_file_path, mode: :primary_csv)
+plan.primary_csv_entry     # => Zip::Entry or nil
+plan.available_paths       # => Set<String> relative paths that will exist under files/
+plan.errors                # => Array<Symbol> of error codes: :no_csv, :multiple_csv_same_level, ...
+```
+
+Modes:
+- `:primary_csv` — zip contains the CSV. Applies shallowest-CSV rule.
+- `:attachments_only` — zip has no CSV. Applies single-top-level-wrapper strip.
+
+Errors from the planner (e.g. multi-CSV-at-shallowest) become validation
+errors in the new flow — they're the same errors `locate_csv_entry_in_zip`
+raises today.
+
+### 2. Build `context[:zip_plan]`
+
+In `CsvValidation#run_row_validators`, build `zip_plan` once per validation
+run and add it to the context hash. The planner runs once; every row uses the
+same plan.
+
+```ruby
+context[:zip_plan] = zip_file ? Bulkrax::ZipPlacementPlanner.plan(zip_file.path, mode: inferred_mode) : nil
+```
+
+Mode is inferred from the upload shape:
+- User uploaded CSV + zip → `:attachments_only`.
+- User uploaded zip only → `:primary_csv`.
+
+### 3. Add `Bulkrax::CsvRow::FileReference` row validator
+
+New file: `app/validators/bulkrax/csv_row/file_reference.rb`.
+
+```ruby
+module Bulkrax
+  module CsvRow
+    module FileReference
+      def self.call(record, row_index, context)
+        plan = context[:zip_plan]
+        return if plan.nil?  # no zip uploaded
+
+        value = record[:file]
+        return if value.blank?
+
+        value.split(Bulkrax.multi_value_element_split_on).each do |raw|
+          path = raw.strip
+          next if path.blank?
+          next if plan.available_paths.include?(path)
+
+          context[:errors] << missing_file_error(record, row_index, path, plan)
+        end
+      end
+
+      # emits either :missing_file_reference or :ambiguous_basename depending
+      # on whether `path` is a bare basename that matches multiple entries
+      def self.missing_file_error(...); end
+    end
+  end
+end
+```
+
+Register in defaults at [lib/bulkrax.rb](../lib/bulkrax.rb#L182):
+
+```ruby
+def csv_row_validators
+  @csv_row_validators ||= [
+    Bulkrax::CsvRow::MissingSourceIdentifier,
+    Bulkrax::CsvRow::DuplicateIdentifier,
+    Bulkrax::CsvRow::ParentReference,
+    Bulkrax::CsvRow::ChildReference,
+    Bulkrax::CsvRow::CircularReference,
+    Bulkrax::CsvRow::RequiredValues,
+    Bulkrax::CsvRow::ControlledVocabulary,
+    Bulkrax::CsvRow::FileReference   # ← new
+  ]
+end
+```
+
+### 4. Handle distinct error categories
+
+Emit different `category:` values so the UI and error CSV can distinguish:
+
+- `missing_file_reference` — path not found in plan.
+- `ambiguous_basename` — CSV used a bare basename that matches multiple
+  entries in the plan under different paths.
+- `case_mismatch` — plan has a matching path with different casing.
+  (Optional — costs a second scan; decide based on user demand.)
+
+Each category gets its own i18n entry under
+`bulkrax.importer.guided_import.validation.file_reference_validator.errors.*`.
+
+### 5. Retire `CsvTemplate::FileValidator`
+
+Delete `app/services/bulkrax/csv_template/file_validator.rb` or reduce to a
+stats helper that answers:
+
+- `zip_included?`
+- `count_references` (how many rows reference files, regardless of missing)
+
+These are run-level observations, not validation errors. Keep as a small
+helper; remove the `missing_files` / `possible_missing_files?` /
+`found_files_count` methods, which are superseded by row errors.
+
+Update [csv_validation.rb:54](../app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb#L54)
+to stop instantiating `FileValidator` for correctness purposes. The
+`assemble_result` call that currently passes `file_validator:` downstream
+either drops the key or retains it for the stats it still produces.
+
+### 6. Update `StepperResponseFormatter`
+
+Current special handling at [stepper_response_formatter.rb:238-261](../app/services/bulkrax/stepper_response_formatter.rb#L238-L261):
+
+```ruby
+missing_files = @data[:missingFiles] || []
+if missing_files.any? && @data[:zipIncluded]
+  missing_files_issue
+  ...
+```
+
+This block either goes away (errors flow through normal row-errors pipe) or
+becomes a derived summary ("N rows reference missing files") computed from
+grouping row errors with `category: 'missing_file_reference'`. Decide based on
+UI needs — per-row errors are clearer, but an aggregate "N files missing"
+headline may still be wanted for quick scan.
+
+### 7. Update `ValidationErrorCsvBuilder`
+
+The builder already handles row errors uniformly
+([validation_error_csv_builder.rb:92](../app/services/bulkrax/validation_error_csv_builder.rb#L92)).
+Missing-file errors now arrive as row errors, so the CSV output should
+automatically include them. Verify via spec.
+
+Remove the special `missing_files` handling at line 92 if it was reading from
+the old flat list.
+
+### 8. "No zip but files referenced" warning
+
+Keep this as a run-level **notice**, not a row error. Similar to
+`append_missing_model_notice!`:
+
+```ruby
+def append_missing_zip_notice!(notices, csv_data)
+  return if csv_data.none? { |r| r[:file].present? }
+  return if zip_present?
+  notices << {
+    field: 'file',
+    category: 'files_referenced_no_zip',
+    message: I18n.t(...)
+  }
+end
+```
+
+Called from `run_validations` before the row loop runs.
+
+### 9. Spec coverage
+
+New spec files:
+- `spec/validators/bulkrax/csv_row/file_reference_spec.rb` — unit coverage for
+  the new row validator, covering:
+  - No zip plan → no errors (nothing to validate against).
+  - Simple basename match in plan → no error.
+  - Path match in plan → no error.
+  - Path mismatch → error with category `missing_file_reference`.
+  - Multi-value cell with one missing → one error for the missing value.
+  - Ambiguous basename → error with category `ambiguous_basename`.
+  - Case mismatch (if implemented) → error with category `case_mismatch`.
+- `spec/services/bulkrax/zip_placement_planner_spec.rb` — unit coverage for
+  the planner, assuming it was extracted as a standalone class by the
+  extraction fix.
+
+Update existing:
+- `spec/parsers/concerns/bulkrax/csv_parser/csv_validation_spec.rb` — end-to-end
+  flows using the new row validator.
+- `spec/services/bulkrax/stepper_response_formatter_spec.rb` — adjust to new
+  formatter output.
+- `spec/services/bulkrax/validation_error_csv_builder_spec.rb` — verify
+  missing-file errors appear in the CSV output.
+
+Delete:
+- `spec/services/bulkrax/csv_template/file_validator_spec.rb` (or pare down to
+  match the reduced helper, if kept).
+
+### 10. Backwards compatibility
+
+Apps overriding `Bulkrax.csv_row_validators` to a custom array will not pick
+up the new validator automatically. Document in the changelog:
+
+> To get file-reference validation, append
+> `Bulkrax::CsvRow::FileReference` to your custom `csv_row_validators` array,
+> or call `Bulkrax.register_csv_row_validator(Bulkrax::CsvRow::FileReference)`.
+
+Apps relying on `result[:missingFiles]` in the validation response need to
+migrate to reading row errors with `category: 'missing_file_reference'`. Call
+out in release notes.
+
+## Effort estimate
+
+- Placement planner extraction (if not done by extraction fix): 2-3 hours.
+- Row validator + registration + i18n: 2-3 hours.
+- Stepper/CsvBuilder updates: 1-2 hours.
+- Spec coverage: 3-4 hours.
+- **Total: roughly 1 day**, assuming the extraction fix has already produced
+  a shareable placement planner.
+
+## Out of scope for this follow-up
+
+- Validation of file *contents* (size, checksum, format).
+- Validation that the zip itself is a valid archive — already handled
+  upstream.
+- Cloud-files flow — `retrieve_cloud_files` places files directly into
+  `files/` at upload time, no zip plan involved. If cloud-files need path
+  validation, that's a separate piece.
+
+## Open questions to resolve before implementing
+
+1. Does the placement planner emerge as a named class from the extraction
+   fix, or does it need to be factored out as step 1 of this follow-up?
+2. Does the UI want to keep an aggregate "N files missing" headline, or go
+   fully row-by-row?
+3. Should `case_mismatch` be its own category, or lumped into
+   `missing_file_reference` with a more specific message?

--- a/spec/controllers/concerns/bulkrax/importer_file_handler_spec.rb
+++ b/spec/controllers/concerns/bulkrax/importer_file_handler_spec.rb
@@ -94,63 +94,63 @@ RSpec.describe Bulkrax::ImporterFileHandler do
       end
     end
 
+    # The cases below all fail the same constraint — the CSV at the shallowest
+    # depth in the zip must be unique — and surface the same error message.
+    # Kept as separate contexts so we exercise each structural shape that
+    # triggers the ambiguity.
+    shared_examples 'ambiguous primary CSV' do
+      it 'returns an error indicating multiple CSVs share the shallowest level' do
+        open_zip do |zip|
+          result = controller.locate_csv_entry_in_zip(zip)
+          expect(result[:messages][:validationStatus][:severity]).to eq('error')
+          expect(result[:messages][:validationStatus][:summary]).to match(/multiple CSV/i)
+        end
+      end
+    end
+
     context 'with multiple CSVs at the same root level' do
-      it 'returns an error' do
+      before do
         Zip::File.open(zip_file.path, create: true) do |zip|
           zip.get_output_stream('data1.csv') { |f| f.write('csv 1') }
           zip.get_output_stream('data2.csv') { |f| f.write('csv 2') }
         end
-
-        open_zip do |zip|
-          result = controller.locate_csv_entry_in_zip(zip)
-          expect(result[:messages][:validationStatus][:severity]).to eq('error')
-          expect(result[:messages][:validationStatus][:summary]).to include('Multiple CSV files found in the same directory within ZIP')
-        end
       end
+
+      include_examples 'ambiguous primary CSV'
     end
 
     context 'with multiple CSVs in different directories at the same depth' do
-      it 'returns an error' do
+      before do
         Zip::File.open(zip_file.path, create: true) do |zip|
           zip.get_output_stream('dir1/data.csv') { |f| f.write('csv 1') }
           zip.get_output_stream('dir2/metadata.csv') { |f| f.write('csv 2') }
-        end
-
-        open_zip do |zip|
-          result = controller.locate_csv_entry_in_zip(zip)
-          expect(result[:messages][:validationStatus][:severity]).to eq('error')
-          expect(result[:messages][:validationStatus][:summary]).to include('Multiple CSV files found at the same level')
         end
       end
 
-      it 'returns an error with three CSVs across different directories' do
-        Zip::File.open(zip_file.path, create: true) do |zip|
-          zip.get_output_stream('dir1/data.csv') { |f| f.write('csv 1') }
-          zip.get_output_stream('dir2/metadata.csv') { |f| f.write('csv 2') }
-          zip.get_output_stream('dir3/info.csv') { |f| f.write('csv 3') }
+      include_examples 'ambiguous primary CSV'
+
+      context 'with three CSVs across different directories' do
+        before do
+          Zip::File.open(zip_file.path, create: true) do |zip|
+            zip.get_output_stream('dir1/data.csv') { |f| f.write('csv 1') }
+            zip.get_output_stream('dir2/metadata.csv') { |f| f.write('csv 2') }
+            zip.get_output_stream('dir3/info.csv') { |f| f.write('csv 3') }
+          end
         end
 
-        open_zip do |zip|
-          result = controller.locate_csv_entry_in_zip(zip)
-          expect(result[:messages][:validationStatus][:severity]).to eq('error')
-          expect(result[:messages][:validationStatus][:summary]).to include('Multiple CSV files found at the same level')
-        end
+        include_examples 'ambiguous primary CSV'
       end
     end
 
     context 'with multiple CSVs in the same subdirectory' do
-      it 'returns an error' do
+      before do
         Zip::File.open(zip_file.path, create: true) do |zip|
           zip.get_output_stream('data/file1.csv') { |f| f.write('csv 1') }
           zip.get_output_stream('data/file2.csv') { |f| f.write('csv 2') }
         end
-
-        open_zip do |zip|
-          result = controller.locate_csv_entry_in_zip(zip)
-          expect(result[:messages][:validationStatus][:severity]).to eq('error')
-          expect(result[:messages][:validationStatus][:summary]).to include('Multiple CSV files found in the same directory within ZIP')
-        end
       end
+
+      include_examples 'ambiguous primary CSV'
     end
 
     context 'with edge cases' do

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -99,6 +99,12 @@ module Bulkrax
     describe '#unzip_imported_file dispatch' do
       let(:job) { described_class.new }
 
+      # Memoized per example so the helpers below return the same path
+      # consistently, and so the `after` hook cleans up exactly one dir
+      # per example rather than leaving a trail of stray tmpdirs.
+      let(:unzip_tmpdir) { Dir.mktmpdir }
+      after { FileUtils.rm_rf(unzip_tmpdir) }
+
       # Shared setup for CsvParser-backed doubles. Not pulled out to a
       # `before` block at the `describe` level because one of the contexts
       # below uses an XmlParser double, and `instance_double` would reject
@@ -106,13 +112,13 @@ module Bulkrax
       # `#remove_spaces_from_filenames`).
       def stub_csv_parser_defaults(parser)
         allow(parser).to receive(:file?).and_return(true)
-        allow(parser).to receive(:importer_unzip_path).and_return(Dir.mktmpdir)
+        allow(parser).to receive(:importer_unzip_path).and_return(unzip_tmpdir)
         allow(parser).to receive(:remove_spaces_from_filenames)
       end
 
       def stub_xml_parser_defaults(parser)
         allow(parser).to receive(:file?).and_return(true)
-        allow(parser).to receive(:importer_unzip_path).and_return(Dir.mktmpdir)
+        allow(parser).to receive(:importer_unzip_path).and_return(unzip_tmpdir)
       end
 
       context 'when the parser is a CsvParser with a zip upload' do

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -62,6 +62,33 @@ module Bulkrax
           importer_job.perform(importer.id)
         end
       end
+
+      context 'when the zip cannot be interpreted (e.g. no CSV inside)' do
+        let(:zip_tmp) { Tempfile.new(['import', '.zip']) }
+        let(:importer) do
+          FactoryBot.create(:bulkrax_importer_csv, parser_fields: { 'import_file_path' => zip_tmp.path })
+        end
+
+        before do
+          Zip::File.open(zip_tmp.path, create: true) do |z|
+            z.get_output_stream('foo.jpg') { |f| f.write('jpg-bytes') }
+          end
+          zip_tmp.close
+        end
+
+        after { zip_tmp.unlink }
+
+        it 'rescues the UnzipError and sets the importer status to Failed' do
+          importer_job.perform(importer.id)
+          expect(importer.reload.status).to eq('Failed')
+        end
+
+        it 'records the error message on the importer status' do
+          importer_job.perform(importer.id)
+          expect(importer.reload.current_status.error_message).to match(/no csv/i)
+          expect(importer.current_status.error_class).to eq('Bulkrax::UnzipError')
+        end
+      end
     end
 
     describe 'schedulable' do

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -91,6 +91,134 @@ module Bulkrax
       end
     end
 
+    # Dispatch tests for `#unzip_imported_file`. The full extraction
+    # contracts are pinned in spec/parsers/bulkrax/csv_parser/unzip_spec.rb
+    # and spec/parsers/bulkrax/application_parser_spec.rb; these specs
+    # verify that the job calls the right method on the right parser for
+    # each upload shape and parser type.
+    describe '#unzip_imported_file dispatch' do
+      let(:job) { described_class.new }
+
+      # Shared setup for CsvParser-backed doubles. Not pulled out to a
+      # `before` block at the `describe` level because one of the contexts
+      # below uses an XmlParser double, and `instance_double` would reject
+      # stubs for methods XmlParser doesn't implement (e.g.
+      # `#remove_spaces_from_filenames`).
+      def stub_csv_parser_defaults(parser)
+        allow(parser).to receive(:file?).and_return(true)
+        allow(parser).to receive(:importer_unzip_path).and_return(Dir.mktmpdir)
+        allow(parser).to receive(:remove_spaces_from_filenames)
+      end
+
+      def stub_xml_parser_defaults(parser)
+        allow(parser).to receive(:file?).and_return(true)
+        allow(parser).to receive(:importer_unzip_path).and_return(Dir.mktmpdir)
+      end
+
+      context 'when the parser is a CsvParser with a zip upload' do
+        let(:parser) { instance_double('Bulkrax::CsvParser') }
+
+        it 'calls #unzip_with_primary_csv' do
+          stub_csv_parser_defaults(parser)
+          allow(parser).to receive(:zip?).and_return(true)
+          allow(parser).to receive(:parser_fields).and_return('import_file_path' => '/tmp/bundle.zip')
+
+          expect(parser).to receive(:unzip_with_primary_csv).with('/tmp/bundle.zip')
+
+          job.send(:unzip_imported_file, parser)
+        end
+      end
+
+      context 'when the parser is a CsvParser with a CSV + separate attachments zip' do
+        let(:parser) { instance_double('Bulkrax::CsvParser') }
+
+        it 'copies the CSV then calls #unzip_attachments_only' do
+          stub_csv_parser_defaults(parser)
+          allow(parser).to receive(:zip?).and_return(false)
+          allow(parser).to receive(:zip_file?).with('/tmp/attach.zip').and_return(true)
+          allow(parser).to receive(:parser_fields).and_return(
+            'import_file_path' => '/tmp/metadata.csv',
+            'attachments_zip_path' => '/tmp/attach.zip'
+          )
+
+          expect(parser).to receive(:copy_file).with('/tmp/metadata.csv').ordered
+          expect(parser).to receive(:unzip_attachments_only).with('/tmp/attach.zip').ordered
+
+          job.send(:unzip_imported_file, parser)
+        end
+      end
+
+      context 'when the parser is CSV-only (no zip at all)' do
+        let(:parser) { instance_double('Bulkrax::CsvParser') }
+
+        it 'just copies the CSV' do
+          stub_csv_parser_defaults(parser)
+          allow(parser).to receive(:zip?).and_return(false)
+          allow(parser).to receive(:zip_file?).with(nil).and_return(false)
+          allow(parser).to receive(:parser_fields).and_return('import_file_path' => '/tmp/metadata.csv')
+
+          expect(parser).to receive(:copy_file).with('/tmp/metadata.csv')
+
+          job.send(:unzip_imported_file, parser)
+        end
+      end
+
+      context 'when the parser does not implement CSV-specific unzip methods (e.g. XmlParser)' do
+        # XmlParser inherits `#unzip` from ApplicationParser for verbatim
+        # extraction. It must not receive `#unzip_with_primary_csv`, which
+        # only exists on CsvParser. XmlParser also doesn't implement
+        # `#remove_spaces_from_filenames`, so the `respond_to?` guard in
+        # the job skips that post-step.
+        let(:parser) { instance_double('Bulkrax::XmlParser') }
+
+        it 'falls back to verbatim #unzip for a zip upload' do
+          stub_xml_parser_defaults(parser)
+          allow(parser).to receive(:zip?).and_return(true)
+          allow(parser).to receive(:parser_fields).and_return('import_file_path' => '/tmp/bundle.zip')
+
+          expect(parser).to receive(:unzip).with('/tmp/bundle.zip')
+
+          job.send(:unzip_imported_file, parser)
+        end
+
+        it 'never takes the attachments-zip branch for an XML parser' do
+          stub_xml_parser_defaults(parser)
+          allow(parser).to receive(:zip?).and_return(false)
+          # An XmlParser would never have `attachments_zip_path` set in
+          # practice, but guard anyway — the branch should be skipped
+          # because the parser doesn't respond to `#unzip_attachments_only`.
+          allow(parser).to receive(:parser_fields).and_return(
+            'import_file_path' => '/tmp/metadata.xml',
+            'attachments_zip_path' => '/tmp/attach.zip'
+          )
+
+          expect(parser).to receive(:copy_file).with('/tmp/metadata.xml')
+
+          job.send(:unzip_imported_file, parser)
+        end
+      end
+
+      context 'when the parser is a BagitParser with a zip upload' do
+        # BagitParser < CsvParser, so it inherits `#unzip_with_primary_csv`.
+        # But BagIt archives do not contain a primary CSV — the method is
+        # overridden on BagitParser to delegate to verbatim `#unzip`. The
+        # job dispatches to the overridden method, which ends up calling
+        # `#unzip` under the hood. We verify by stubbing `#unzip` on the
+        # double and expecting the override to forward to it.
+        let(:parser) { instance_double('Bulkrax::BagitParser') }
+
+        it 'receives unzip_with_primary_csv which ultimately extracts verbatim via #unzip' do
+          stub_csv_parser_defaults(parser)
+          allow(parser).to receive(:zip?).and_return(true)
+          allow(parser).to receive(:parser_fields).and_return('import_file_path' => '/tmp/bag.zip')
+
+          expect(parser).to receive(:unzip_with_primary_csv).with('/tmp/bag.zip')
+
+          job.send(:unzip_imported_file, parser)
+        end
+      end
+    end
+
     describe 'schedulable' do
       before do
         allow(importer).to receive(:schedulable?).and_return(true)

--- a/spec/models/bulkrax/importer_spec.rb
+++ b/spec/models/bulkrax/importer_spec.rb
@@ -107,21 +107,10 @@ module Bulkrax
       end
     end
 
-    describe '#importer_unzip_path' do
-      context 'when parser_fields import_file_path is a string path to an existing zip file' do
-        it 'returns the directory containing the zip file' do
-          zip_tmp = Tempfile.new(['import', '.zip'])
-          zip_path = zip_tmp.path
-          Zip::File.open(zip_path, create: true) { |z| z.get_output_stream('dummy') { |f| f.write('x') } }
-          zip_tmp.close
-
-          importer = FactoryBot.build(:bulkrax_importer_csv, parser_fields: { 'import_file_path' => zip_path })
-          expect(importer.importer_unzip_path).to eq(File.dirname(zip_path))
-        ensure
-          zip_tmp&.unlink
-        end
-      end
-    end
+    # NOTE: the full contract for `#importer_unzip_path` lives in
+    # spec/parsers/bulkrax/csv_parser/unzip_spec.rb alongside the CsvParser
+    # extraction specs, where it can be exercised against real filesystem
+    # behavior.
 
     describe '#original_files' do
       let(:csv_file) { Tempfile.new(['metadata', '.csv']) }

--- a/spec/parsers/bulkrax/application_parser_spec.rb
+++ b/spec/parsers/bulkrax/application_parser_spec.rb
@@ -201,6 +201,23 @@ module Bulkrax
           end
         end
       end
+
+      # Zip Slip defense — a malicious zip entry with `..` must not write
+      # outside the extraction directory. Base-class unzip is inherited
+      # by BagIt and any other parsers, so this defense protects them too.
+      context 'when the zip contains a path-traversal entry (..)' do
+        it 'raises UnzipError and writes nothing outside the extraction dir' do
+          outside_dir = File.realpath(Dir.mktmpdir)
+          with_zip('data.csv' => 'title', "../#{File.basename(outside_dir)}/evil.txt" => 'pwned') do |zip_path|
+            expect { parser.unzip(zip_path) }
+              .to raise_error(Bulkrax::UnzipError, /unsafe/i)
+
+            expect(File).not_to exist(File.join(outside_dir, 'evil.txt'))
+          end
+        ensure
+          FileUtils.rm_rf(outside_dir) if outside_dir
+        end
+      end
     end
 
     describe '#macos_junk_entry?' do

--- a/spec/parsers/bulkrax/application_parser_spec.rb
+++ b/spec/parsers/bulkrax/application_parser_spec.rb
@@ -124,43 +124,9 @@ module Bulkrax
       end
     end
 
-    describe '#remove_spaces_from_filenames' do
-      let(:parser) { described_class.new(importer) }
-      let(:before_filenames) { ['spec/fixtures/csv/files/no_space.jpg', 'spec/fixtures/csv/files/has space.jpg'] }
-      let(:after_filenames) { ['spec/fixtures/csv/files/no_space.jpg', 'spec/fixtures/csv/files/has_space.jpg'] }
-
-      before do
-        before_filenames.each do |file_path|
-          File.write(file_path, 'w')
-        end
-
-        allow(Dir).to receive(:glob).and_return(before_filenames)
-      end
-
-      after do
-        after_filenames.each do |file_path|
-          File.delete(file_path)
-        end
-      end
-
-      it 'renames files to replace spaces with underscores' do
-        expect(File.exist?('spec/fixtures/csv/files/has space.jpg')).to eq(true)
-        expect(File.exist?('spec/fixtures/csv/files/has_space.jpg')).to eq(false)
-
-        parser.remove_spaces_from_filenames
-
-        expect(File.exist?('spec/fixtures/csv/files/has space.jpg')).to eq(false)
-        expect(File.exist?('spec/fixtures/csv/files/has_space.jpg')).to eq(true)
-      end
-
-      it 'does not alter files that do not have spaces in their name' do
-        expect(File.exist?('spec/fixtures/csv/files/no_space.jpg')).to eq(true)
-
-        parser.remove_spaces_from_filenames
-
-        expect(File.exist?('spec/fixtures/csv/files/no_space.jpg')).to eq(true)
-      end
-    end
+    # NOTE: `#remove_spaces_from_filenames` is a CSV-specific concern and
+    # now lives on `Bulkrax::CsvParser`. Its contract is exercised in
+    # spec/parsers/bulkrax/csv_parser/unzip_spec.rb.
 
     describe '#unzip' do
       let(:parser)    { described_class.new(importer) }
@@ -189,21 +155,24 @@ module Bulkrax
         zip_file.close!
       end
 
-      context 'when the zip contains a top-level wrapper directory (directory zipped, not contents)' do
-        it 'extracts files directly into the unzip path, stripping the wrapper directory' do
+      # The base-class `#unzip` is a verbatim extraction: it preserves the
+      # zip's internal structure and only filters macOS junk. Parser
+      # subclasses that need to interpret the archive (e.g. CsvParser's
+      # `#unzip_with_primary_csv`) do their own extraction.
+      context 'when the zip contains a top-level wrapper directory' do
+        it 'preserves the wrapper directory in the extracted paths' do
           with_zip('directory/data.csv' => 'title,identifier',
                    'directory/files/a.jpg' => 'jpg-content') do |zip_path|
             parser.unzip(zip_path)
 
-            expect(File.exist?(File.join(unzip_dir, 'data.csv'))).to be true
-            expect(File.exist?(File.join(unzip_dir, 'files', 'a.jpg'))).to be true
-            expect(File.exist?(File.join(unzip_dir, 'directory', 'data.csv'))).to be false
+            expect(File.exist?(File.join(unzip_dir, 'directory', 'data.csv'))).to be true
+            expect(File.exist?(File.join(unzip_dir, 'directory', 'files', 'a.jpg'))).to be true
           end
         end
       end
 
-      context 'when the zip contains files at the root (contents zipped, not directory)' do
-        it 'extracts files directly into the unzip path without stripping any prefix' do
+      context 'when the zip contains files at the root' do
+        it 'extracts files directly into the unzip path' do
           with_zip('data.csv' => 'title,identifier',
                    'files/a.jpg' => 'jpg-content') do |zip_path|
             parser.unzip(zip_path)
@@ -216,13 +185,13 @@ module Bulkrax
 
       context 'when the zip contains macOS junk entries (__MACOSX, .DS_Store, ._files)' do
         it 'skips junk entries and extracts only real files' do
-          with_zip('directory/data.csv' => 'title,identifier',
-                   'directory/.DS_Store' => 'junk',
-                   'directory/files/a.jpg' => 'jpg-content',
-                   '__MACOSX/directory/._.DS_Store' => 'junk',
-                   '__MACOSX/directory/._data.csv' => 'junk',
-                   '__MACOSX/directory/._files' => 'junk',
-                   '__MACOSX/directory/files/._a.jpg' => 'junk') do |zip_path|
+          with_zip('data.csv' => 'title,identifier',
+                   '.DS_Store' => 'junk',
+                   'files/a.jpg' => 'jpg-content',
+                   '__MACOSX/._.DS_Store' => 'junk',
+                   '__MACOSX/._data.csv' => 'junk',
+                   '__MACOSX/._files' => 'junk',
+                   '__MACOSX/files/._a.jpg' => 'junk') do |zip_path|
             parser.unzip(zip_path)
 
             expect(File.exist?(File.join(unzip_dir, 'data.csv'))).to be true

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -269,6 +269,23 @@ module Bulkrax
             end
           end
         end
+
+        # BagitParser inherits `#unzip_with_primary_csv` and
+        # `#unzip_attachments_only` from CsvParser, but BagIt archives
+        # don't contain a primary CSV at a shallowest level. BagitParser
+        # overrides both to delegate to the base-class verbatim `#unzip`,
+        # preserving the BagIt layout (bagit.txt + data/ + manifests).
+        describe 'CSV-flavored unzip overrides' do
+          it '#unzip_with_primary_csv delegates to verbatim #unzip' do
+            expect(subject).to receive(:unzip).with('/tmp/bag.zip')
+            subject.unzip_with_primary_csv('/tmp/bag.zip')
+          end
+
+          it '#unzip_attachments_only delegates to verbatim #unzip' do
+            expect(subject).to receive(:unzip).with('/tmp/bag.zip')
+            subject.unzip_attachments_only('/tmp/bag.zip')
+          end
+        end
       end
     end
 

--- a/spec/parsers/bulkrax/csv_parser/unzip_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/unzip_spec.rb
@@ -1,0 +1,380 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Consolidated contract for CSV import unzip / file placement.
+#
+# - `Bulkrax::Importer#importer_unzip_path` always returns
+#   `File.join(parser.base_path, "import_#{path_string}")`, creates the dir
+#   on `mkdir: true`, never returns nil, and is stable across calls.
+#
+# - `Bulkrax::CsvParser#unzip_with_primary_csv(zip_path)` (Case 3: single zip
+#   containing a CSV) extracts the primary CSV to
+#   `importer_unzip_path/{basename}` and every other entry to
+#   `importer_unzip_path/files/{path_relative_to_primary_csv_dir}`.
+#
+# - `Bulkrax::CsvParser#unzip_attachments_only(zip_path)` (Case 2: separate
+#   attachments zip accompanying an uploaded CSV) extracts every entry to
+#   `importer_unzip_path/files/{path}`, stripping a single top-level wrapper
+#   directory if present. CSVs inside the zip are treated as ordinary
+#   attachments since the primary CSV was uploaded separately.
+#
+# These specs use real zip files in tmpdirs — `importer_unzip_path` is
+# stubbed to a tmpdir (not to a dummy value) so `unzip_*` methods can
+# actually write to the filesystem and we verify the resulting layout.
+#
+# Error cases use `raise_error` assertions — failures must be visible, not
+# silent.
+RSpec.describe Bulkrax::CsvParser do
+  let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
+  subject(:parser) { described_class.new(importer) }
+
+  # Each spec gets a fresh unzip_path backing directory.
+  let(:unzip_dir) { File.realpath(Dir.mktmpdir) }
+  before do
+    dir = unzip_dir
+    importer.define_singleton_method(:importer_unzip_path) do |mkdir: false|
+      FileUtils.mkdir_p(dir) if mkdir
+      dir
+    end
+  end
+  after { FileUtils.rm_rf(unzip_dir) }
+
+  # Builds a zip file with the given entries at `zip_path`.
+  # `entries` is a Hash<String, String> mapping `entry_name => content`.
+  def build_zip(zip_path, entries)
+    Zip::File.open(zip_path, create: true) do |zip|
+      entries.each do |name, content|
+        next if name.end_with?('/')
+        zip.get_output_stream(name) { |f| f.write(content) }
+      end
+    end
+  end
+
+  # Builds a temporary zip, yields its path, and cleans up afterward.
+  def with_zip(entries)
+    zip_file = Tempfile.new(['import', '.zip'])
+    build_zip(zip_file.path, entries)
+    yield zip_file.path
+  ensure
+    zip_file&.close!
+  end
+
+  describe '#unzip_with_primary_csv' do
+    context 'flat zip: {metadata.csv, foo.jpg}' do
+      it 'places the CSV at the unzip root and files under files/' do
+        with_zip('metadata.csv' => 'header1,header2', 'foo.jpg' => 'jpg-bytes') do |zip_path|
+          parser.unzip_with_primary_csv(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'metadata.csv'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+          expect(File).not_to exist(File.join(unzip_dir, 'foo.jpg'))
+        end
+      end
+    end
+
+    context 'zip containing only a CSV (the staging bug — zip has no files alongside)' do
+      # Regression coverage for the TypeError reported on staging:
+      # `all_generic_no_files9.zip` contained only a CSV. The old
+      # `normalize_unzipped_files_structure` moved the source zip into
+      # files/, which broke the next `importer_unzip_path` call.
+      it 'places the CSV at the unzip root and creates no files/ directory' do
+        with_zip('metadata.csv' => 'header1,header2') do |zip_path|
+          parser.unzip_with_primary_csv(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'metadata.csv'))
+          expect(File).not_to exist(File.join(unzip_dir, 'files'))
+        end
+      end
+    end
+
+    context 'zip with a single wrapper directory: {wrapper/metadata.csv, wrapper/files/foo.jpg}' do
+      it 'strips the wrapper, placing the CSV at root and preserving files/ structure' do
+        with_zip('wrapper/metadata.csv' => 'h1,h2', 'wrapper/files/foo.jpg' => 'jpg') do |zip_path|
+          parser.unzip_with_primary_csv(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'metadata.csv'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+        end
+      end
+    end
+
+    context 'zip with a wrapper and nested non-files: {wrapper/metadata.csv, wrapper/subdir/foo.jpg}' do
+      it 'places the CSV at root; non-primary entries land under files/ preserving relative structure' do
+        with_zip('wrapper/metadata.csv' => 'h1,h2', 'wrapper/subdir/foo.jpg' => 'jpg') do |zip_path|
+          parser.unzip_with_primary_csv(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'metadata.csv'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'subdir', 'foo.jpg'))
+        end
+      end
+    end
+
+    context 'zip with CSV at root + files in subdir: {metadata.csv, files/foo.jpg}' do
+      it 'places the CSV at root and preserves files/ layout' do
+        with_zip('metadata.csv' => 'h1,h2', 'files/foo.jpg' => 'jpg') do |zip_path|
+          parser.unzip_with_primary_csv(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'metadata.csv'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+        end
+      end
+    end
+
+    context 'zip with primary CSV plus deeper non-primary CSVs: {wrapper/metadata.csv, wrapper/nested/other.csv}' do
+      it 'treats only the shallowest CSV as primary; deeper CSVs go under files/' do
+        with_zip('wrapper/metadata.csv' => 'primary', 'wrapper/nested/other.csv' => 'other') do |zip_path|
+          parser.unzip_with_primary_csv(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'metadata.csv'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'nested', 'other.csv'))
+        end
+      end
+    end
+
+    context 'zip containing macOS junk' do
+      it 'excludes __MACOSX/, .DS_Store, and ._* entries from extraction' do
+        with_zip(
+          'metadata.csv' => 'h1,h2',
+          'files/foo.jpg' => 'jpg',
+          '__MACOSX/files/._foo.jpg' => 'junk',
+          '.DS_Store' => 'junk',
+          'files/._foo.jpg' => 'junk'
+        ) do |zip_path|
+          parser.unzip_with_primary_csv(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'metadata.csv'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+          expect(File).not_to exist(File.join(unzip_dir, '__MACOSX'))
+          expect(File).not_to exist(File.join(unzip_dir, '.DS_Store'))
+          expect(File).not_to exist(File.join(unzip_dir, 'files', '._foo.jpg'))
+        end
+      end
+    end
+
+    context 'when the zip contains no CSV' do
+      it 'raises a visible error' do
+        with_zip('foo.jpg' => 'jpg', 'bar.pdf' => 'pdf') do |zip_path|
+          expect { parser.unzip_with_primary_csv(zip_path) }
+            .to raise_error(/no csv/i)
+        end
+      end
+    end
+
+    context 'when multiple CSVs share the shallowest level (same directory)' do
+      it 'raises a visible error' do
+        with_zip('a.csv' => '1', 'b.csv' => '2', 'files/foo.jpg' => 'jpg') do |zip_path|
+          expect { parser.unzip_with_primary_csv(zip_path) }
+            .to raise_error(Bulkrax::UnzipError, /multiple csv/i)
+        end
+      end
+    end
+
+    context 'when multiple CSVs share the shallowest level (different directories)' do
+      it 'raises a visible error' do
+        with_zip('dir1/a.csv' => '1', 'dir2/b.csv' => '2') do |zip_path|
+          expect { parser.unzip_with_primary_csv(zip_path) }
+            .to raise_error(Bulkrax::UnzipError, /multiple csv/i)
+        end
+      end
+    end
+
+    context 'when the zip is empty of real entries (only junk)' do
+      it 'raises a no-csv error' do
+        with_zip('__MACOSX/foo' => 'junk', '.DS_Store' => 'junk') do |zip_path|
+          expect { parser.unzip_with_primary_csv(zip_path) }
+            .to raise_error(/no csv/i)
+        end
+      end
+    end
+  end
+
+  describe '#unzip_attachments_only' do
+    context 'zip with flat files: {foo.jpg, bar.pdf}' do
+      it 'places every entry under files/' do
+        with_zip('foo.jpg' => 'jpg', 'bar.pdf' => 'pdf') do |zip_path|
+          parser.unzip_attachments_only(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'bar.pdf'))
+        end
+      end
+    end
+
+    context 'zip with a single files/ wrapper: {files/foo.jpg, files/bar.pdf}' do
+      it 'strips the wrapper and places entries under files/ without doubling' do
+        with_zip('files/foo.jpg' => 'jpg', 'files/bar.pdf' => 'pdf') do |zip_path|
+          parser.unzip_attachments_only(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'bar.pdf'))
+          expect(File).not_to exist(File.join(unzip_dir, 'files', 'files', 'foo.jpg'))
+        end
+      end
+    end
+
+    context 'zip with a single arbitrary wrapper: {myfiles/foo.jpg}' do
+      it 'strips the wrapper and places entries under files/' do
+        with_zip('myfiles/foo.jpg' => 'jpg', 'myfiles/bar.pdf' => 'pdf') do |zip_path|
+          parser.unzip_attachments_only(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'bar.pdf'))
+        end
+      end
+    end
+
+    context 'zip with nested structure: {files/subdir/foo.jpg}' do
+      it 'strips a single top-level wrapper and preserves deeper structure under files/' do
+        with_zip('files/subdir/foo.jpg' => 'jpg') do |zip_path|
+          parser.unzip_attachments_only(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'files', 'subdir', 'foo.jpg'))
+        end
+      end
+    end
+
+    context 'zip with multiple top-level entries: {foo.jpg, subdir/bar.pdf}' do
+      it 'does not strip (no single wrapper) and preserves structure under files/' do
+        with_zip('foo.jpg' => 'jpg', 'subdir/bar.pdf' => 'pdf') do |zip_path|
+          parser.unzip_attachments_only(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'subdir', 'bar.pdf'))
+        end
+      end
+    end
+
+    context 'zip containing macOS junk' do
+      it 'excludes junk entries' do
+        with_zip(
+          'foo.jpg' => 'jpg',
+          '__MACOSX/foo' => 'junk',
+          '.DS_Store' => 'junk',
+          '._foo.jpg' => 'junk'
+        ) do |zip_path|
+          parser.unzip_attachments_only(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+          expect(File).not_to exist(File.join(unzip_dir, 'files', '__MACOSX'))
+          expect(File).not_to exist(File.join(unzip_dir, 'files', '.DS_Store'))
+          expect(File).not_to exist(File.join(unzip_dir, 'files', '._foo.jpg'))
+        end
+      end
+    end
+
+    context 'when the zip contains CSVs alongside other files' do
+      # CSVs inside an attachments zip are legitimate — the user uploaded
+      # the primary CSV separately, so any CSVs in the attachments zip are
+      # just additional attachments (referenced by the primary CSV's file
+      # column, same as JPGs or PDFs).
+      it 'places CSV entries under files/ just like any other attachment' do
+        with_zip('extra.csv' => 'h1,h2', 'foo.jpg' => 'jpg') do |zip_path|
+          parser.unzip_attachments_only(zip_path)
+
+          expect(File).to exist(File.join(unzip_dir, 'files', 'extra.csv'))
+          expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
+        end
+      end
+    end
+  end
+
+  describe '#remove_spaces_from_filenames' do
+    before { FileUtils.mkdir_p(File.join(unzip_dir, 'files')) }
+
+    it 'renames files under files/ that contain spaces, replacing spaces with underscores' do
+      File.write(File.join(unzip_dir, 'files', 'has space.jpg'), 'jpg')
+      File.write(File.join(unzip_dir, 'files', 'no_space.jpg'), 'jpg')
+
+      parser.remove_spaces_from_filenames
+
+      expect(File).to exist(File.join(unzip_dir, 'files', 'has_space.jpg'))
+      expect(File).not_to exist(File.join(unzip_dir, 'files', 'has space.jpg'))
+      expect(File).to exist(File.join(unzip_dir, 'files', 'no_space.jpg'))
+    end
+
+    it 'is a no-op when no filenames contain spaces' do
+      File.write(File.join(unzip_dir, 'files', 'alpha.jpg'), 'jpg')
+      File.write(File.join(unzip_dir, 'files', 'beta.pdf'), 'pdf')
+
+      expect { parser.remove_spaces_from_filenames }.not_to raise_error
+
+      expect(File).to exist(File.join(unzip_dir, 'files', 'alpha.jpg'))
+      expect(File).to exist(File.join(unzip_dir, 'files', 'beta.pdf'))
+    end
+
+    it 'only looks at the top level of files/ (nested files are not renamed)' do
+      # Post-fix, nested files under files/subdir/ exist because the CSV
+      # references paths like "subdir/file with space.jpg". Renaming nested
+      # entries would break those references. Only the top-level files/
+      # directory is rewritten — consistent with pre-1098 behavior.
+      FileUtils.mkdir_p(File.join(unzip_dir, 'files', 'subdir'))
+      File.write(File.join(unzip_dir, 'files', 'subdir', 'nested space.jpg'), 'jpg')
+
+      parser.remove_spaces_from_filenames
+
+      expect(File).to exist(File.join(unzip_dir, 'files', 'subdir', 'nested space.jpg'))
+      expect(File).not_to exist(File.join(unzip_dir, 'files', 'subdir', 'nested_space.jpg'))
+    end
+  end
+end
+
+RSpec.describe Bulkrax::Importer, type: :model do
+  describe '#importer_unzip_path' do
+    let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
+    let(:expected_path) { File.join(importer.parser.base_path, "import_#{importer.path_string}") }
+
+    after do
+      FileUtils.rm_rf(expected_path) if Dir.exist?(expected_path)
+    end
+
+    it 'returns base_path/import_{path_string} regardless of whether the dir exists' do
+      FileUtils.rm_rf(expected_path) if Dir.exist?(expected_path)
+      expect(Dir.exist?(expected_path)).to be false
+
+      expect(importer.importer_unzip_path).to eq(expected_path)
+    end
+
+    it 'never returns nil' do
+      expect(importer.importer_unzip_path).to be_a(String)
+      expect(importer.importer_unzip_path).not_to be_empty
+    end
+
+    it 'creates the directory when mkdir: true' do
+      FileUtils.rm_rf(expected_path) if Dir.exist?(expected_path)
+
+      importer.importer_unzip_path(mkdir: true)
+
+      expect(Dir.exist?(expected_path)).to be true
+    end
+
+    it 'does not create the directory when mkdir: false (default)' do
+      FileUtils.rm_rf(expected_path) if Dir.exist?(expected_path)
+
+      importer.importer_unzip_path
+
+      expect(Dir.exist?(expected_path)).to be false
+    end
+
+    it 'is stable across calls within one importer instance' do
+      first = importer.importer_unzip_path
+      second = importer.importer_unzip_path
+      expect(first).to eq(second)
+    end
+
+    it 'does not return the directory containing the import_file_path zip' do
+      # Prior (buggy) behavior returned File.dirname(import_file_path) when
+      # import_file_path was a zip that existed on disk. The fix must not
+      # return that directory — it must return the canonical import_* path.
+      zip_tmp = Tempfile.new(['import', '.zip'])
+      Zip::File.open(zip_tmp.path, create: true) { |z| z.get_output_stream('dummy') { |f| f.write('x') } }
+      zip_tmp.close
+      importer.parser_fields['import_file_path'] = zip_tmp.path
+
+      expect(importer.importer_unzip_path).to eq(expected_path)
+      expect(importer.importer_unzip_path).not_to eq(File.dirname(zip_tmp.path))
+    ensure
+      zip_tmp&.unlink
+    end
+  end
+end

--- a/spec/parsers/bulkrax/csv_parser/unzip_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/unzip_spec.rb
@@ -187,6 +187,24 @@ RSpec.describe Bulkrax::CsvParser do
         end
       end
     end
+
+    # Zip Slip defense (https://security.snyk.io/research/zip-slip-vulnerability).
+    # A malicious zip can include entries whose names use `..` to escape
+    # the extraction directory, or absolute paths that point elsewhere on
+    # disk. Extraction must refuse such entries before writing anything.
+    context 'when a zip contains a path-traversal entry (..)' do
+      it 'raises UnzipError and writes nothing outside the extraction dir' do
+        outside_dir = File.realpath(Dir.mktmpdir)
+        with_zip('metadata.csv' => 'h1,h2', "../#{File.basename(outside_dir)}/evil.txt" => 'pwned') do |zip_path|
+          expect { parser.unzip_with_primary_csv(zip_path) }
+            .to raise_error(Bulkrax::UnzipError, /unsafe/i)
+
+          expect(File).not_to exist(File.join(outside_dir, 'evil.txt'))
+        end
+      ensure
+        FileUtils.rm_rf(outside_dir) if outside_dir
+      end
+    end
   end
 
   describe '#unzip_attachments_only' do
@@ -275,6 +293,21 @@ RSpec.describe Bulkrax::CsvParser do
           expect(File).to exist(File.join(unzip_dir, 'files', 'extra.csv'))
           expect(File).to exist(File.join(unzip_dir, 'files', 'foo.jpg'))
         end
+      end
+    end
+
+    # Zip Slip defense — same protection as unzip_with_primary_csv.
+    context 'when the zip contains a path-traversal entry (..)' do
+      it 'raises UnzipError and writes nothing outside the extraction dir' do
+        outside_dir = File.realpath(Dir.mktmpdir)
+        with_zip('foo.jpg' => 'jpg', "../#{File.basename(outside_dir)}/evil.txt" => 'pwned') do |zip_path|
+          expect { parser.unzip_attachments_only(zip_path) }
+            .to raise_error(Bulkrax::UnzipError, /unsafe/i)
+
+          expect(File).not_to exist(File.join(outside_dir, 'evil.txt'))
+        end
+      ensure
+        FileUtils.rm_rf(outside_dir) if outside_dir
       end
     end
   end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -561,8 +561,20 @@ module Bulkrax
       end
 
       context 'when an argument is not passed' do
-        it 'returns the correct path' do
-          expect(subject.path_to_files).to eq('spec/fixtures/csv/files/')
+        it 'returns the files directory' do
+          expect(subject.path_to_files).to eq('spec/fixtures/csv/files')
+        end
+      end
+
+      # `path_to_files` previously memoized into `@path_to_files`
+      # for both directory lookups (filename blank) and file lookups
+      # (filename present). If it was first called with a filename and
+      # then later called without one, it returned the stale per-file path
+      # instead of the directory.
+      context 'when called first with a filename then without' do
+        it 'returns the directory on the no-filename call, not the memoized file path' do
+          expect(subject.path_to_files(filename: 'sun.jpg')).to eq('spec/fixtures/csv/files/sun.jpg')
+          expect(subject.path_to_files).to eq('spec/fixtures/csv/files')
         end
       end
     end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -567,46 +567,10 @@ module Bulkrax
       end
     end
 
-    describe '#unzip' do
-      let(:unzip_dir) { File.realpath(Dir.mktmpdir) }
-
-      before do
-        dir = unzip_dir
-        importer.define_singleton_method(:importer_unzip_path) { |**| dir }
-      end
-      after { FileUtils.rm_rf(unzip_dir) }
-
-      def build_zip(zip_path, entries)
-        Zip::File.open(zip_path, create: true) do |zip|
-          entries.each do |name, content|
-            next if name.end_with?('/')
-            zip.get_output_stream(name) { |f| f.write(content) }
-          end
-        end
-      end
-
-      def with_zip(entries)
-        zip_file = Tempfile.new(['import', '.zip'])
-        build_zip(zip_file.path, entries)
-        yield zip_file.path
-      ensure
-        zip_file.close!
-      end
-
-      context 'when the zip is flat (image files at root, no files/ subdirectory)' do
-        it 'moves extracted files into a files/ subdirectory' do
-          with_zip('Cornus_drummondii.jpg' => 'jpg-content',
-                   'ArtThumbnail.JPG' => 'jpg-content') do |zip_path|
-            subject.unzip(zip_path)
-
-            expect(File.exist?(File.join(unzip_dir, 'files', 'Cornus_drummondii.jpg'))).to be true
-            expect(File.exist?(File.join(unzip_dir, 'files', 'ArtThumbnail.JPG'))).to be true
-            expect(File.exist?(File.join(unzip_dir, 'Cornus_drummondii.jpg'))).to be false
-            expect(File.exist?(File.join(unzip_dir, 'ArtThumbnail.JPG'))).to be false
-          end
-        end
-      end
-    end
+    # NOTE: CSV-specific unzip behavior is pinned in
+    # spec/parsers/bulkrax/csv_parser/unzip_spec.rb, which covers
+    # `#unzip_with_primary_csv` and `#unzip_attachments_only` against the
+    # accepted zip shapes from guided-import validation.
 
     describe '#file_paths' do
       let(:importer) do


### PR DESCRIPTION
# Summary

Ref https://github.com/notch8/palni_palci_knapsack/issues/609

A csv-only file zipped for the import failed to unzip correctly, and resulted in the jobs continually crashing and restarting, and the importer remaining in `pending` status. 

# Details

Bugs (some pre-existing, some due to guided import enhancements) existed in several paths of the CSV parser unzip process. 

This PR:
- adds a spec to document and test all expected unzipping behavior (which initially failed)
- corrects the unzip process
- adds a future plan to address moving the guided import file validation to row-level validation, to ensure consistency between validation and actual import behavior




