### PR TITLE
Split with regex

### DIFF
--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -33,12 +33,11 @@ module Bulkrax
     end
 
     def process_split
-      if self.split.is_a?(TrueClass)
-        @result = @result.split(Bulkrax.multi_value_element_split_on)
-      elsif self.split
-        @result = @result.split(Regexp.new(self.split))
-        @result = @result.map(&:strip).select(&:present?)
-      end
+      pattern = Bulkrax::SplitPatternCoercion.coerce(self.split)
+      return unless pattern
+
+      @result = @result.split(pattern)
+      @result = @result.map(&:strip).select(&:present?) unless self.split.is_a?(TrueClass)
     end
 
     def process_parse

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -165,7 +165,7 @@ module Bulkrax
     def add_file
       self.parsed_metadata['file'] ||= []
       if record['file']&.is_a?(String)
-        self.parsed_metadata['file'] = record['file'].split(Bulkrax.multi_value_element_split_on)
+        self.parsed_metadata['file'] = record['file'].split(Bulkrax::CsvParser.file_split_pattern)
       elsif record['file'].is_a?(Array)
         self.parsed_metadata['file'] = record['file']
       end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -13,6 +13,15 @@ module Bulkrax
       true
     end
 
+    # Returns the Regexp used to split a record's `file` cell into filenames,
+    # honouring the `file` mapping's `split:` when set.
+    def self.file_split_pattern
+      file_mapping = Bulkrax.field_mappings.dig(to_s, 'file') ||
+                     Bulkrax.field_mappings.dig(to_s, :file) || {}
+      split_value  = file_mapping['split'] || file_mapping[:split]
+      Bulkrax::SplitPatternCoercion.coerce(split_value) || Bulkrax.multi_value_element_split_on
+    end
+
     def records(_opts = {})
       return @records if @records.present?
 
@@ -356,19 +365,10 @@ module Bulkrax
         file_mapping = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from)&.first&.to_sym || :file
         next if r[file_mapping].blank?
 
-        split_value = Bulkrax.field_mappings.dig(self.class.to_s, :file, :split)
-        split_pattern = case split_value
-                        when Regexp
-                          split_value
-                        when String
-                          Regexp.new(split_value)
-                        else
-                          Bulkrax.multi_value_element_split_on
-                        end
         files_dir = path_to_files
         raise StandardError, "Record references local files but no files directory could be resolved from the import path" if files_dir.nil?
 
-        r[file_mapping].split(split_pattern).map do |f|
+        r[file_mapping].split(self.class.file_split_pattern).map do |f|
           file = File.join(files_dir, f.strip.tr(' ', '_'))
           if File.exist?(file) # rubocop:disable Style/GuardClause
             file

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -13,8 +13,9 @@ module Bulkrax
       true
     end
 
-    # Returns the Regexp used to split a record's `file` cell into filenames,
-    # honouring the `file` mapping's `split:` when set.
+    # @return [Regexp] the pattern String#split should use on a `file` cell.
+    #   Honours the `file` mapping's `split:` when set, otherwise falls back
+    #   to {Bulkrax.multi_value_element_split_on}.
     def self.file_split_pattern
       file_mapping = Bulkrax.field_mappings.dig(to_s, 'file') ||
                      Bulkrax.field_mappings.dig(to_s, :file) || {}
@@ -361,14 +362,16 @@ module Bulkrax
       raise StandardError, 'No records were found' if records.blank?
       return [] if importerexporter.metadata_only?
 
-      @file_paths ||= records.map do |r|
-        file_mapping = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from)&.first&.to_sym || :file
-        next if r[file_mapping].blank?
+      # Compute once — these don't vary per record.
+      file_mapping  = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from)&.first&.to_sym || :file
+      split_pattern = self.class.file_split_pattern
+      files_dir     = path_to_files
 
-        files_dir = path_to_files
+      @file_paths ||= records.map do |r|
+        next if r[file_mapping].blank?
         raise StandardError, "Record references local files but no files directory could be resolved from the import path" if files_dir.nil?
 
-        r[file_mapping].split(self.class.file_split_pattern).map do |f|
+        r[file_mapping].split(split_pattern).map do |f|
           file = File.join(files_dir, f.strip.tr(' ', '_'))
           if File.exist?(file) # rubocop:disable Style/GuardClause
             file

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_template_generation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_template_generation.rb
@@ -27,7 +27,10 @@ module Bulkrax
 
         def initialize(models: nil, admin_set_id: nil)
           @admin_set_id = admin_set_id
-          @mapping_manager = CsvTemplate::MappingManager.new
+          # Template generation excludes system-maintained fields (generated:
+          # true) so users don't see columns like date_uploaded, depositor,
+          # etc. on the downloadable template.
+          @mapping_manager = CsvTemplate::MappingManager.new(include_generated: false)
           @mappings = @mapping_manager.mappings
           @field_analyzer = CsvTemplate::FieldAnalyzer.new(@mappings, admin_set_id)
           @all_models = CsvTemplate::ModelLoader.new(Array.wrap(models)).models

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -72,8 +72,9 @@ module Bulkrax
           file_key      = resolve_validation_key(mapping_manager, key: 'file',                            default: :file)
 
           csv_data       = parse_validation_rows(raw_csv, source_id_key, parent_key, children_key, file_key)
-          all_models     = csv_data.map { |r| r[:model] }.compact.uniq
-          all_models    |= [Bulkrax.default_work_type] if Bulkrax.default_work_type.present?
+          # Ensure all models are Strings for FieldAnalyzer lookup
+          all_models     = csv_data.map { |r| r[:model].to_s }.reject(&:blank?).uniq
+          all_models    |= [Bulkrax.default_work_type.to_s] if Bulkrax.default_work_type.present?
           field_analyzer = CsvTemplate::FieldAnalyzer.new(mappings, admin_set_id)
           field_metadata = build_validation_field_metadata(all_models, field_analyzer)
 

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -28,7 +28,7 @@ module Bulkrax
           header_issues    = check_headers(headers, raw_csv, mapping_manager, mappings, field_metadata, field_analyzer)
           missing_required = header_issues[:missing_required]
           notices, row_errors, file_validator, collections, works, file_sets =
-            run_validations(csv_data, all_ids, headers, source_id_key, mappings, field_metadata, missing_required, zip_file, admin_set_id)
+            run_validations(csv_data, all_ids, headers, source_id_key, mappings, field_metadata, missing_required, zip_file, admin_set_id, mapping_manager: mapping_manager)
 
           result = assemble_result(
             headers: headers, missing_required: missing_required, header_issues: header_issues,
@@ -44,13 +44,13 @@ module Bulkrax
 
         # Builds notices, runs row validators, file validator, and hierarchy extraction.
         # Returns [notices, row_errors, file_validator, collections, works, file_sets].
-        def run_validations(csv_data, all_ids, headers, source_id_key, mappings, field_metadata, missing_required, zip_file, admin_set_id) # rubocop:disable Metrics/ParameterLists
+        def run_validations(csv_data, all_ids, headers, source_id_key, mappings, field_metadata, missing_required, zip_file, admin_set_id, mapping_manager: nil) # rubocop:disable Metrics/ParameterLists
           find_record = build_find_record
           notices     = []
           append_missing_source_id!(missing_required, headers, source_id_key, csv_data.map { |r| r[:model] }.compact.uniq)
           append_missing_model_notice!(notices, headers, csv_data)
 
-          row_errors                       = run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record, notices)
+          row_errors                       = run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record, notices, mapping_manager: mapping_manager)
           file_validator                   = CsvTemplate::FileValidator.new(csv_data, zip_file, admin_set_id)
           collections, works, file_sets    = extract_hierarchy_items(csv_data, all_ids, find_record, mappings)
           [notices, row_errors, file_validator, collections, works, file_sets]
@@ -106,7 +106,7 @@ module Bulkrax
         end
 
         # Runs all registered row validators and returns the collected errors.
-        def run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record, notices = []) # rubocop:disable Metrics/ParameterLists
+        def run_row_validators(csv_data, all_ids, source_id_key, mappings, field_metadata, find_record, notices = [], mapping_manager: nil) # rubocop:disable Metrics/ParameterLists
           context = {
             errors: [],
             warnings: [],
@@ -118,6 +118,7 @@ module Bulkrax
             parent_column: resolve_relationship_column(mappings, 'related_parents_field_mapping', 'parents'),
             children_column: resolve_relationship_column(mappings, 'related_children_field_mapping', 'children'),
             mappings: mappings,
+            mapping_manager: mapping_manager,
             field_metadata: field_metadata,
             find_record_by_source_identifier: find_record,
             relationship_graph: build_relationship_graph(csv_data, mappings),

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -99,7 +99,7 @@ module Bulkrax
           extract_validation_items(
             csv_data, all_ids, find_record,
             parent_split_pattern: resolve_parent_split_pattern(mappings),
-            child_split_pattern: resolve_children_split_pattern(mappings) || '|'
+            child_split_pattern: resolve_children_split_pattern(mappings) || Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON
           )
         end
 

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -90,7 +90,9 @@ module Bulkrax
 
           {
             missing_required: find_missing_required_headers(headers, field_metadata, mapping_manager),
-            unrecognized: find_unrecognized_validation_headers(headers, valid_headers),
+            unrecognized: find_unrecognized_validation_headers(headers, valid_headers,
+                                                               mapping_manager: mapping_manager,
+                                                               field_metadata: field_metadata),
             empty_columns: find_empty_column_positions(headers, raw_csv)
           }
         end

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
@@ -53,13 +53,33 @@ module Bulkrax
           mappings: mappings
         )
         all_cols = CsvTemplate::ColumnBuilder.new(svc).all_columns
-        all_cols - CsvTemplate::CsvBuilder::IGNORED_PROPERTIES
+        # ColumnBuilder only emits the first `from:` alias per non-property key
+        # (core/file/relationship). Accept every alias so a CSV using a
+        # non-primary alias like `file` (when mappings are `from: ['item', 'file']`)
+        # isn't flagged unrecognised. Property-level aliases are handled
+        # separately by find_unrecognized_validation_headers via mapped_to_key.
+        non_property_aliases = non_property_mapping_aliases(mappings)
+        (all_cols + non_property_aliases).uniq - CsvTemplate::CsvBuilder::IGNORED_PROPERTIES
       rescue StandardError => e
         Rails.logger.error("CsvParser.validate_csv: error building valid headers – #{e.message}")
         standard = %w[model source_identifier parents children file]
         model_fields = field_metadata.values.flat_map { |m| m[:properties] }
                                             .map { |prop| mapping_manager.key_to_mapped_column(prop) }
         (standard + model_fields).uniq
+      end
+
+      # Returns every `from:` alias for mapping keys that describe non-property
+      # columns (core/file/relationship). These keys are fixed by the descriptor
+      # rather than discovered per-model, so every alias is unambiguously valid.
+      def non_property_mapping_aliases(mappings)
+        descriptor = CsvTemplate::ColumnDescriptor.new
+        non_property_keys = descriptor.core_columns +
+                            CsvTemplate::ColumnDescriptor::COLUMN_DESCRIPTIONS[:files].flat_map(&:keys) +
+                            CsvTemplate::ColumnDescriptor::COLUMN_DESCRIPTIONS[:relationships].flat_map(&:keys)
+        non_property_keys.flat_map do |key|
+          entry = mappings[key]
+          entry.is_a?(Hash) ? Array(entry["from"]) : []
+        end
       end
 
       def find_missing_required_headers(headers, field_metadata, mapping_manager)

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
@@ -205,19 +205,11 @@ module Bulkrax
       end
 
       def resolve_parent_split_pattern(mappings)
-        split_val = mappings.dig('parents', 'split') || mappings.dig(:parents, :split)
-        return nil if split_val.blank?
-        return Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON if split_val == true
-
-        split_val
+        Bulkrax::SplitPatternCoercion.coerce(mappings.dig('parents', 'split') || mappings.dig(:parents, :split))
       end
 
       def resolve_children_split_pattern(mappings)
-        split_val = mappings.dig('children', 'split') || mappings.dig(:children, :split)
-        return nil if split_val.blank?
-        return Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON if split_val == true
-
-        split_val
+        Bulkrax::SplitPatternCoercion.coerce(mappings.dig('children', 'split') || mappings.dig(:children, :split))
       end
 
       # Builds a graph of { source_identifier => [parent_ids] } from all CSV records.
@@ -264,8 +256,9 @@ module Bulkrax
       end
 
       def split_or_single(value, split_pattern)
-        if split_pattern
-          value.to_s.split(split_pattern).map(&:strip).reject(&:blank?)
+        coerced = Bulkrax::SplitPatternCoercion.coerce(split_pattern)
+        if coerced
+          value.to_s.split(coerced).map(&:strip).reject(&:blank?)
         elsif value.present?
           [value.to_s.strip]
         else

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
@@ -73,11 +73,23 @@ module Bulkrax
         missing.uniq
       end
 
-      def find_unrecognized_validation_headers(headers, valid_headers)
+      # A header is considered recognised if it appears in valid_headers or
+      # if it matches any alias in a known property's `from` array. The real
+      # importer (CsvParser#missing_elements) scans every `from` entry when
+      # matching incoming columns, so the validator has to use the same rule
+      # — otherwise a CSV that imports cleanly gets flagged for columns like
+      # `creator` when the mapping declares `creator: { from: ['author', 'creator'] }`.
+      def find_unrecognized_validation_headers(headers, valid_headers, mapping_manager: nil, field_metadata: nil)
+        known_property_keys = (field_metadata || {}).values.flat_map { |m| Array(m[:properties]) }.to_set
         checker = DidYouMean::SpellChecker.new(dictionary: valid_headers)
-        headers
-          .reject { |h| h.blank? || valid_headers.include?(h) || valid_headers.include?(h.sub(/_\d+\z/, '')) }
-          .index_with { |h| checker.correct(h).first }
+        unrecognized = headers.reject do |h|
+          next true if h.blank?
+          base = h.sub(/_\d+\z/, '')
+          next true if valid_headers.include?(h) || valid_headers.include?(base)
+          mapped_key = mapping_manager&.mapped_to_key(base)
+          mapped_key && known_property_keys.include?(mapped_key)
+        end
+        unrecognized.index_with { |h| checker.correct(h).first }
       end
 
       def find_empty_column_positions(headers, raw_csv)

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_hierarchy.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_hierarchy.rb
@@ -5,7 +5,7 @@ module Bulkrax
     # Hierarchy-building helpers for CsvValidation. Handles extracting and
     # categorising items from parsed CSV data for the guided import tree view.
     module CsvValidationHierarchy
-      def extract_validation_items(csv_data, all_ids = Set.new, find_record = nil, parent_split_pattern: nil, child_split_pattern: '|')
+      def extract_validation_items(csv_data, all_ids = Set.new, find_record = nil, parent_split_pattern: nil, child_split_pattern: Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON)
         child_to_parents = build_child_to_parents_map(csv_data, child_split_pattern: child_split_pattern)
         collections = []
         works       = []
@@ -19,7 +19,7 @@ module Bulkrax
         [collections, works, file_sets]
       end
 
-      def build_child_to_parents_map(csv_data, child_split_pattern: '|')
+      def build_child_to_parents_map(csv_data, child_split_pattern: Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON)
         Hash.new { |h, k| h[k] = [] }.tap do |map|
           csv_data.each do |item|
             next if item[:source_identifier].blank?
@@ -31,7 +31,7 @@ module Bulkrax
         end
       end
 
-      def categorise_validation_item(item, child_to_parents, all_ids, collections, works, file_sets, find_record = nil, parent_split_pattern: nil, child_split_pattern: '|') # rubocop:disable Metrics/ParameterLists
+      def categorise_validation_item(item, child_to_parents, all_ids, collections, works, file_sets, find_record = nil, parent_split_pattern: nil, child_split_pattern: Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON) # rubocop:disable Metrics/ParameterLists
         item_id   = item[:source_identifier]
         model_str = item[:model].to_s
 
@@ -51,7 +51,7 @@ module Bulkrax
         item_id  = item[:source_identifier]
         title    = item[:raw_row]['title'] || item_id
         parents  = collect_relationship_ids(item[:parent],   item[:raw_row], 'parents',  split_pattern: opts[:parent])
-        children = collect_relationship_ids(item[:children], item[:raw_row], 'children', split_pattern: opts[:child] || '|')
+        children = collect_relationship_ids(item[:children], item[:raw_row], 'children', split_pattern: opts[:child] || Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON)
 
         {
           id: item_id,
@@ -65,12 +65,14 @@ module Bulkrax
         }
       end
 
-      def parse_relationship_field(value, split_pattern: '|')
+      def parse_relationship_field(value, split_pattern: Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON)
         return [] if value.blank?
-        value.to_s.split(split_pattern).map(&:strip).reject(&:blank?)
+
+        pattern = Bulkrax::SplitPatternCoercion.coerce(split_pattern) || Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON
+        value.to_s.split(pattern).map(&:strip).reject(&:blank?)
       end
 
-      def collect_relationship_ids(base_value, raw_row, column, split_pattern: '|')
+      def collect_relationship_ids(base_value, raw_row, column, split_pattern: Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON)
         base_ids = parse_relationship_field(base_value, split_pattern: split_pattern)
         suffix_pattern = /\A#{Regexp.escape(column)}_\d+\z/
         suffix_ids = raw_row

--- a/app/services/bulkrax/csv_template/file_validator.rb
+++ b/app/services/bulkrax/csv_template/file_validator.rb
@@ -46,7 +46,7 @@ module Bulkrax
         @referenced_files ||= @csv_data.flat_map do |item|
           next [] if item[:file].blank?
 
-          item[:file].split(Bulkrax.multi_value_element_split_on).map { |f| File.basename(f.strip) }
+          item[:file].split(Bulkrax::CsvParser.file_split_pattern).map { |f| File.basename(f.strip) }
         end.compact
       end
 

--- a/app/services/bulkrax/csv_template/mapping_manager.rb
+++ b/app/services/bulkrax/csv_template/mapping_manager.rb
@@ -6,8 +6,16 @@ module Bulkrax
     class MappingManager
       attr_reader :mappings
 
-      def initialize
-        @mappings = load_mappings
+      # @param include_generated [Boolean] when false, excludes mapping entries
+      #   flagged `generated: true` (system-maintained fields like
+      #   date_uploaded, depositor, source_identifier). Template generation
+      #   passes +false+ so the downloadable template doesn't expose
+      #   system columns; import validation uses the default +true+ so that
+      #   user-configured mappings like `rights_statement` (which Bulkrax
+      #   ships with `generated: true`) are still recognised when the CSV
+      #   uses one of their `from:` aliases.
+      def initialize(include_generated: true)
+        @mappings = load_mappings(include_generated: include_generated)
       end
 
       def mapped_to_key(column_str)
@@ -45,10 +53,11 @@ module Bulkrax
 
       private
 
-      def load_mappings
-        Bulkrax.field_mappings["Bulkrax::CsvParser"].reject do |_key, value|
-          value["generated"] == true
-        end
+      def load_mappings(include_generated:)
+        raw = Bulkrax.field_mappings["Bulkrax::CsvParser"]
+        return raw if include_generated
+
+        raw.reject { |_key, value| value["generated"] == true }
       end
     end
   end

--- a/app/services/bulkrax/csv_template/split_formatter.rb
+++ b/app/services/bulkrax/csv_template/split_formatter.rb
@@ -9,6 +9,8 @@ module Bulkrax
 
         if split_value == true
           parse_pattern(Bulkrax.multi_value_element_split_on.source)
+        elsif split_value.is_a?(Regexp)
+          parse_pattern(split_value.source)
         elsif split_value.is_a?(String)
           parse_pattern(split_value)
         else
@@ -34,9 +36,14 @@ module Bulkrax
       end
 
       def format_message(chars)
-        formatted = chars.chars.then do |c|
-          c.length > 1 ? "#{c[0..-2].join(' ')}, or #{c.last}" : c.first
-        end
+        list = chars.chars
+        # Use spaces rather than commas between delimiters so the message
+        # stays unambiguous when one of the delimiters IS a comma.
+        formatted = if list.length <= 1
+                      list.first || chars # no extractable chars → surface as-is
+                    else
+                      "#{list[0..-2].join(' ')} or #{list.last}"
+                    end
         "Split multiple values with #{formatted}"
       end
     end

--- a/app/services/bulkrax/split_pattern_coercion.rb
+++ b/app/services/bulkrax/split_pattern_coercion.rb
@@ -1,36 +1,42 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  # Coerces a split pattern into a Regexp for String#split.
+  # Coerces a stored split pattern into a Regexp suitable for String#split.
   #
   # Bulkrax field mappings are persisted as JSON in several host applications
   # (e.g. Hyku), so the `split` value for a mapping can show up in several
-  # forms and we need a single policy that handles all of them:
+  # forms. This module is the single place that normalises them:
   #
-  # * nil / blank           → `nil` (no split)
+  # * nil / blank           → `nil` (caller should treat as "no split")
   # * already a Regexp      → returned unchanged
   # * `true`                → {Bulkrax.multi_value_element_split_on}
   # * String, any content   → `Regexp.new(str)` — the String is treated as a
   #                           regex source, matching the long-standing
   #                           contract in {Bulkrax::ApplicationMatcher}.
-  #                           This means `"\\|"` → `/\|/` and a serialised
-  #                           regex like `"(?-mix:\\s*[;|]\\s*)"` rebuilds
-  #                           into an equivalent Regexp.
+  #                           `"\\|"` → `/\|/`; a serialised regex like
+  #                           `"(?-mix:\\s*[;|]\\s*)"` rebuilds into an
+  #                           equivalent Regexp.
+  # * invalid regex source  → `nil` (we neither raise nor hand back an
+  #                           unusable value to String#split).
+  # * any other type        → `nil` (likewise — never returns something
+  #                           String#split can't accept).
   #
-  # This is the single place in the gem that translates stored split
-  # configuration into the value consumed by String#split — import,
-  # validation, and hierarchy code paths all route through here so the
-  # behaviour is consistent regardless of how the mapping was persisted.
+  # Import, validation, and hierarchy code paths all route through here so
+  # the behaviour is consistent regardless of how the mapping was persisted.
+  #
+  # @param split_val [nil, true, Regexp, String, Object] the configured split
+  # @return [nil, Regexp] a pattern ready for String#split, or nil when
+  #   no usable pattern can be derived from the input.
   module SplitPatternCoercion
     def self.coerce(split_val)
       return nil if split_val.blank?
       return Bulkrax.multi_value_element_split_on if split_val == true
       return split_val if split_val.is_a?(Regexp)
-      return split_val unless split_val.is_a?(String)
+      return nil unless split_val.is_a?(String)
 
       Regexp.new(split_val)
     rescue RegexpError
-      split_val
+      nil
     end
   end
 end

--- a/app/services/bulkrax/split_pattern_coercion.rb
+++ b/app/services/bulkrax/split_pattern_coercion.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  # Coerces a split pattern into a Regexp for String#split.
+  #
+  # Bulkrax field mappings are persisted as JSON in several host applications
+  # (e.g. Hyku), so the `split` value for a mapping can show up in several
+  # forms and we need a single policy that handles all of them:
+  #
+  # * nil / blank           → `nil` (no split)
+  # * already a Regexp      → returned unchanged
+  # * `true`                → {Bulkrax.multi_value_element_split_on}
+  # * String, any content   → `Regexp.new(str)` — the String is treated as a
+  #                           regex source, matching the long-standing
+  #                           contract in {Bulkrax::ApplicationMatcher}.
+  #                           This means `"\\|"` → `/\|/` and a serialised
+  #                           regex like `"(?-mix:\\s*[;|]\\s*)"` rebuilds
+  #                           into an equivalent Regexp.
+  #
+  # This is the single place in the gem that translates stored split
+  # configuration into the value consumed by String#split — import,
+  # validation, and hierarchy code paths all route through here so the
+  # behaviour is consistent regardless of how the mapping was persisted.
+  module SplitPatternCoercion
+    def self.coerce(split_val)
+      return nil if split_val.blank?
+      return Bulkrax.multi_value_element_split_on if split_val == true
+      return split_val if split_val.is_a?(Regexp)
+      return split_val unless split_val.is_a?(String)
+
+      Regexp.new(split_val)
+    rescue RegexpError
+      split_val
+    end
+  end
+end

--- a/app/validators/bulkrax/csv_row/child_reference.rb
+++ b/app/validators/bulkrax/csv_row/child_reference.rb
@@ -37,7 +37,8 @@ module Bulkrax
       end
 
       def self.collect_child_ids(record, context)
-        split_pattern = context[:child_split_pattern] || '|'
+        split_pattern = Bulkrax::SplitPatternCoercion.coerce(context[:child_split_pattern]) ||
+                        Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON
         children_column = context[:children_column] || 'children'
 
         base_ids = record[:children].to_s.split(split_pattern).map(&:strip).reject(&:blank?)

--- a/app/validators/bulkrax/csv_row/parent_reference.rb
+++ b/app/validators/bulkrax/csv_row/parent_reference.rb
@@ -34,7 +34,7 @@ module Bulkrax
       end
 
       def self.collect_parent_ids(record, context)
-        split_pattern = context[:parent_split_pattern]
+        split_pattern = Bulkrax::SplitPatternCoercion.coerce(context[:parent_split_pattern])
         parent_column = context[:parent_column] || 'parents'
 
         base_ids = if split_pattern

--- a/app/validators/bulkrax/csv_row/required_values.rb
+++ b/app/validators/bulkrax/csv_row/required_values.rb
@@ -17,7 +17,7 @@ module Bulkrax
         return if metadata.blank?
 
         add_default_work_type_warning(context, record, row_index, model) if using_default
-        add_missing_required_value_errors(context, record, row_index, metadata)
+        add_missing_required_value_errors(context, record, row_index, metadata, context[:mapping_manager])
       end
 
       def self.add_default_work_type_warning(context, record, row_index, model)
@@ -38,9 +38,9 @@ module Bulkrax
       end
       private_class_method :add_default_work_type_warning
 
-      def self.add_missing_required_value_errors(context, record, row_index, metadata)
+      def self.add_missing_required_value_errors(context, record, row_index, metadata, mapping_manager)
         (metadata[:required_terms] || []).each do |field|
-          next if record[:raw_row].any? { |key, value| normalize_header(key.to_s) == field && value.present? }
+          next if record[:raw_row].any? { |key, value| resolve_header(key.to_s, mapping_manager) == field && value.present? }
 
           context[:errors] << {
             row: row_index,
@@ -55,6 +55,18 @@ module Bulkrax
         end
       end
       private_class_method :add_missing_required_value_errors
+
+      # Resolves a raw CSV header into its mapping key so that `from:` aliases
+      # are honoured (e.g. a column named `rights` satisfies the requirement
+      # for `rights_statement` when the mapping declares
+      # `rights_statement: { from: ['rights', 'rights_statement', ...] }`).
+      # Numeric suffixes (e.g. `title_1`) are stripped before lookup so they
+      # satisfy the unsuffixed required field.
+      def self.resolve_header(header, mapping_manager)
+        base = normalize_header(header)
+        mapping_manager ? mapping_manager.mapped_to_key(base) : base
+      end
+      private_class_method :resolve_header
 
       def self.normalize_header(header)
         header.sub(/_\d+\z/, '')

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -1373,6 +1373,62 @@ module Bulkrax
         expect(entry.parsed_metadata['visibility_after_lease']).to eq('open')
       end
     end
+    # Characterisation coverage for how the `file` column is split during
+    # ingestion (writing to parsed_metadata['file']). These specs pin the
+    # current behaviour so it stays visible if the implementation is later
+    # refactored to honour the `file` mapping's `split:` value.
+    describe '#add_file' do
+      let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
+      subject(:entry) do
+        described_class.new(importerexporter: importer, raw_metadata: raw_metadata, identifier: 'id-1')
+      end
+      let(:parser) { importer.parser }
+
+      before do
+        allow(parser).to receive(:path_to_files).and_return('spec/fixtures/csv/files')
+        allow(entry).to receive(:path_to_file) { |name| "spec/fixtures/csv/files/#{name}" }
+        entry.parsed_metadata = {}
+      end
+
+      context 'with a pipe-separated `file` cell' do
+        let(:raw_metadata) { { 'source_identifier' => 'id-1', 'file' => 'sun.jpg|moon.jpg' } }
+
+        it 'splits on the Bulkrax default pattern and writes an array' do
+          entry.send(:add_file)
+          expect(entry.parsed_metadata['file']).to eq(%w[spec/fixtures/csv/files/sun.jpg spec/fixtures/csv/files/moon.jpg])
+        end
+      end
+
+      context 'when the `file` mapping configures a non-default split' do
+        let(:raw_metadata) { { 'source_identifier' => 'id-1', 'file' => 'sun.jpg;moon.jpg' } }
+
+        around do |spec|
+          old = Bulkrax.field_mappings['Bulkrax::CsvParser']
+          Bulkrax.field_mappings['Bulkrax::CsvParser'] = { 'file' => { split: ';' } }
+          spec.run
+          Bulkrax.field_mappings['Bulkrax::CsvParser'] = old
+        end
+
+        it 'currently ignores the configured split and uses the default (pre-refactor behaviour)' do
+          entry.send(:add_file)
+          # Default pattern /\s*[:;|]\s*/ happens to include `;`, so this splits
+          # "correctly" here — but the point of this characterisation is that
+          # the value of the `file` mapping's `split:` is NOT consulted at all.
+          expect(entry.parsed_metadata['file'])
+            .to eq(%w[spec/fixtures/csv/files/sun.jpg spec/fixtures/csv/files/moon.jpg])
+        end
+      end
+
+      context 'when the `file` cell is already an Array' do
+        let(:raw_metadata) { { 'source_identifier' => 'id-1', 'file' => ['sun.jpg', 'moon.jpg'] } }
+
+        it 'passes the array through without splitting' do
+          entry.send(:add_file)
+          expect(entry.parsed_metadata['file']).to eq(%w[spec/fixtures/csv/files/sun.jpg spec/fixtures/csv/files/moon.jpg])
+        end
+      end
+    end
+
     describe '#path_to_file' do
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
       subject(:entry) { described_class.new(importerexporter: importer) }

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -1373,10 +1373,9 @@ module Bulkrax
         expect(entry.parsed_metadata['visibility_after_lease']).to eq('open')
       end
     end
-    # Characterisation coverage for how the `file` column is split during
-    # ingestion (writing to parsed_metadata['file']). These specs pin the
-    # current behaviour so it stays visible if the implementation is later
-    # refactored to honour the `file` mapping's `split:` value.
+    # Ingestion writes to parsed_metadata['file'] via Bulkrax::CsvParser.
+    # file_split_pattern, so any `split:` configured on the `file` mapping is
+    # honoured — matching #file_paths and FileValidator#referenced_files.
     describe '#add_file' do
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
       subject(:entry) do
@@ -1390,30 +1389,30 @@ module Bulkrax
         entry.parsed_metadata = {}
       end
 
-      context 'with a pipe-separated `file` cell' do
+      context 'with a pipe-separated `file` cell and no configured split' do
         let(:raw_metadata) { { 'source_identifier' => 'id-1', 'file' => 'sun.jpg|moon.jpg' } }
 
-        it 'splits on the Bulkrax default pattern and writes an array' do
+        it 'falls back to Bulkrax.multi_value_element_split_on and writes an array' do
           entry.send(:add_file)
           expect(entry.parsed_metadata['file']).to eq(%w[spec/fixtures/csv/files/sun.jpg spec/fixtures/csv/files/moon.jpg])
         end
       end
 
+      # Use a delimiter (`,`) that the default pattern /\s*[:;|]\s*/ does NOT
+      # match, so this spec genuinely distinguishes honouring-the-config from
+      # falling back to the default.
       context 'when the `file` mapping configures a non-default split' do
-        let(:raw_metadata) { { 'source_identifier' => 'id-1', 'file' => 'sun.jpg;moon.jpg' } }
+        let(:raw_metadata) { { 'source_identifier' => 'id-1', 'file' => 'sun.jpg,moon.jpg' } }
 
         around do |spec|
           old = Bulkrax.field_mappings['Bulkrax::CsvParser']
-          Bulkrax.field_mappings['Bulkrax::CsvParser'] = { 'file' => { split: ';' } }
+          Bulkrax.field_mappings['Bulkrax::CsvParser'] = { 'file' => { split: ',' } }
           spec.run
           Bulkrax.field_mappings['Bulkrax::CsvParser'] = old
         end
 
-        it 'currently ignores the configured split and uses the default (pre-refactor behaviour)' do
+        it 'honours the configured split' do
           entry.send(:add_file)
-          # Default pattern /\s*[:;|]\s*/ happens to include `;`, so this splits
-          # "correctly" here — but the point of this characterisation is that
-          # the value of the `file` mapping's `split:` is NOT consulted at all.
           expect(entry.parsed_metadata['file'])
             .to eq(%w[spec/fixtures/csv/files/sun.jpg spec/fixtures/csv/files/moon.jpg])
         end

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -173,6 +173,77 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
         expect(result).to include('title', 'creator')
       end
     end
+
+    context 'when ColumnBuilder succeeds (happy path)' do
+      let(:mapping_manager) { Bulkrax::CsvTemplate::MappingManager.new }
+      let(:field_analyzer)  { instance_double(Bulkrax::CsvTemplate::FieldAnalyzer) }
+      let(:mappings) do
+        {
+          'title' => { 'from' => ['title'] },
+          'file' => { 'from' => ['file'] },
+          'parents' => { 'from' => ['parents'], 'related_parents_field_mapping' => true },
+          'children' => { 'from' => ['children'], 'related_children_field_mapping' => true }
+        }
+      end
+      let(:field_metadata) do
+        { 'GenericWorkResource' =>
+          { properties: %w[title], required_terms: [], controlled_vocab_terms: [] } }
+      end
+
+      before do
+        allow(Bulkrax).to receive(:field_mappings).and_return('Bulkrax::CsvParser' => mappings)
+        allow(field_analyzer).to receive(:find_or_create_field_list_for)
+          .with(model_name: 'GenericWorkResource')
+          .and_return('GenericWorkResource' => { 'properties' => %w[title] })
+      end
+
+      it 'does not hit the rescue branch' do
+        expect(Rails.logger).not_to receive(:error).with(/error building valid headers/)
+        host.build_valid_validation_headers(mapping_manager, field_analyzer,
+                                            %w[GenericWorkResource], mappings, field_metadata)
+      end
+
+      it 'includes the core visibility and embargo columns' do
+        result = host.build_valid_validation_headers(mapping_manager, field_analyzer,
+                                                    %w[GenericWorkResource], mappings, field_metadata)
+        expect(result).to include('visibility', 'embargo_release_date',
+                                  'visibility_during_embargo', 'visibility_after_embargo')
+      end
+    end
+
+    # Regression: ColumnBuilder emits only the first `from:` alias per
+    # non-property key (core/file/relationship). When a tenant maps `file`
+    # as `from: ['item', 'file']`, a CSV header `file` was wrongly flagged
+    # unrecognised because only `item` made it into valid_headers.
+    context 'when a non-property mapping has multiple `from:` aliases' do
+      let(:mapping_manager) { Bulkrax::CsvTemplate::MappingManager.new }
+      let(:field_analyzer)  { instance_double(Bulkrax::CsvTemplate::FieldAnalyzer) }
+      let(:mappings) do
+        {
+          'title' => { 'from' => ['title'] },
+          'file' => { 'from' => %w[item file], 'split' => '\\|' },
+          'parents' => { 'from' => ['parents'], 'related_parents_field_mapping' => true },
+          'children' => { 'from' => ['children'], 'related_children_field_mapping' => true }
+        }
+      end
+      let(:field_metadata) do
+        { 'GenericWorkResource' =>
+          { properties: %w[title], required_terms: [], controlled_vocab_terms: [] } }
+      end
+
+      before do
+        allow(Bulkrax).to receive(:field_mappings).and_return('Bulkrax::CsvParser' => mappings)
+        allow(field_analyzer).to receive(:find_or_create_field_list_for)
+          .with(model_name: 'GenericWorkResource')
+          .and_return('GenericWorkResource' => { 'properties' => %w[title] })
+      end
+
+      it 'includes every `from:` alias for the file mapping' do
+        result = host.build_valid_validation_headers(mapping_manager, field_analyzer,
+                                                    %w[GenericWorkResource], mappings, field_metadata)
+        expect(result).to include('item', 'file')
+      end
+    end
   end
 
   describe '#find_unrecognized_validation_headers (respects all `from` aliases)' do

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -175,6 +175,52 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
     end
   end
 
+  describe '#find_unrecognized_validation_headers (respects all `from` aliases)' do
+    let(:mappings) do
+      {
+        'creator' => { 'from' => %w[author creator], 'split' => '\\|' },
+        'resource_type' => { 'from' => ['type', 'resource type'], 'split' => '\\|' },
+        'title' => { 'from' => ['title'], 'split' => '\\|' }
+      }
+    end
+    let(:mapping_manager) { Bulkrax::CsvTemplate::MappingManager.new }
+    let(:field_analyzer)  { instance_double(Bulkrax::CsvTemplate::FieldAnalyzer) }
+    let(:field_metadata)  do
+      { 'GenericWorkResource' =>
+        { properties: %w[title creator resource_type], required_terms: [], controlled_vocab_terms: [] } }
+    end
+
+    before do
+      allow(Bulkrax).to receive(:field_mappings).and_return('Bulkrax::CsvParser' => mappings)
+      allow(field_analyzer).to receive(:find_or_create_field_list_for)
+        .with(model_name: 'GenericWorkResource')
+        .and_return('GenericWorkResource' => { 'properties' => %w[title creator resource_type] })
+    end
+
+    def valid_headers
+      host.build_valid_validation_headers(mapping_manager, field_analyzer,
+                                          %w[GenericWorkResource], mappings, field_metadata)
+    end
+
+    it 'does not flag a header matching a non-first `from` alias ("creator")' do
+      headers = %w[title creator]
+      result  = host.find_unrecognized_validation_headers(headers, valid_headers)
+      expect(result).not_to have_key('creator')
+    end
+
+    it 'does not flag a header matching a non-first `from` alias ("resource_type")' do
+      headers = %w[title resource_type]
+      result  = host.find_unrecognized_validation_headers(headers, valid_headers)
+      expect(result).not_to have_key('resource_type')
+    end
+
+    it 'still flags a header that matches no alias of any known property' do
+      headers = %w[title totally_made_up]
+      result  = host.find_unrecognized_validation_headers(headers, valid_headers)
+      expect(result).to have_key('totally_made_up')
+    end
+  end
+
   describe '#resolve_children_split_pattern' do
     it 'returns nil when no split is configured for children' do
       mappings = {}
@@ -196,6 +242,46 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       mappings = { 'children' => { 'split' => ';' } }
       expect(host.resolve_children_split_pattern(mappings)).to eq(';')
     end
+  end
+
+  # Hyku persists field_mapping as JSON; a Regexp configured via the UI
+  # serialises to its `Regexp#to_s` form (e.g. "(?-mix:\\s*[;|]\\s*)",
+  # "(?i-mx:foo)", etc. — any valid Regexp is fair game) and round-trips
+  # back as a String. Callers pass the result of these resolvers into
+  # String#split, which treats a String argument as a literal substring,
+  # so a serialised Regexp never matches real content and cells are never
+  # split. The resolver must coerce any `Regexp#to_s`-shaped String back
+  # into an equivalent Regexp.
+  #
+  # We exercise a representative set of Regexp forms rather than pinning to
+  # one particular delimiter, so the fix is general rather than tailored to
+  # the one pattern that prompted this bug report.
+  shared_examples 'coerces a serialised Regexp back into a Regexp' do |resolver, key|
+    [
+      /\s*[;|]\s*/,      # whitespace + pipe/semicolon (original bug repro)
+      /\|/,              # plain pipe
+      /,\s*/,            # comma + optional space
+      /\A\s*foo\s*\z/i   # flagged (case-insensitive) regex
+    ].each do |original|
+      it "rebuilds an equivalent Regexp for #{original.inspect} (serialised as #{original.to_s.inspect})" do
+        mappings = { key.to_s => { 'split' => original.to_s } }
+        result   = host.public_send(resolver, mappings)
+        expect(result).to be_a(Regexp)
+        # Pattern body + options should match the original so split/match behaviour is preserved.
+        expect(result.source).to eq(original.source)
+        expect(result.options).to eq(original.options)
+      end
+    end
+  end
+
+  describe '#resolve_parent_split_pattern (JSON-serialised Regexp)' do
+    include_examples 'coerces a serialised Regexp back into a Regexp',
+                     :resolve_parent_split_pattern, :parents
+  end
+
+  describe '#resolve_children_split_pattern (JSON-serialised Regexp)' do
+    include_examples 'coerces a serialised Regexp back into a Regexp',
+                     :resolve_children_split_pattern, :children
   end
 
   describe '#build_relationship_graph' do

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -202,22 +202,22 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
                                           %w[GenericWorkResource], mappings, field_metadata)
     end
 
+    def unrecognized(headers)
+      host.find_unrecognized_validation_headers(headers, valid_headers,
+                                                mapping_manager: mapping_manager,
+                                                field_metadata: field_metadata)
+    end
+
     it 'does not flag a header matching a non-first `from` alias ("creator")' do
-      headers = %w[title creator]
-      result  = host.find_unrecognized_validation_headers(headers, valid_headers)
-      expect(result).not_to have_key('creator')
+      expect(unrecognized(%w[title creator])).not_to have_key('creator')
     end
 
     it 'does not flag a header matching a non-first `from` alias ("resource_type")' do
-      headers = %w[title resource_type]
-      result  = host.find_unrecognized_validation_headers(headers, valid_headers)
-      expect(result).not_to have_key('resource_type')
+      expect(unrecognized(%w[title resource_type])).not_to have_key('resource_type')
     end
 
     it 'still flags a header that matches no alias of any known property' do
-      headers = %w[title totally_made_up]
-      result  = host.find_unrecognized_validation_headers(headers, valid_headers)
-      expect(result).to have_key('totally_made_up')
+      expect(unrecognized(%w[title totally_made_up])).to have_key('totally_made_up')
     end
   end
 
@@ -268,10 +268,10 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
   # wrapper), so assert behaviour rather than internal representation.
   shared_examples 'coerces a serialised Regexp back into a Regexp' do |resolver, key|
     {
-      /\s*[;|]\s*/     => ['coll1 | coll2', %w[coll1 coll2]],      # original bug repro
-      /\|/             => ['a|b|c',         %w[a b c]],             # plain pipe
-      /,\s*/           => ['a, b, c',       %w[a b c]],             # comma + optional space
-      /\A\s*foo\s*\z/i => ['FOO',           []]                     # flagged (case-insensitive): split consumes entire string
+      /\s*[;|]\s*/ => ['coll1 | coll2', %w[coll1 coll2]], # original bug repro
+      /\|/ => ['a|b|c',         %w[a b c]], # plain pipe
+      /,\s*/ => ['a, b, c', %w[a b c]], # comma + optional space
+      /\A\s*foo\s*\z/i => ['FOO', []] # flagged (case-insensitive): split consumes entire string
     }.each do |original, (sample, expected_split)|
       it "rebuilds a Regexp that splits like #{original.inspect} (serialised as #{original.to_s.inspect})" do
         mappings = { key.to_s => { 'split' => original.to_s } }

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -238,9 +238,14 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
         .to eq(Bulkrax::DEFAULT_MULTI_VALUE_ELEMENT_SPLIT_ON)
     end
 
-    it 'returns the custom split string when split is a string' do
+    it 'treats a String split value as a regex source (matching ApplicationMatcher)' do
+      # The shared SplitPatternCoercion.coerce contract: any String becomes
+      # Regexp.new(str). This keeps relationship-field splitting consistent
+      # with the long-standing ApplicationMatcher#process_split behaviour.
       mappings = { 'children' => { 'split' => ';' } }
-      expect(host.resolve_children_split_pattern(mappings)).to eq(';')
+      result   = host.resolve_children_split_pattern(mappings)
+      expect(result).to be_a(Regexp)
+      expect('a;b;c'.split(result)).to eq(%w[a b c])
     end
   end
 
@@ -256,20 +261,24 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
   # We exercise a representative set of Regexp forms rather than pinning to
   # one particular delimiter, so the fix is general rather than tailored to
   # the one pattern that prompted this bug report.
+  # Each case pairs an original Regexp with a sample String whose split
+  # result we can predict. We only care that the coerced Regexp splits the
+  # same way as the original — the internal `.source` / `.options` may
+  # legitimately differ (Regexp.new of a "(?-mix:...)" string keeps the
+  # wrapper), so assert behaviour rather than internal representation.
   shared_examples 'coerces a serialised Regexp back into a Regexp' do |resolver, key|
-    [
-      /\s*[;|]\s*/,      # whitespace + pipe/semicolon (original bug repro)
-      /\|/,              # plain pipe
-      /,\s*/,            # comma + optional space
-      /\A\s*foo\s*\z/i   # flagged (case-insensitive) regex
-    ].each do |original|
-      it "rebuilds an equivalent Regexp for #{original.inspect} (serialised as #{original.to_s.inspect})" do
+    {
+      /\s*[;|]\s*/     => ['coll1 | coll2', %w[coll1 coll2]],      # original bug repro
+      /\|/             => ['a|b|c',         %w[a b c]],             # plain pipe
+      /,\s*/           => ['a, b, c',       %w[a b c]],             # comma + optional space
+      /\A\s*foo\s*\z/i => ['FOO',           []]                     # flagged (case-insensitive): split consumes entire string
+    }.each do |original, (sample, expected_split)|
+      it "rebuilds a Regexp that splits like #{original.inspect} (serialised as #{original.to_s.inspect})" do
         mappings = { key.to_s => { 'split' => original.to_s } }
         result   = host.public_send(resolver, mappings)
         expect(result).to be_a(Regexp)
-        # Pattern body + options should match the original so split/match behaviour is preserved.
-        expect(result.source).to eq(original.source)
-        expect(result.options).to eq(original.options)
+        expect(sample.split(result)).to eq(sample.split(original))
+        expect(sample.split(result)).to eq(expected_split)
       end
     end
   end

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -219,6 +219,38 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
     it 'still flags a header that matches no alias of any known property' do
       expect(unrecognized(%w[title totally_made_up])).to have_key('totally_made_up')
     end
+
+    # Bulkrax ships `rights_statement` with `generated: true`. The validator
+    # must still honour its `from:` aliases so a CSV with a `rights` column
+    # isn't flagged as unrecognised (and, via #find_missing_required_headers,
+    # `rights_statement` isn't reported missing when `rights` is present).
+    context 'when a mapping is flagged generated: true' do
+      let(:mappings) do
+        {
+          'title' => { 'from' => ['title'], 'split' => '\\|' },
+          'rights_statement' => { 'from' => %w[rights rights_statement], 'split' => '\\|', 'generated' => true }
+        }
+      end
+      let(:field_metadata) do
+        { 'GenericWorkResource' =>
+          { properties: %w[title rights_statement], required_terms: ['rights_statement'], controlled_vocab_terms: [] } }
+      end
+
+      before do
+        allow(field_analyzer).to receive(:find_or_create_field_list_for)
+          .with(model_name: 'GenericWorkResource')
+          .and_return('GenericWorkResource' => { 'properties' => %w[title rights_statement] })
+      end
+
+      it 'does not flag a `from:` alias ("rights") as unrecognised' do
+        expect(unrecognized(%w[title rights])).not_to have_key('rights')
+      end
+
+      it 'does not report rights_statement as missing when `rights` alias is present' do
+        missing = host.find_missing_required_headers(%w[title rights], field_metadata, mapping_manager)
+        expect(missing).to be_empty
+      end
+    end
   end
 
   describe '#resolve_children_split_pattern' do

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_hierarchy_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_hierarchy_spec.rb
@@ -173,7 +173,8 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHierarchy do
                                            'parents_1' => 'col1',
                                            'parents_2' => 'col2' })
         ids = Set.new(%w[col1 col2 work1])
-        split_hash  = host.build_item_hash(split_item,  {}, ids, type: 'work', parent: '|')
+        # Pattern is a regex source; escape '|' so it's not empty-alternation.
+        split_hash  = host.build_item_hash(split_item,  {}, ids, type: 'work', parent: '\\|')
         suffix_hash = host.build_item_hash(suffix_item, {}, ids, type: 'work')
         expect(split_hash[:parentIds]).to eq(suffix_hash[:parentIds])
       end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -633,6 +633,54 @@ module Bulkrax
           expect(subject.file_paths).to eq([])
         end
       end
+
+      # Characterisation coverage for how the `file` mapping's `split:` value
+      # is interpreted. These lock in each branch of the case statement in
+      # #file_paths so the behaviour is preserved when the inline block is
+      # later refactored into a shared helper.
+      context 'when the `file` mapping configures a split:' do
+        let(:base_mappings) { { 'Bulkrax::CsvParser' => { :file => { split: split_value } } } }
+
+        before do
+          allow(subject).to receive(:records).and_return([{ file: 'sun.jpg;moon.jpg' }])
+          allow(subject).to receive(:path_to_files).and_return('spec/fixtures/csv/files')
+          allow(File).to receive(:exist?).and_return(true)
+          allow(Bulkrax).to receive(:field_mappings).and_return(base_mappings)
+        end
+
+        context 'as a Regexp' do
+          let(:split_value) { /;/ }
+
+          it 'splits on the configured Regexp' do
+            result = subject.file_paths
+            expect(result).to include('spec/fixtures/csv/files/sun.jpg', 'spec/fixtures/csv/files/moon.jpg')
+          end
+        end
+
+        context 'as a regex-source String' do
+          let(:split_value) { ';' }
+
+          it 'builds a Regexp from the String and splits on it' do
+            result = subject.file_paths
+            expect(result).to include('spec/fixtures/csv/files/sun.jpg', 'spec/fixtures/csv/files/moon.jpg')
+          end
+        end
+      end
+
+      context 'when no `file` split: is configured' do
+        before do
+          # Explicit — no `file` key in the mappings, so split_value is nil.
+          allow(Bulkrax).to receive(:field_mappings).and_return('Bulkrax::CsvParser' => {})
+          allow(subject).to receive(:records).and_return([{ file: 'sun.jpg|moon.jpg' }])
+          allow(subject).to receive(:path_to_files).and_return('spec/fixtures/csv/files')
+          allow(File).to receive(:exist?).and_return(true)
+        end
+
+        it 'falls back to Bulkrax.multi_value_element_split_on' do
+          result = subject.file_paths
+          expect(result).to include('spec/fixtures/csv/files/sun.jpg', 'spec/fixtures/csv/files/moon.jpg')
+        end
+      end
     end
 
     describe '#missing_elements' do

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -639,7 +639,7 @@ module Bulkrax
       # #file_paths so the behaviour is preserved when the inline block is
       # later refactored into a shared helper.
       context 'when the `file` mapping configures a split:' do
-        let(:base_mappings) { { 'Bulkrax::CsvParser' => { :file => { split: split_value } } } }
+        let(:base_mappings) { { 'Bulkrax::CsvParser' => { file: { split: split_value } } } }
 
         before do
           allow(subject).to receive(:records).and_return([{ file: 'sun.jpg;moon.jpg' }])

--- a/spec/services/bulkrax/csv_template/file_validator_spec.rb
+++ b/spec/services/bulkrax/csv_template/file_validator_spec.rb
@@ -317,4 +317,49 @@ RSpec.describe Bulkrax::CsvTemplate::FileValidator do
       end
     end
   end
+
+  # Characterisation coverage for how the `file` cell is split when counting
+  # references. These specs pin the current behaviour (always uses
+  # Bulkrax.multi_value_element_split_on, ignoring any configured `file`
+  # split) so the change is visible when the implementation is refactored.
+  describe 'split behaviour for the file column' do
+    let(:csv_data) { [{ file: 'sun.jpg;moon.jpg', source_identifier: 'work1' }] }
+
+    context 'with no `file` mapping configured' do
+      it 'splits on Bulkrax.multi_value_element_split_on' do
+        validator = described_class.new(csv_data, nil)
+        expect(validator.count_references).to eq(1)
+        expect(validator.possible_missing_files?).to be true
+      end
+    end
+
+    context 'when the `file` mapping configures a non-default split' do
+      around do |spec|
+        old = Bulkrax.field_mappings['Bulkrax::CsvParser']
+        Bulkrax.field_mappings['Bulkrax::CsvParser'] = { 'file' => { split: ',' } }
+        spec.run
+        Bulkrax.field_mappings['Bulkrax::CsvParser'] = old
+      end
+
+      it 'currently ignores the configured split and uses the default (pre-refactor behaviour)' do
+        # Default /\s*[:;|]\s*/ splits the ";" from csv_data. A correctly-
+        # configured split would be `,` and would NOT split "sun.jpg;moon.jpg".
+        zip = Tempfile.new(['test', '.zip'])
+        Zip::File.open(zip.path, create: true) do |zipfile|
+          zipfile.get_output_stream('sun.jpg') { |f| f.write('a') }
+          zipfile.get_output_stream('moon.jpg') { |f| f.write('b') }
+        end
+        zip.rewind
+        validator = described_class.new(csv_data, zip)
+        # Default split pattern splits on ';' → 2 files found, 0 missing.
+        # When the refactor lands, the `,` configuration will keep
+        # "sun.jpg;moon.jpg" as a single token and neither filename will
+        # match the zip entries.
+        expect(validator.found_files_count).to eq(2)
+        expect(validator.missing_files).to eq([])
+        zip.close
+        zip.unlink
+      end
+    end
+  end
 end

--- a/spec/services/bulkrax/csv_template/file_validator_spec.rb
+++ b/spec/services/bulkrax/csv_template/file_validator_spec.rb
@@ -318,22 +318,26 @@ RSpec.describe Bulkrax::CsvTemplate::FileValidator do
     end
   end
 
-  # Characterisation coverage for how the `file` cell is split when counting
-  # references. These specs pin the current behaviour (always uses
-  # Bulkrax.multi_value_element_split_on, ignoring any configured `file`
-  # split) so the change is visible when the implementation is refactored.
+  # FileValidator splits via Bulkrax::CsvParser.file_split_pattern, so any
+  # `split:` configured on the `file` mapping is honoured — matching
+  # #file_paths and CsvEntry#add_file.
   describe 'split behaviour for the file column' do
-    let(:csv_data) { [{ file: 'sun.jpg;moon.jpg', source_identifier: 'work1' }] }
-
     context 'with no `file` mapping configured' do
-      it 'splits on Bulkrax.multi_value_element_split_on' do
+      let(:csv_data) { [{ file: 'sun.jpg;moon.jpg', source_identifier: 'work1' }] }
+
+      it 'falls back to Bulkrax.multi_value_element_split_on' do
         validator = described_class.new(csv_data, nil)
         expect(validator.count_references).to eq(1)
         expect(validator.possible_missing_files?).to be true
       end
     end
 
+    # Use a delimiter (`,`) that the default pattern /\s*[:;|]\s*/ does NOT
+    # match, so this spec genuinely distinguishes honouring-the-config from
+    # falling back to the default.
     context 'when the `file` mapping configures a non-default split' do
+      let(:csv_data) { [{ file: 'sun.jpg,moon.jpg', source_identifier: 'work1' }] }
+
       around do |spec|
         old = Bulkrax.field_mappings['Bulkrax::CsvParser']
         Bulkrax.field_mappings['Bulkrax::CsvParser'] = { 'file' => { split: ',' } }
@@ -341,9 +345,7 @@ RSpec.describe Bulkrax::CsvTemplate::FileValidator do
         Bulkrax.field_mappings['Bulkrax::CsvParser'] = old
       end
 
-      it 'currently ignores the configured split and uses the default (pre-refactor behaviour)' do
-        # Default /\s*[:;|]\s*/ splits the ";" from csv_data. A correctly-
-        # configured split would be `,` and would NOT split "sun.jpg;moon.jpg".
+      it 'honours the configured split' do
         zip = Tempfile.new(['test', '.zip'])
         Zip::File.open(zip.path, create: true) do |zipfile|
           zipfile.get_output_stream('sun.jpg') { |f| f.write('a') }
@@ -351,10 +353,6 @@ RSpec.describe Bulkrax::CsvTemplate::FileValidator do
         end
         zip.rewind
         validator = described_class.new(csv_data, zip)
-        # Default split pattern splits on ';' → 2 files found, 0 missing.
-        # When the refactor lands, the `,` configuration will keep
-        # "sun.jpg;moon.jpg" as a single token and neither filename will
-        # match the zip entries.
         expect(validator.found_files_count).to eq(2)
         expect(validator.missing_files).to eq([])
         zip.close

--- a/spec/services/bulkrax/csv_template/mapping_manager_spec.rb
+++ b/spec/services/bulkrax/csv_template/mapping_manager_spec.rb
@@ -21,10 +21,25 @@ RSpec.describe Bulkrax::CsvTemplate::MappingManager do
   end
 
   describe '#initialize' do
-    it 'loads mappings and filters out generated fields' do
+    it 'loads all mappings including ones flagged generated: true by default' do
+      # The import/validation path needs the FULL mapping so that aliases on
+      # a `generated: true` entry (e.g. `rights` → `rights_statement`) are
+      # still recognised.
       expect(manager.mappings).to be_a(Hash)
       expect(manager.mappings).to have_key('title')
-      expect(manager.mappings).not_to have_key('generated_field')
+      expect(manager.mappings).to have_key('generated_field')
+    end
+
+    context 'when initialized with include_generated: false' do
+      # Template-generation passes this so the downloadable CSV template
+      # doesn't expose system-maintained columns (date_uploaded, depositor,
+      # source_identifier, etc.).
+      let(:filtered_manager) { described_class.new(include_generated: false) }
+
+      it 'excludes mapping entries flagged generated: true' do
+        expect(filtered_manager.mappings).to have_key('title')
+        expect(filtered_manager.mappings).not_to have_key('generated_field')
+      end
     end
   end
 

--- a/spec/services/bulkrax/csv_template/split_formatter_spec.rb
+++ b/spec/services/bulkrax/csv_template/split_formatter_spec.rb
@@ -14,13 +14,19 @@ RSpec.describe Bulkrax::CsvTemplate::SplitFormatter do
       end
     end
 
+    # Output rules (see SplitFormatter#format_message):
+    #   1 delimiter  → "Split multiple values with X"
+    #   2 delimiters → "Split multiple values with X or Y"
+    #   3+ delimiters → "Split multiple values with X Y or Z"
+    # Spaces — not commas — between delimiters, so the message stays
+    # unambiguous when one of the delimiters IS a comma.
     context 'when split_value is true' do
       it 'uses the default Bulkrax multi_value_element_split_on pattern' do
         allow(Bulkrax).to receive(:multi_value_element_split_on).and_return(/[|;]/)
 
         result = formatter.format(true)
 
-        expect(result).to eq('Split multiple values with |, or ;')
+        expect(result).to eq('Split multiple values with | or ;')
       end
     end
 
@@ -31,16 +37,49 @@ RSpec.describe Bulkrax::CsvTemplate::SplitFormatter do
         expect(result).to eq('Split multiple values with |')
       end
 
-      it 'formats a character class pattern with multiple characters' do
+      it 'formats a two-char character class' do
         result = formatter.format('[|;]')
 
-        expect(result).to eq('Split multiple values with |, or ;')
+        expect(result).to eq('Split multiple values with | or ;')
+      end
+
+      it 'formats a three-char character class using spaces' do
+        result = formatter.format('[:;|]')
+
+        expect(result).to eq('Split multiple values with : ; or |')
+      end
+
+      it 'formats correctly when a delimiter is itself a comma' do
+        # This is precisely why the joiner is a space: "|, ," would be ambiguous.
+        result = formatter.format('[|,]')
+
+        expect(result).to eq('Split multiple values with | or ,')
       end
 
       it 'formats an escaped character pattern' do
         result = formatter.format('\|')
 
         expect(result).to eq('Split multiple values with |')
+      end
+    end
+
+    context 'when split_value is a Regexp' do
+      # Hosts may set split to a live Regexp (not just a String). Previously
+      # this fell through to the `else` branch and produced an inspect-style
+      # dump; now the formatter parses the Regexp's source like a String.
+      it 'formats a two-char character-class Regexp' do
+        expect(formatter.format(/[|;]/)).to eq('Split multiple values with | or ;')
+      end
+
+      it 'formats an escaped single-char Regexp' do
+        expect(formatter.format(/\|/)).to eq('Split multiple values with |')
+      end
+
+      it 'formats the default multi-value split Regexp' do
+        # /\s*[:;|]\s*/ is the gem-wide default — the most common case users
+        # see on the CSV template download. Without the punctuation fix this
+        # previously rendered as "Split multiple values with : ;, or |".
+        expect(formatter.format(/\s*[:;|]\s*/)).to eq('Split multiple values with : ; or |')
       end
     end
 

--- a/spec/services/bulkrax/split_pattern_coercion_spec.rb
+++ b/spec/services/bulkrax/split_pattern_coercion_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::SplitPatternCoercion do
+  describe '.coerce' do
+    it 'returns nil for nil' do
+      expect(described_class.coerce(nil)).to be_nil
+    end
+
+    it 'returns nil for an empty string' do
+      expect(described_class.coerce('')).to be_nil
+    end
+
+    it 'returns Bulkrax.multi_value_element_split_on when given true' do
+      expect(described_class.coerce(true)).to eq(Bulkrax.multi_value_element_split_on)
+    end
+
+    it 'returns a Regexp argument unchanged' do
+      pattern = /\s*,\s*/
+      expect(described_class.coerce(pattern)).to equal(pattern)
+    end
+
+    it 'returns non-string, non-regexp values unchanged' do
+      # Defensive: unusual values (Arrays, Symbols, etc.) shouldn't blow up.
+      expect(described_class.coerce(:some_symbol)).to eq(:some_symbol)
+    end
+
+    context 'when given a String' do
+      # String is treated as a regex source to match the long-standing
+      # contract in Bulkrax::ApplicationMatcher#process_split.
+      {
+        '\\|'                      => ['a|b',           %w[a b]],           # plain pipe
+        ','                        => ['a,b,c',         %w[a b c]],
+        '\\s*;\\s*'                => ['a ; b ;c',      %w[a b c]],
+        '(?-mix:\\s*[;|]\\s*)'     => ['coll1 | coll2', %w[coll1 coll2]],   # serialised Regexp
+        '(?i-mx:\\AFOO\\z)'        => ['FOO',           []]                 # serialised flagged Regexp
+      }.each do |src, (sample, expected)|
+        it "builds a Regexp from #{src.inspect} that splits #{sample.inspect} → #{expected.inspect}" do
+          result = described_class.coerce(src)
+          expect(result).to be_a(Regexp)
+          expect(sample.split(result)).to eq(expected)
+        end
+      end
+
+      it 'returns the original String when the source is not a valid Regexp' do
+        # e.g. a stray unclosed group. We don't raise, we just pass it through.
+        bad = '('
+        expect(described_class.coerce(bad)).to eq(bad)
+      end
+    end
+  end
+end

--- a/spec/services/bulkrax/split_pattern_coercion_spec.rb
+++ b/spec/services/bulkrax/split_pattern_coercion_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Bulkrax::SplitPatternCoercion do
       # String is treated as a regex source to match the long-standing
       # contract in Bulkrax::ApplicationMatcher#process_split.
       {
-        '\\|'                      => ['a|b',           %w[a b]],           # plain pipe
-        ','                        => ['a,b,c',         %w[a b c]],
-        '\\s*;\\s*'                => ['a ; b ;c',      %w[a b c]],
-        '(?-mix:\\s*[;|]\\s*)'     => ['coll1 | coll2', %w[coll1 coll2]],   # serialised Regexp
-        '(?i-mx:\\AFOO\\z)'        => ['FOO',           []]                 # serialised flagged Regexp
+        '\\|' => ['a|b', %w[a b]], # plain pipe
+        ',' => ['a,b,c', %w[a b c]],
+        '\\s*;\\s*' => ['a ; b ;c', %w[a b c]],
+        '(?-mix:\\s*[;|]\\s*)' => ['coll1 | coll2', %w[coll1 coll2]], # serialised Regexp
+        '(?i-mx:\\AFOO\\z)' => ['FOO', []] # serialised flagged Regexp
       }.each do |src, (sample, expected)|
         it "builds a Regexp from #{src.inspect} that splits #{sample.inspect} → #{expected.inspect}" do
           result = described_class.coerce(src)

--- a/spec/services/bulkrax/split_pattern_coercion_spec.rb
+++ b/spec/services/bulkrax/split_pattern_coercion_spec.rb
@@ -21,9 +21,13 @@ RSpec.describe Bulkrax::SplitPatternCoercion do
       expect(described_class.coerce(pattern)).to equal(pattern)
     end
 
-    it 'returns non-string, non-regexp values unchanged' do
-      # Defensive: unusual values (Arrays, Symbols, etc.) shouldn't blow up.
-      expect(described_class.coerce(:some_symbol)).to eq(:some_symbol)
+    it 'returns nil for values String#split could not accept (Symbol, Integer, Array, ...)' do
+      # The coercion's contract is "nil or Regexp", so unusual mapping values
+      # round-trip to nil rather than being handed straight to String#split
+      # (which would raise TypeError).
+      expect(described_class.coerce(:some_symbol)).to be_nil
+      expect(described_class.coerce(42)).to be_nil
+      expect(described_class.coerce([',', ';'])).to be_nil
     end
 
     context 'when given a String' do
@@ -43,10 +47,10 @@ RSpec.describe Bulkrax::SplitPatternCoercion do
         end
       end
 
-      it 'returns the original String when the source is not a valid Regexp' do
-        # e.g. a stray unclosed group. We don't raise, we just pass it through.
-        bad = '('
-        expect(described_class.coerce(bad)).to eq(bad)
+      it 'returns nil for a String that is not a valid Regexp source' do
+        # e.g. a stray unclosed group. We neither raise nor return an
+        # unusable String — callers can treat nil as "no split".
+        expect(described_class.coerce('(')).to be_nil
       end
     end
   end

--- a/spec/validators/bulkrax/csv_row/child_reference_spec.rb
+++ b/spec/validators/bulkrax/csv_row/child_reference_spec.rb
@@ -166,4 +166,27 @@ RSpec.describe Bulkrax::CsvRow::ChildReference do
       expect(context[:errors].first[:value]).to eq('missing_child')
     end
   end
+
+  context 'when child_split_pattern is a Regexp serialised as a String' do
+    let(:serialised_split) { '(?-mix:\\s*[;|]\\s*)' }
+    let(:all_ids)          { Set.new(%w[col1 work1 work2]) }
+
+    def make_context_with_split(split_pattern)
+      { errors: [], warnings: [], all_ids: all_ids, child_split_pattern: split_pattern,
+        find_record_by_source_identifier: nil }
+    end
+
+    it 'splits on | and validates each id individually' do
+      context = make_context_with_split(serialised_split)
+      described_class.call(make_record(children: 'work1 | work2'), 2, context)
+      expect(context[:errors]).to be_empty
+    end
+
+    it 'reports only the missing id when the String regex splits correctly' do
+      context = make_context_with_split(serialised_split)
+      described_class.call(make_record(children: 'work1 | missing_child'), 2, context)
+      expect(context[:errors].length).to eq(1)
+      expect(context[:errors].first[:value]).to eq('missing_child')
+    end
+  end
 end

--- a/spec/validators/bulkrax/csv_row/parent_reference_spec.rb
+++ b/spec/validators/bulkrax/csv_row/parent_reference_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe Bulkrax::CsvRow::ParentReference do
       split_context = make_context
       split_record = { source_identifier: 'work2', model: 'GenericWork',
                        parent: 'col1|missing_parent', raw_row: {} }
-      described_class.call(split_record, 2, split_context.merge(parent_split_pattern: '|'))
+      # Pattern is a regex source; '|' would be empty-alternation, so escape it.
+      described_class.call(split_record, 2, split_context.merge(parent_split_pattern: '\\|'))
 
       suffix_context = make_context
       suffix_record = { source_identifier: 'work2', model: 'GenericWork',

--- a/spec/validators/bulkrax/csv_row/parent_reference_spec.rb
+++ b/spec/validators/bulkrax/csv_row/parent_reference_spec.rb
@@ -117,4 +117,26 @@ RSpec.describe Bulkrax::CsvRow::ParentReference do
       expect(context[:errors].first[:value]).to eq('missing_parent')
     end
   end
+
+  context 'when parent_split_pattern is a Regexp serialised as a String' do
+    let(:serialised_split) { '(?-mix:\\s*[;|]\\s*)' }
+    let(:all_ids)          { Set.new(%w[coll1 coll2]) }
+
+    it 'splits on | and validates each id individually' do
+      context = make_context(all_ids: all_ids).merge(parent_split_pattern: serialised_split)
+      record = { source_identifier: 'work2', model: 'GenericWork',
+                 parent: 'coll1 | coll2', raw_row: {} }
+      described_class.call(record, 2, context)
+      expect(context[:errors]).to be_empty
+    end
+
+    it 'reports only the missing id when the String regex splits correctly' do
+      context = make_context(all_ids: all_ids).merge(parent_split_pattern: serialised_split)
+      record = { source_identifier: 'work2', model: 'GenericWork',
+                 parent: 'coll1 | missing_parent', raw_row: {} }
+      described_class.call(record, 2, context)
+      expect(context[:errors].length).to eq(1)
+      expect(context[:errors].first[:value]).to eq('missing_parent')
+    end
+  end
 end

--- a/spec/validators/bulkrax/csv_row/required_values_spec.rb
+++ b/spec/validators/bulkrax/csv_row/required_values_spec.rb
@@ -105,4 +105,45 @@ RSpec.describe Bulkrax::CsvRow::RequiredValues do
       end
     end
   end
+
+  # When the CSV uses an alias for a required field (e.g. `rights` satisfying
+  # `rights_statement` because `rights_statement: { from: ['rights', ...] }`),
+  # the validator must honour the mapping — otherwise the header-level check
+  # passes but every row still gets flagged as missing the value.
+  context 'when the CSV header uses a from: alias for a required field' do
+    let(:mapping_manager) do
+      mappings = {
+        'rights_statement' => { 'from' => ['rights', 'rights_statement', 'rights statement'], 'generated' => true },
+        'title' => { 'from' => ['title'] }
+      }
+      allow(Bulkrax).to receive(:field_mappings).and_return('Bulkrax::CsvParser' => mappings)
+      Bulkrax::CsvTemplate::MappingManager.new
+    end
+
+    def alias_context
+      make_context(required_terms: %w[title rights_statement]).merge(mapping_manager: mapping_manager)
+    end
+
+    it 'treats `rights` as satisfying the `rights_statement` requirement' do
+      record = make_record('title' => 'My Title', 'rights' => 'http://rightsstatements.org/vocab/CNE/1.0/')
+      described_class.call(record, 2, alias_context)
+      expect(alias_context[:errors]).to be_empty
+    end
+
+    it 'still flags rights_statement as missing when the `rights` column is blank' do
+      record = make_record('title' => 'My Title', 'rights' => '')
+      context = alias_context
+      described_class.call(record, 2, context)
+      expect(context[:errors].map { |e| e[:column] }).to contain_exactly('rights_statement')
+    end
+
+    it 'falls back to exact-header matching when no mapping_manager is provided' do
+      # Back-compat: callers that do not pass a mapping_manager (e.g. existing
+      # specs) still work because we short-circuit to the normalised header.
+      record = make_record('title' => 'My Title', 'rights_statement' => 'CNE')
+      context = make_context(required_terms: %w[title rights_statement])
+      described_class.call(record, 2, context)
+      expect(context[:errors]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
# Problem

Parents, children, and files columns were not honoring the field mappings split configuration. 
# Proposed Changes
This PR introduces a SplitPatternCoercion module to consolidate the behavior and keep it consistent between validators and all the locations using the split by delimiter feature. 

An additional bug was found and resolved dealing with validation of column headings, ensuring that any mapped term validates correctly. 