### PR TITLE
Truncate validations and other UI enhancements

### DIFF
--- a/app/assets/javascripts/bulkrax/datatables.js
+++ b/app/assets/javascripts/bulkrax/datatables.js
@@ -1,3 +1,22 @@
+function bulkraxDatatableLanguage() {
+  var i18n = (window.BulkraxI18n && window.BulkraxI18n.datatable && window.BulkraxI18n.datatable.language) || {}
+  return {
+    emptyTable: i18n.empty_table,
+    info: i18n.info,
+    infoEmpty: i18n.info_empty,
+    infoFiltered: i18n.info_filtered,
+    lengthMenu: i18n.length_menu,
+    loadingRecords: i18n.loading_records,
+    processing: i18n.processing,
+    search: i18n.search,
+    zeroRecords: i18n.zero_records,
+    paginate: {
+      next: i18n.next,
+      previous: i18n.previous
+    }
+  }
+}
+
 Blacklight.onLoad(function() {
   if($('#importer-show-table').length) {
     $('#importer-show-table').DataTable( {
@@ -10,6 +29,7 @@ Blacklight.onLoad(function() {
       "ajax": window.location.href.replace(/(\/(importers|exporters)\/\d+)/, "$1/entry_table.json"),
       "pageLength": 30,
       "lengthMenu": [[30, 100, 200], [30, 100, 200]],
+      "language": bulkraxDatatableLanguage(),
       "columns": [
         { "data": "identifier" },
         { "data": "id" },
@@ -45,6 +65,7 @@ Blacklight.onLoad(function() {
       "ajax": window.location.href.replace(/(\/importers)/, "$1/importer_table.json"),
       "pageLength": 30,
       "lengthMenu": [[30, 100, 200], [30, 100, 200]],
+      "language": bulkraxDatatableLanguage(),
       "order": [[2, 'desc']],
       "columns": [
         { "data": "name" },
@@ -76,6 +97,7 @@ Blacklight.onLoad(function() {
       "ajax": window.location.href.replace(/(\/exporters)/, "$1/exporter_table.json"),
       "pageLength": 30,
       "lengthMenu": [[30, 100, 200], [30, 100, 200]],
+      "language": bulkraxDatatableLanguage(),
       "columns": [
         { "data": "name" },
         { "data": "status_message" },
@@ -94,13 +116,22 @@ Blacklight.onLoad(function() {
 
 })
 
+function bulkraxDatatableFilters() {
+  return (window.BulkraxI18n && window.BulkraxI18n.datatable && window.BulkraxI18n.datatable.filters) || {}
+}
+
+function bulkraxDatatableStatuses() {
+  return (window.BulkraxI18n && window.BulkraxI18n.datatable && window.BulkraxI18n.datatable.status) || {}
+}
+
 function entrySelect() {
   let entrySelect = document.createElement('select')
   entrySelect.id = 'entry-filter'
   entrySelect.classList.value = 'form-control input-sm'
   entrySelect.style.marginRight = '10px'
 
-  entrySelect.add(new Option('Filter by Entry Class', ''))
+  var filters = bulkraxDatatableFilters()
+  entrySelect.add(new Option(filters.filter_by_entry_class || 'Filter by Entry Class', ''))
   // Read the options from the footer and add them to the entrySelect
   $('#importer-entry-classes').text().split('|').forEach(function (col, i) {
     entrySelect.add(new Option(col.trim()))
@@ -122,13 +153,17 @@ function statusSelect() {
   statusSelect.classList.value = 'form-control input-sm'
   statusSelect.style.marginRight = '10px'
 
-  statusSelect.add(new Option('Filter by Status', ''));
-  statusSelect.add(new Option('Complete'))
-  statusSelect.add(new Option('Pending'))
-  statusSelect.add(new Option('Failed'))
-  statusSelect.add(new Option('Skipped'))
-  statusSelect.add(new Option('Deleted'))
-  statusSelect.add(new Option('Complete (with failures)'))
+  var filters = bulkraxDatatableFilters()
+  var statuses = bulkraxDatatableStatuses()
+  statusSelect.add(new Option(filters.filter_by_status || 'Filter by Status', ''));
+  // The option value must remain the English status string, as that is what
+  // the backend search/filter logic matches against.
+  statusSelect.add(new Option(statuses.complete || 'Complete', 'Complete'))
+  statusSelect.add(new Option(statuses.pending || 'Pending', 'Pending'))
+  statusSelect.add(new Option(statuses.failed || 'Failed', 'Failed'))
+  statusSelect.add(new Option(statuses.skipped || 'Skipped', 'Skipped'))
+  statusSelect.add(new Option(statuses.deleted || 'Deleted', 'Deleted'))
+  statusSelect.add(new Option(statuses.complete_with_failures || 'Complete (with failures)', 'Complete (with failures)'))
 
   document.querySelector('div.dataTables_filter').firstChild.prepend(statusSelect)
 

--- a/app/assets/javascripts/bulkrax/importers_stepper.js
+++ b/app/assets/javascripts/bulkrax/importers_stepper.js
@@ -1663,8 +1663,11 @@
 
     // Download errors button
     if (data.validationErrorsCacheKey) {
+      var locale = $('input[name="locale"]').val()
       var downloadUrl =
-        CONSTANTS.ENDPOINTS.DOWNLOAD_VALIDATION_ERRORS + '?key=' + encodeURIComponent(data.validationErrorsCacheKey)
+        CONSTANTS.ENDPOINTS.DOWNLOAD_VALIDATION_ERRORS +
+        '?key=' + encodeURIComponent(data.validationErrorsCacheKey) +
+        (locale ? '&locale=' + encodeURIComponent(locale) : '')
       var $btn = $(
         '<a class="btn btn-outline-secondary btn-sm mt-2" href="' +
           downloadUrl +

--- a/app/assets/javascripts/bulkrax/importers_stepper.js
+++ b/app/assets/javascripts/bulkrax/importers_stepper.js
@@ -91,6 +91,9 @@
     // Hierarchy rendering limits
     MAX_TREE_DEPTH: 50, // Prevent stack overflow on deeply nested hierarchies
 
+    // Validation issue list cap — accordion shows up to this many items; full list is in the downloaded CSV
+    MAX_ISSUE_ITEMS: 10,
+
     // API endpoints
     ENDPOINTS: {
       DEMO_SCENARIOS: '/importers/guided_import/demo_scenarios',
@@ -1341,6 +1344,8 @@
     $('input[name="importer[parser_fields][override_rights_statement]"]').prop('checked', false)
 
     // Clear review step warnings from previous run
+    $('.review-errors-list').empty()
+    $('.review-errors').hide()
     $('.review-warnings-list').empty()
     $('.review-warnings').hide()
     $('.large-import-warning').hide()
@@ -1745,12 +1750,14 @@
     return grouped
   }
 
-  // Render missing required fields grouped by model
+  // Render missing required fields grouped by model. Group count capped at
+  // CONSTANTS.MAX_ISSUE_ITEMS so we never show a partial group.
   function renderMissingRequiredFields(items) {
     var groupedByModel = groupItemsByModel(items)
+    var modelNames = Object.keys(groupedByModel).slice(0, CONSTANTS.MAX_ISSUE_ITEMS)
     var parts = []
 
-    Object.keys(groupedByModel).forEach(function (modelName) {
+    modelNames.forEach(function (modelName) {
       parts.push('<div class="missing-field-group">')
       parts.push('<strong class="missing-field-model">' + modelName + '</strong>')
       parts.push('<ul>')
@@ -1768,14 +1775,32 @@
     return parts.join('')
   }
 
-  // Render default issue items (unrecognized fields, file references, etc.)
+  // Render default issue items (unrecognized fields, file references, etc.).
+  // When items carry a `category` (row-level errors/warnings), show up to
+  // CONSTANTS.MAX_ISSUE_ITEMS per category so each distinct problem type is
+  // represented. Otherwise fall back to a simple slice of the first N items.
   function renderDefaultIssueItems(items) {
-    var listItems = items.map(function (item) {
+    var hasCategories = items.some(function (item) { return item.category })
+    var capped = hasCategories ? capItemsPerCategory(items) : items.slice(0, CONSTANTS.MAX_ISSUE_ITEMS)
+    var listItems = capped.map(function (item) {
       var msg = item.message ? ' — ' + item.message : ''
       return '<li>• ' + item.field + msg + '</li>'
     })
 
     return '<ul>' + listItems.join('') + '</ul>'
+  }
+
+  // Keep the first CONSTANTS.MAX_ISSUE_ITEMS entries per category, preserving
+  // their original order so rows still read top-to-bottom within each category.
+  function capItemsPerCategory(items) {
+    var counts = {}
+    var result = []
+    items.forEach(function (item) {
+      var cat = item.category || 'uncategorized'
+      counts[cat] = (counts[cat] || 0) + 1
+      if (counts[cat] <= CONSTANTS.MAX_ISSUE_ITEMS) result.push(item)
+    })
+    return result
   }
 
   // Render issue items based on issue type
@@ -1845,7 +1870,7 @@
             issue.title,
             issue.icon,
             issue.severity,
-            issue.count,
+            countDisplayFor(issue),
             issue.defaultOpen,
             issueContent
           )
@@ -1853,6 +1878,144 @@
       })
     }
 
+  }
+
+  // Build the count badge display for a validation issue accordion.
+  // Returns a plain number (or null) normally, or an HTML fragment with a
+  // truncation note when the inline list is capped.
+  function countDisplayFor(issue) {
+    if (issue.count == null) return null
+    if (!isIssueTruncated(issue)) return issue.count
+
+    var noteText = t('validation_truncated_note', {
+      shown: issueShownCount(issue)
+    })
+    var tooltip = t('validation_truncated_tooltip')
+    return issue.count +
+      ' <span class="accordion-count-note" title="' + escapeHtml(tooltip) +
+      '" aria-label="' + escapeHtml(tooltip) + '">' +
+      escapeHtml(noteText) + '</span>'
+  }
+
+  // How many items are actually rendered in the accordion body, mirroring the
+  // slicing logic in renderDefaultIssueItems / renderMissingRequiredFields.
+  function issueShownCount(issue) {
+    var items = issue.items || []
+    if (!items.length) return 0
+
+    var hasModelField = issue.type === 'missing_required_fields' &&
+      items.some(function (item) { return item.model })
+    if (hasModelField) {
+      return Math.min(issueDisplayUnitCount(issue), CONSTANTS.MAX_ISSUE_ITEMS)
+    }
+
+    var hasCategories = items.some(function (item) { return item.category })
+    if (hasCategories) return capItemsPerCategory(items).length
+
+    return Math.min(items.length, CONSTANTS.MAX_ISSUE_ITEMS)
+  }
+
+  // Decide whether an issue's rendered item list is capped. Mirrors the
+  // slicing logic in renderDefaultIssueItems / renderMissingRequiredFields so
+  // the header note only appears when items are actually dropped.
+  function isIssueTruncated(issue) {
+    var items = issue.items || []
+    if (!items.length) return false
+
+    var hasModelField = issue.type === 'missing_required_fields' &&
+      items.some(function (item) { return item.model })
+    if (hasModelField) return issueDisplayUnitCount(issue) > CONSTANTS.MAX_ISSUE_ITEMS
+
+    var hasCategories = items.some(function (item) { return item.category })
+    if (hasCategories) {
+      var counts = {}
+      for (var i = 0; i < items.length; i++) {
+        var cat = items[i].category || 'uncategorized'
+        counts[cat] = (counts[cat] || 0) + 1
+        if (counts[cat] > CONSTANTS.MAX_ISSUE_ITEMS) return true
+      }
+      return false
+    }
+
+    return items.length > CONSTANTS.MAX_ISSUE_ITEMS
+  }
+
+  // Render one review-section (errors or warnings) on Step 3 from a list of
+  // validation issues. Row-level issues get a per-category breakdown.
+  function renderReviewIssueSection(issues, sectionSelector, listSelector, rowLevelType) {
+    if (!issues.length) {
+      $(listSelector).empty()
+      $(sectionSelector).hide()
+      return
+    }
+
+    var html = ''
+    issues.forEach(function (issue) {
+      var label = issue.title
+      if (issue.count) { label += ' (' + issue.count + ')' }
+      var detail = issue.summary || issue.description || ''
+      html += '<p>' + label
+      if (detail) { html += ' — ' + detail }
+      html += '</p>'
+
+      if (issue.type === rowLevelType && issue.items && issue.items.length) {
+        html += renderWarningCategoryBreakdown(issue.items)
+      }
+    })
+    $(listSelector).html(html)
+    $(sectionSelector).show()
+  }
+
+  // Render a bulleted breakdown of row-warning items grouped by category.
+  // Used on the Review & Start Import step under "Row Validation Warnings".
+  function renderWarningCategoryBreakdown(items) {
+    var counts = items.reduce(function (acc, item) {
+      var cat = item.category || 'uncategorized'
+      acc[cat] = (acc[cat] || 0) + 1
+      return acc
+    }, {})
+    var html = '<ul class="review-warning-categories">'
+    Object.keys(counts).forEach(function (cat) {
+      html += '<li>' + escapeHtml(warningCategoryLabel(cat)) + ' (' + counts[cat] + ')</li>'
+    })
+    html += '</ul>'
+    return html
+  }
+
+  // Localized label for a warning category, with a humanized fallback so a
+  // new validator category doesn't produce raw snake_case in the UI.
+  function warningCategoryLabel(category) {
+    var key = 'warning_category_' + category
+    var label = t(key)
+    if (label === key) return humanizeCategory(category)
+    return label
+  }
+
+  function humanizeCategory(category) {
+    if (!category) return ''
+    return category
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, function (c) { return c.toUpperCase() })
+  }
+
+  // Count the display units for an issue. For missing-required-fields grouped
+  // by model the unit is a model-group; for everything else it's an item.
+  function issueDisplayUnitCount(issue) {
+    if (!issue.items || !issue.items.length) return 0
+    var hasModelField = issue.type === 'missing_required_fields' &&
+      issue.items.some(function (item) { return item.model })
+    if (!hasModelField) return issue.items.length
+
+    var seen = {}
+    var groups = 0
+    issue.items.forEach(function (item) {
+      var key = item.model || 'Unknown'
+      if (!seen[key]) {
+        seen[key] = true
+        groups += 1
+      }
+    })
+    return groups
   }
 
   // Create accordion HTML
@@ -2313,26 +2476,14 @@
 
     $('.review-settings').html(settingsHtml)
 
-    // Warnings — derive from messages.issues so all warning types are covered
-    var warningIssues = (data && data.messages && data.messages.issues)
-      ? data.messages.issues.filter(function (issue) { return issue.severity === 'warning' })
-      : []
-    if (warningIssues.length > 0) {
-      var warningsHtml = ''
-      warningIssues.forEach(function (issue) {
-        var label = issue.title
-        if (issue.count) { label += ' (' + issue.count + ')' }
-        var detail = issue.summary || issue.description || ''
-        warningsHtml += '<p>' + label
-        if (detail) { warningsHtml += ' — ' + detail }
-        warningsHtml += '</p>'
-      })
-      $('.review-warnings-list').html(warningsHtml)
-      $('.review-warnings').show()
-    } else {
-      $('.review-warnings-list').empty()
-      $('.review-warnings').hide()
-    }
+    // Errors and warnings — derive from messages.issues so every severity is covered.
+    // Row-level errors/warnings get a per-category breakdown beneath the summary line.
+    var allIssues = (data && data.messages && data.messages.issues) || []
+    var errorIssues = allIssues.filter(function (issue) { return issue.severity === 'error' })
+    var warningIssues = allIssues.filter(function (issue) { return issue.severity === 'warning' })
+
+    renderReviewIssueSection(errorIssues, '.review-errors', '.review-errors-list', 'row_level_errors')
+    renderReviewIssueSection(warningIssues, '.review-warnings', '.review-warnings-list', 'row_level_warnings')
 
     // Large import warning
     $('.total-items-count').text(totalItems)

--- a/app/assets/javascripts/bulkrax/importers_stepper.js
+++ b/app/assets/javascripts/bulkrax/importers_stepper.js
@@ -1941,8 +1941,10 @@
   }
 
   // Render one review-section (errors or warnings) on Step 3 from a list of
-  // validation issues. Row-level issues get a per-category breakdown.
-  function renderReviewIssueSection(issues, sectionSelector, listSelector, rowLevelType) {
+  // validation issues. Each issue gets a breakdown appropriate to its shape:
+  // row-level issues group by category, missing_required_fields groups by
+  // model, everything else is a flat list of field names.
+  function renderReviewIssueSection(issues, sectionSelector, listSelector) {
     if (!issues.length) {
       $(listSelector).empty()
       $(sectionSelector).hide()
@@ -1958,12 +1960,51 @@
       if (detail) { html += ' — ' + detail }
       html += '</p>'
 
-      if (issue.type === rowLevelType && issue.items && issue.items.length) {
-        html += renderWarningCategoryBreakdown(issue.items)
-      }
+      html += renderReviewIssueBreakdown(issue)
     })
     $(listSelector).html(html)
     $(sectionSelector).show()
+  }
+
+  // Pick the right breakdown renderer for an issue on the Step 3 summary.
+  function renderReviewIssueBreakdown(issue) {
+    var items = issue.items || []
+    if (!items.length) return ''
+
+    if (issue.type === 'row_level_errors' || issue.type === 'row_level_warnings') {
+      return renderWarningCategoryBreakdown(items)
+    }
+    if (issue.type === 'missing_required_fields' && items.some(function (i) { return i.model })) {
+      return renderMissingRequiredBreakdown(items)
+    }
+    return renderFieldListBreakdown(items)
+  }
+
+  // Missing required fields grouped by model, matching the Step 1 accordion layout.
+  function renderMissingRequiredBreakdown(items) {
+    var grouped = groupItemsByModel(items)
+    var html = '<ul class="review-warning-categories">'
+    Object.keys(grouped).forEach(function (modelName) {
+      var fields = grouped[modelName].map(escapeHtml).join(', ')
+      html += '<li><strong>' + escapeHtml(modelName) + ':</strong> ' + fields + '</li>'
+    })
+    html += '</ul>'
+    return html
+  }
+
+  // Flat list of `field — message` entries — used for unrecognized fields,
+  // file references, notices. Message provides the context a bare field name
+  // lacks (e.g. "No model column found — all rows will be imported as …").
+  function renderFieldListBreakdown(items) {
+    var html = '<ul class="review-warning-categories">'
+    items.forEach(function (item) {
+      if (!item || !item.field) return
+      var line = escapeHtml(item.field)
+      if (item.message) line += ' — ' + escapeHtml(item.message)
+      html += '<li>' + line + '</li>'
+    })
+    html += '</ul>'
+    return html
   }
 
   // Render a bulleted breakdown of row-warning items grouped by category.
@@ -2482,8 +2523,8 @@
     var errorIssues = allIssues.filter(function (issue) { return issue.severity === 'error' })
     var warningIssues = allIssues.filter(function (issue) { return issue.severity === 'warning' })
 
-    renderReviewIssueSection(errorIssues, '.review-errors', '.review-errors-list', 'row_level_errors')
-    renderReviewIssueSection(warningIssues, '.review-warnings', '.review-warnings-list', 'row_level_warnings')
+    renderReviewIssueSection(errorIssues, '.review-errors', '.review-errors-list')
+    renderReviewIssueSection(warningIssues, '.review-warnings', '.review-warnings-list')
 
     // Large import warning
     $('.total-items-count').text(totalItems)

--- a/app/assets/stylesheets/bulkrax/stepper/_review.scss
+++ b/app/assets/stylesheets/bulkrax/stepper/_review.scss
@@ -50,20 +50,22 @@
   }
 }
 
-.review-warnings {
-  h4 {
-    color: $color-warning-dark;
-  }
-}
+.review-errors h4 { color: $color-error-dark; }
+.review-warnings h4 { color: $color-warning-dark; }
 
+.review-errors-list { color: $color-error-dark; }
+.review-warnings-list { color: $color-warning-dark; }
+
+.review-errors-list,
 .review-warnings-list {
-  font-size: 12px;
-  color: $color-warning-dark;
+  .review-warning-categories {
+    margin: 4px 0 8px 0;
+    padding-left: 20px;
+    list-style: disc;
 
-  ul {
-    margin: 0;
-    padding-left: 0;
-    list-style: none;
+    li {
+      font-size: 13px;
+    }
   }
 }
 

--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -75,7 +75,7 @@ module Bulkrax
       return unless defined?(::Hyrax)
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Importers', bulkrax.importers_path
+      add_breadcrumb t(:'bulkrax.headings.importers'), bulkrax.importers_path
       add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
       add_breadcrumb @entry.id
     end
@@ -88,7 +88,7 @@ module Bulkrax
       return unless defined?(::Hyrax)
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Exporters', bulkrax.exporters_path
+      add_breadcrumb t(:'bulkrax.headings.exporters'), bulkrax.exporters_path
       add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
       add_breadcrumb @entry.id
     end

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -48,7 +48,7 @@ module Bulkrax
       @exporter = Exporter.new
       return unless defined?(::Hyrax)
       add_exporter_breadcrumbs
-      add_breadcrumb 'New'
+      add_breadcrumb t(:'bulkrax.headings.new_exporter')
     end
 
     # GET /exporters/1/edit
@@ -56,7 +56,7 @@ module Bulkrax
       if defined?(::Hyrax)
         add_exporter_breadcrumbs
         add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
-        add_breadcrumb 'Edit'
+        add_breadcrumb t(:'bulkrax.headings.edit_exporter')
       end
 
       # Correctly populate export_source_collection input
@@ -141,7 +141,7 @@ module Bulkrax
     def add_exporter_breadcrumbs
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Exporters', bulkrax.exporters_path
+      add_breadcrumb t(:'bulkrax.headings.exporters'), bulkrax.exporters_path
     end
 
     # Download methods

--- a/app/controllers/bulkrax/guided_imports_controller.rb
+++ b/app/controllers/bulkrax/guided_imports_controller.rb
@@ -165,7 +165,7 @@ module Bulkrax
     def add_importer_breadcrumbs
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Importers', bulkrax.importers_path
+      add_breadcrumb t(:'bulkrax.headings.importers'), bulkrax.importers_path
     end
 
     def check_permissions

--- a/app/controllers/bulkrax/guided_imports_controller.rb
+++ b/app/controllers/bulkrax/guided_imports_controller.rb
@@ -48,6 +48,8 @@ module Bulkrax
     end
 
     def download_validation_errors
+      set_locale_from_params
+
       cache_key = params[:key].to_s
       expected_prefix = "guided_import_errors:#{session.id}:"
       return head :not_found unless cache_key.start_with?(expected_prefix)

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -63,7 +63,7 @@ module Bulkrax
         json_response('new')
       elsif defined?(::Hyrax)
         add_importer_breadcrumbs
-        add_breadcrumb 'New'
+        add_breadcrumb t(:'bulkrax.headings.new_importer')
       end
     end
 
@@ -84,7 +84,7 @@ module Bulkrax
       elsif defined?(::Hyrax)
         add_importer_breadcrumbs
         add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-        add_breadcrumb 'Edit'
+        add_breadcrumb t(:'bulkrax.headings.edit_importer')
       end
     end
 
@@ -189,9 +189,9 @@ module Bulkrax
       return unless defined?(::Hyrax)
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Importers', bulkrax.importers_path
+      add_breadcrumb t(:'bulkrax.headings.importers'), bulkrax.importers_path
       add_breadcrumb @importer.name, bulkrax.importer_path(@importer.id)
-      add_breadcrumb 'Upload Corrected Entries'
+      add_breadcrumb t(:'bulkrax.headings.upload_corrected_entries_action')
     end
 
     # POST /importer/1/upload_corrected_entries_file
@@ -313,7 +313,7 @@ module Bulkrax
     def add_importer_breadcrumbs
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-      add_breadcrumb 'Importers', bulkrax.importers_path
+      add_breadcrumb t(:'bulkrax.headings.importers'), bulkrax.importers_path
     end
 
     def setup_client(url)

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -35,7 +35,6 @@ module Bulkrax
             row_errors: row_errors, csv_data: csv_data, file_validator: file_validator,
             collections: collections, works: works, file_sets: file_sets, notices: notices
           )
-          apply_rights_statement_validation_override!(result, missing_required)
           result[:raw_csv_data] = csv_data
           result
         end
@@ -72,9 +71,8 @@ module Bulkrax
           file_key      = resolve_validation_key(mapping_manager, key: 'file',                            default: :file)
 
           csv_data       = parse_validation_rows(raw_csv, source_id_key, parent_key, children_key, file_key)
-          # Ensure all models are Strings for FieldAnalyzer lookup
           all_models     = csv_data.map { |r| r[:model].to_s }.reject(&:blank?).uniq
-          all_models    |= [Bulkrax.default_work_type.to_s] if Bulkrax.default_work_type.present?
+          all_models    |= [Bulkrax.default_work_type] if Bulkrax.default_work_type.present?
           field_analyzer = CsvTemplate::FieldAnalyzer.new(mappings, admin_set_id)
           field_metadata = build_validation_field_metadata(all_models, field_analyzer)
 

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation_helpers.rb
@@ -152,25 +152,12 @@ module Bulkrax
         }
       end
 
-      def apply_rights_statement_validation_override!(result, missing_required)
-        only_rights = missing_required.present? &&
-                      missing_required.all? { |h| h[:field].to_s == 'rights_statement' }
-        return unless only_rights && !result[:isValid]
-        return if result[:headers].blank?
-        return if result[:missingFiles]&.any?
-
-        result[:isValid]     = true
-        result[:hasWarnings] = true
-      end
-
       # Assembles the final result hash returned to the guided import UI.
       def assemble_result(headers:, missing_required:, header_issues:, row_errors:, csv_data:, file_validator:, collections:, works:, file_sets:, notices: []) # rubocop:disable Metrics/ParameterLists
-        row_error_entries   = row_errors.select { |e| e[:severity] == 'error' }
-        row_warning_entries = row_errors.select { |e| e[:severity] == 'warning' }
-        has_errors   = missing_required.any? || headers.blank? || csv_data.empty? ||
-                       file_validator.missing_files.any? || row_error_entries.any?
-        has_warnings = header_issues[:unrecognized].any? || header_issues[:empty_columns].any? ||
-                       file_validator.possible_missing_files? || row_warning_entries.any? || notices.any?
+        is_valid, has_warnings = determine_validity(
+          headers: headers, missing_required: missing_required, header_issues: header_issues,
+          row_errors: row_errors, csv_data: csv_data, file_validator: file_validator, notices: notices
+        )
 
         {
           headers: headers,
@@ -179,7 +166,7 @@ module Bulkrax
           unrecognized: header_issues[:unrecognized],
           emptyColumns: header_issues[:empty_columns],
           rowCount: csv_data.length,
-          isValid: !has_errors,
+          isValid: is_valid,
           hasWarnings: has_warnings,
           rowErrors: row_errors,
           collections: collections,
@@ -191,6 +178,27 @@ module Bulkrax
           foundFiles: file_validator.found_files_count,
           zipIncluded: file_validator.zip_included?
         }
+      end
+
+      # Returns [is_valid, has_warnings] for the assembled result.
+      # rights_statement can be supplied on Step 2, so a CSV missing ONLY the
+      # rights_statement column is valid-with-warnings rather than a blocker;
+      # the display formatter styles that case as a warning accordion.
+      def determine_validity(headers:, missing_required:, header_issues:, row_errors:, csv_data:, file_validator:, notices:) # rubocop:disable Metrics/ParameterLists
+        row_error_entries   = row_errors.select { |e| e[:severity] == 'error' }
+        row_warning_entries = row_errors.select { |e| e[:severity] == 'warning' }
+
+        only_rights_missing = missing_required.present? &&
+                              missing_required.all? { |h| h[:field].to_s == 'rights_statement' }
+        blocking_missing_required = missing_required.any? && !only_rights_missing
+
+        has_errors   = blocking_missing_required || headers.blank? || csv_data.empty? ||
+                       file_validator.missing_files.any? || row_error_entries.any?
+        has_warnings = header_issues[:unrecognized].any? || header_issues[:empty_columns].any? ||
+                       file_validator.possible_missing_files? || row_warning_entries.any? ||
+                       notices.any? || only_rights_missing
+
+        [!has_errors, has_warnings]
       end
 
       # Builds the find_record lambda used by row validators and hierarchy extraction.

--- a/app/services/bulkrax/stepper_response_formatter.rb
+++ b/app/services/bulkrax/stepper_response_formatter.rb
@@ -338,7 +338,8 @@ module Bulkrax
         message = [message, error[:suggestion]].compact.join(' ') if error[:suggestion].present?
         {
           field: I18n.t('bulkrax.importer.guided_import.stepper_response_formatter.row_errors_issue.row_label', row: error[:row], column: error[:column]),
-          message: message
+          message: message,
+          category: error[:category]
         }
       end
     end

--- a/app/services/bulkrax/validation_error_csv_builder.rb
+++ b/app/services/bulkrax/validation_error_csv_builder.rb
@@ -47,17 +47,19 @@ module Bulkrax
       blank_data    = Array.new(@headers.length)
 
       CSV.generate(force_quotes: false) do |csv|
-        csv << ['row', 'errors'] + @headers
+        csv << ['row', 'errors', 'categories'] + @headers
 
         file_level_error_rows.each do |message|
-          csv << [nil, message] + blank_data
+          csv << [nil, message, nil] + blank_data
         end
 
         @csv_data.each_with_index do |record, index|
           row_number = index + 2 # header is row 1; first data row is row 2
-          error_messages = errors_by_row[row_number]&.map { |e| e[:message] }&.join(' | ')
+          row_errors = errors_by_row[row_number]
+          error_messages   = row_errors&.map { |e| e[:message] }&.join(' | ')
+          error_categories = row_errors&.map { |e| e[:category] }&.compact&.uniq&.join(' | ')
           raw_row = record[:raw_row] || {}
-          csv << [row_number, error_messages] + @headers.map { |h| raw_row[h] }
+          csv << [row_number, error_messages, error_categories] + @headers.map { |h| raw_row[h] }
         end
       end
     end

--- a/app/services/bulkrax/validation_error_csv_builder.rb
+++ b/app/services/bulkrax/validation_error_csv_builder.rb
@@ -4,9 +4,18 @@ require 'csv'
 
 module Bulkrax
   # Builds a CSV string containing all validation errors from a guided import.
+  #
+  # Output columns, in order:
+  #   1. row        — 1-based row number from the source CSV (blank for file-level rows)
+  #   2. errors     — all error messages for that row, joined with " | "
+  #   3. categories — distinct validator categories for that row's errors (e.g.
+  #                   "missing_required_value | invalid_parent_reference"),
+  #                   joined with " | "; blank for file-level rows
+  #   4..N. the original CSV headers, carrying the raw cell values
+  #
   # File-level errors (missing required columns, unrecognized headers, empty
   # columns, missing files) appear first as summary rows with a blank `row`
-  # cell. Row-level errors follow, one output row per errored data row.
+  # and `categories` cell. Row-level errors follow, one output row per data row.
   #
   # Usage:
   #   csv = Bulkrax::ValidationErrorCsvBuilder.build(
@@ -21,10 +30,21 @@ module Bulkrax
   #     }
   #   )
   class ValidationErrorCsvBuilder
+    I18N_BASE = 'bulkrax.importer.guided_import.validation.validation_error_csv_builder'
+    private_constant :I18N_BASE
+
     # @param headers [Array<String>] original CSV headers in order
     # @param csv_data [Array<Hash>] one entry per data row; each hash has
     #   :raw_row (String-keyed hash of column=>value)
-    # @param row_errors [Array<Hash>] each hash has :row (Integer) and :message (String)
+    # @param row_errors [Array<Hash>] each hash describes a single row-level
+    #   validation result with the following keys:
+    #   - :row [Integer] 1-based source row number (header is row 1)
+    #   - :message [String] human-readable error/warning message
+    #   - :category [String, nil] validator category slug used to populate the
+    #     `categories` output column (e.g. 'missing_required_value',
+    #     'invalid_parent_reference'); omitted/nil categories are dropped
+    #   - :severity, :column, :value, :suggestion, :source_identifier — not
+    #     emitted by this builder but commonly present on the same hash
     # @param file_errors [Hash] file-level issues:
     #   - :missing_required [Array<Hash>] each hash has :model and :field
     #   - :unrecognized [Hash] column_name => suggestion_or_nil
@@ -78,21 +98,23 @@ module Bulkrax
       messages = []
 
       Array(@file_errors[:missing_required]).each do |entry|
-        messages << "Missing required column '#{entry[:field]}' (#{entry[:model]})"
+        messages << I18n.t("#{I18N_BASE}.missing_required_column", field: entry[:field], model: entry[:model])
       end
 
       Hash(@file_errors[:unrecognized]).each do |col, suggestion|
-        msg = "Unrecognized column '#{col}'"
-        msg += " (did you mean '#{suggestion}'?)" if suggestion.present?
-        messages << msg
+        messages << if suggestion.present?
+                      I18n.t("#{I18N_BASE}.unrecognized_column_with_suggestion", column: col, suggestion: suggestion)
+                    else
+                      I18n.t("#{I18N_BASE}.unrecognized_column", column: col)
+                    end
       end
 
       Array(@file_errors[:empty_columns]).each do |pos|
-        messages << "Column #{pos + 2} has no header and will be ignored during import"
+        messages << I18n.t("#{I18N_BASE}.empty_column", column: pos + 2)
       end
 
       Array(@file_errors[:missing_files]).each do |filename|
-        messages << "Missing file: #{filename}"
+        messages << I18n.t("#{I18N_BASE}.missing_file", filename: filename)
       end
 
       messages

--- a/app/validators/bulkrax/csv_row/required_values.rb
+++ b/app/validators/bulkrax/csv_row/required_values.rb
@@ -40,6 +40,8 @@ module Bulkrax
 
       def self.add_missing_required_value_errors(context, record, row_index, metadata, mapping_manager)
         (metadata[:required_terms] || []).each do |field|
+          column_present = record[:raw_row].keys.any? { |key| resolve_header(key.to_s, mapping_manager) == field }
+          next unless column_present
           next if record[:raw_row].any? { |key, value| resolve_header(key.to_s, mapping_manager) == field && value.present? }
 
           context[:errors] << {

--- a/app/views/bulkrax/exporters/edit.html.erb
+++ b/app/views/bulkrax/exporters/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span> Edit Exporter</h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span> <%= t('bulkrax.headings.edit_exporter') %></h1>
 <% end %>
 
 <div class="row">

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-cloud-download" aria-hidden="true"></span> Exporters</h1>
+  <h1><span class="fa fa-cloud-download" aria-hidden="true"></span> <%= t('bulkrax.headings.exporters') %></h1>
   <div class="pull-right">
     <%= link_to new_exporter_path, class: 'btn btn-primary', data: { turbolinks: false } do %>
       <span class="fa fa-edit" aria-hidden="true"></span> <%= t(:'helpers.action.exporter.new') %>
@@ -10,6 +10,8 @@
 <% content_for(:head) do %>
   <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
+
+<%= render 'bulkrax/shared/datatable_i18n' %>
 
 <div class="panel card panel-default">
   <div class="panel-body card-body">

--- a/app/views/bulkrax/exporters/new.html.erb
+++ b/app/views/bulkrax/exporters/new.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span> New Exporter</h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span> <%= t('bulkrax.headings.new_exporter') %></h1>
 <% end %>
 
 <div class="row">

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -9,7 +9,7 @@
 
     <% if File.exist?(@exporter.exporter_export_zip_path) %>
       <%= simple_form_for @exporter, method: :get, url: exporter_download_path(@exporter), html: { class: 'form-inline bulkrax-p-align' } do |form| %>
-        <strong>Download:</strong>
+        <strong><%= t('bulkrax.exporter.labels.download') %>:</strong>
         <%= render 'downloads', exporter: @exporter, form: form %>
         <%= form.button :submit, value: t('helpers.action.exporter.download'), data: { disable_with: false } %>
       <% end %>

--- a/app/views/bulkrax/guided_imports/new.html.erb
+++ b/app/views/bulkrax/guided_imports/new.html.erb
@@ -520,6 +520,13 @@
                 </div>
               </div>
 
+              <div class="review-section review-errors" style="display: none;">
+                <h4><%= t('bulkrax.importer.guided_import.step3.section_errors') %></h4>
+                <div class="review-errors-list">
+                  <!-- Will be populated by JS -->
+                </div>
+              </div>
+
               <div class="review-section review-warnings" style="display: none;">
                 <h4><%= t('bulkrax.importer.guided_import.step3.section_warnings') %></h4>
                 <div class="review-warnings-list">

--- a/app/views/bulkrax/importers/_edit_item_buttons.html.erb
+++ b/app/views/bulkrax/importers/_edit_item_buttons.html.erb
@@ -2,12 +2,12 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-body">
-        <h5>Options for Updating an Entry</h5>
+        <h5><%= t('bulkrax.importer.edit_form.entry_modal_title') %></h5>
         <hr />
-        <p>Rebuild metadata and files.</p>
+        <p><%= t('bulkrax.importer.edit_form.entry_rebuild_hint') %></p>
         <%= link_to t('helpers.action.importer.build'), item_entry_path(item, e), method: :patch, class: 'btn btn-primary'  %>
         <hr />
-        <p>Remove existing work and then recreate the works metadata and files.</p>
+        <p><%= t('bulkrax.importer.edit_form.entry_remove_and_recreate_hint') %></p>
         <%= link_to t('helpers.action.importer.remove_and_build'), item_entry_path(item, e, destroy_first: true), method: :patch, class: 'btn btn-primary'  %>
       </div>
       <div class="modal-footer">

--- a/app/views/bulkrax/importers/index.html.erb
+++ b/app/views/bulkrax/importers/index.html.erb
@@ -16,6 +16,8 @@
   <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
+<%= render 'bulkrax/shared/datatable_i18n' %>
+
 <div class="panel card panel-default">
   <div class="panel-body card-body">
     <div class="table-responsive">

--- a/app/views/bulkrax/importers/new.html.erb
+++ b/app/views/bulkrax/importers/new.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span> New Importer</h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span> <%= t('bulkrax.headings.new_importer') %></h1>
 <% end %>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -58,7 +58,7 @@
     <div class="accordion-container">
       <div class="accordion-heading" role="tab" id="parser-fields-heading">
         <a class="accordion-title" role="button" data-toggle="collapse" data-target="#parser-fields-importer-show" aria-expanded="true" aria-controls="parser-fields-importer-show">
-          Parser fields:
+          <%= t('bulkrax.importer.labels.parser_fields') %>:
         </a>
         <a role="button" data-toggle="collapse" data-target="#parser-fields-importer-show" aria-expanded="true" aria-controls="parser-fields-importer-show">
           <div class="accordion-icon fa fa-times-circle" aria-hidden="true"></div>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -1,3 +1,5 @@
+<%= render 'bulkrax/shared/datatable_i18n' %>
+
 <div class="col-xs-12 main-header d-flex justify-content-between align-items-center">
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importer: <%= @importer.name %></h1>
   <div class="pull-right">

--- a/app/views/bulkrax/shared/_datatable_i18n.html.erb
+++ b/app/views/bulkrax/shared/_datatable_i18n.html.erb
@@ -1,0 +1,3 @@
+<script>
+  window.BulkraxI18n = Object.assign({}, window.BulkraxI18n || {}, { datatable: <%= raw I18n.t('bulkrax.datatable').to_json %> });
+</script>

--- a/app/views/bulkrax/shared/_datatable_i18n.html.erb
+++ b/app/views/bulkrax/shared/_datatable_i18n.html.erb
@@ -1,3 +1,3 @@
 <script>
-  window.BulkraxI18n = Object.assign({}, window.BulkraxI18n || {}, { datatable: <%= raw I18n.t('bulkrax.datatable').to_json %> });
+  window.BulkraxI18n = Object.assign({}, window.BulkraxI18n || {}, { datatable: <%= raw json_escape(I18n.t('bulkrax.datatable').to_json) %> });
 </script>

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -199,9 +199,20 @@ de:
           validating: Validierung läuft...
           validation_failed: Die Validierung ist fehlgeschlagen. Bitte versuchen Sie es erneut.
           validation_timeout: Die Validierung ist fehlgeschlagen. Ihre Dateien sind möglicherweise zu groß. Bitte versuchen Sie es mit kleineren Dateien oder kontaktieren Sie den Support.
+          validation_truncated_note: auf %{shown} gekürzt – laden Sie die Fehler-CSV für die vollständige Liste herunter
+          validation_truncated_tooltip: Diese Liste ist begrenzt, damit die Seite übersichtlich bleibt. Die vollständige Liste finden Sie in der heruntergeladenen Fehler-CSV-Datei.
           visibility_institution: Institution
           visibility_private: Privat
           visibility_public: Öffentlich
+          warning_category_circular_reference: Zirkelbezug
+          warning_category_default_work_type_used: Standard-Werktyp verwendet
+          warning_category_duplicate_source_identifier: Doppelter Quell-Identifikator in CSV
+          warning_category_existing_source_identifier: Vorhandener Quell-Identifikator (wird aktualisiert)
+          warning_category_invalid_child_reference: Ungültige Kind-Referenz
+          warning_category_invalid_controlled_value: Ungültiger Wert aus kontrolliertem Vokabular
+          warning_category_invalid_parent_reference: Ungültige Eltern-Referenz
+          warning_category_missing_required_value: Erforderlicher Wert fehlt
+          warning_category_missing_source_identifier: Quell-Identifikator fehlt
           zip_limit: 'Es ist nur eine ZIP-Datei zulässig. Folgende Dateien wurden nicht hinzugefügt:'
         nav:
           back: Zurück
@@ -264,6 +275,7 @@ de:
           large_import_message_html: Sie sind im Begriff, <span class="total-items-count">%{count}</span> Artikel zu importieren. Große Importe dauern länger und sind schwieriger zu beheben. Erwägen Sie, den Import in kleinere Pakete aufzuteilen.
           large_import_warning: Warnung vor großen Importen
           ready_to_import: Bereit zum Importieren
+          section_errors: Fehler
           section_files: Dateien
           section_records: Aufzeichnungen
           section_settings: Einstellungen

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -17,13 +17,22 @@ de:
         record_link: "%{record_type} Link"
         unknown: Unbekannt
     exporter:
+      hints:
+        generated_metadata: Diese exportierten Felder können derzeit nicht importiert werden.
+        include_thumbnails: Diese exportierten Felder können derzeit nicht importiert werden.
+        limit: Lassen Sie das Feld leer oder geben Sie 0 ein, um alle Datensätze einzuschließen.
       labels:
         all: Alle
         collection: Sammlung
+        collection_entries: Sammlungseinträge
+        export_format: Exportformat
         export_from: Exportieren von
         export_source: Exportquelle
         export_type: Art des Exports
         field_mapping: Feldzuordnung
+        file_set_entries: Dateisatzeinträge
+        filter_by_date: Nach Datum filtern
+        finish_date: Enddatum
         full: Metadaten und Dateien
         generated_metadata: Generierte Metadaten einbeziehen?
         importer: Importeur
@@ -33,7 +42,20 @@ de:
         name: Name
         parser_fields: Parserfelder
         parser_klass: Parser
+        start_date: Startdatum
+        status: Status
+        total_entries: Gesamtzahl der Einträge
+        total_work_entries: Gesamtzahl der Werke
         user: Benutzer
+        work_entries: Werkeinträge
+        workflow_status:
+          approved: Genehmigt
+          broken_url: Defekte URL
+          deleted: Gelöscht
+          in_process: In Bearbeitung
+          ingested: Aufgenommen
+          needs_repair: Benötigt Reparatur
+          unapproved: Nicht genehmigt
         worktype: Arbeitsart
       prompts:
         export_from: Bitte wählen Sie eine Exportquelle aus.
@@ -96,8 +118,10 @@ de:
         override_rights_statement: Wenn diese Option aktiviert ist, wird immer die ausgewählte Rechteanweisung verwendet. Wenn sie deaktiviert ist, werden die Rechteanweisung oder die Rechteanweisung aus dem Datensatz verwendet. Der angegebene Wert wird nur verwendet, wenn dc:rights leer ist.
       labels:
         admin_set: Verwaltungssatz
+        collection_entries: Sammlungseinträge
         entry_id: Eintrags-ID
         exporter: Exporteur
+        file_set_entries: Dateisatzeinträge
         frequency: Frequenz
         identifier: Kennung
         importer: Importeur
@@ -109,6 +133,7 @@ de:
         total_work_entries: Total Works
         type: Typ
         user: Benutzer
+        work_entries: Werkeinträge
       oai:
         hints:
           metadata_prefix: Zum Beispiel oai_dc, dcterms oder oai_qdc
@@ -185,6 +210,8 @@ de:
           review_total: "%{total} Gesamt — %{collections} Sammlungen, %{works} Werke, %{file_sets} Dateisätze"
           review_visibility: 'Sichtweite:'
           server_error: Bei der Validierung ist ein Serverfehler aufgetreten. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support.
+          existing_record_badge: vorhanden
+          existing_record_title: Dieser Datensatz ist bereits im Repository vorhanden und wird beim Import verknüpft.
           shared_badge: geteilt
           starting: Es geht los...
           upload_csv_and_zip: CSV-Dateien + separat hochgeladene Dateien
@@ -336,6 +363,14 @@ de:
             errors:
               message: "Das referenzierte übergeordnete Element '%{value}' existiert nicht als %{field} in dieser CSV-Datei."
               suggestion: "Prüfen Sie auf Tippfehler oder fügen Sie den Datensatz für das übergeordnete Element hinzu."
+          child_reference_validator:
+            errors:
+              message: "Das referenzierte untergeordnete Element '%{value}' existiert nicht als %{field} in dieser CSV-Datei."
+              suggestion: "Prüfen Sie auf Tippfehler oder fügen Sie den Datensatz für das untergeordnete Element hinzu."
+          circular_reference_validator:
+            errors:
+              message: "'%{value}' ist Teil einer zirkulären Eltern-Kind-Beziehung."
+              suggestion: "Überprüfen Sie die Eltern-/Kind-Spalten und entfernen Sie die fehlerhaften Referenzen."
           passed: Validierung erfolgreich
           passed_warnings: Validierung mit Warnungen bestanden
           recognized_fields: 'Erkannte Felder: %{fields}'
@@ -353,6 +388,7 @@ de:
               message: "Das Feld '%{field}' ist erforderlich, ist aber für diese Zeile leer."
               suggestion: "Geben Sie einen Wert für '%{field}' ein."
           unable_to_process: Die Validierungsdateien konnten nicht verarbeitet werden.
+          empty_column: 'Spalte %{column} (keine Überschrift)'
           notices_desc: 'Diese Hinweise können Auswirkungen auf den Import Ihrer CSV-Datei haben:'
           notices_title: Importhinweise
           unrecognized_desc: 'Diese Spalten werden beim Import ignoriert:'
@@ -417,6 +453,7 @@ de:
         name: Name
         next_run: Nächster Lauf
         status: Status
+        status_set_at: Status gesetzt am
         total_collection_entries: Gesamtzahl der Sammlungseinträge
         total_file_set_entries: Gesamtzahl der Dateisätze
         total_work_entries: Gesamtzahl der Arbeitseinsätze

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -69,6 +69,7 @@ de:
           other: "%{count}-Fehler verhinderten das Speichern dieses Exporters:"
     headings:
       edit_exporter: Exporter bearbeiten
+      exporters: Exporteure
       importers: Importeure
       new_exporter: Neuer Exporter
       new_importer: Neuer Importer
@@ -467,6 +468,29 @@ de:
         total_work_entries: Gesamtzahl der Arbeitseinsätze
         type: Typ
         updated_at: Aktualisiert am
+    datatable:
+      filters:
+        filter_by_entry_class: Nach Eintragsklasse filtern
+        filter_by_status: Nach Status filtern
+      language:
+        empty_table: Keine Daten in der Tabelle verfügbar
+        info: Zeige _START_ bis _END_ von _TOTAL_ Einträgen
+        info_empty: Zeige 0 bis 0 von 0 Einträgen
+        info_filtered: (gefiltert aus _MAX_ Gesamteinträgen)
+        length_menu: _MENU_ Einträge anzeigen
+        loading_records: Lade...
+        next: Weiter
+        previous: Zurück
+        processing: Wird verarbeitet...
+        search: 'Suche:'
+        zero_records: Keine passenden Einträge gefunden
+      status:
+        complete: Abgeschlossen
+        complete_with_failures: Abgeschlossen (mit Fehlern)
+        deleted: Gelöscht
+        failed: Fehlgeschlagen
+        pending: Ausstehend
+        skipped: Übersprungen
   helpers:
     action:
       exporter:

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -69,11 +69,13 @@ de:
           other: "%{count}-Fehler verhinderten das Speichern dieses Exporters:"
     headings:
       edit_exporter: Exporter bearbeiten
+      edit_importer: Importer bearbeiten
       exporters: Exporteure
       importers: Importeure
       new_exporter: Neuer Exporter
       new_importer: Neuer Importer
       upload_corrected_entries: 'Korrigierte Einträge hochgeladen: %{name}'
+      upload_corrected_entries_action: Korrigierte Einträge hochladen
     importer:
       bagit:
         bags_to_import: 'Zu importierender Beutel oder Beutel:'

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -25,6 +25,7 @@ de:
         all: Alle
         collection: Sammlung
         collection_entries: Sammlungseinträge
+        download: Herunterladen
         export_format: Exportformat
         export_from: Exportieren von
         export_source: Exportquelle
@@ -67,7 +68,10 @@ de:
           one: 'Ein Fehler verhinderte das Speichern dieses Exporters:'
           other: "%{count}-Fehler verhinderten das Speichern dieses Exporters:"
     headings:
+      edit_exporter: Exporter bearbeiten
       importers: Importeure
+      new_exporter: Neuer Exporter
+      new_importer: Neuer Importer
       upload_corrected_entries: 'Korrigierte Einträge hochgeladen: %{name}'
     importer:
       bagit:
@@ -99,6 +103,9 @@ de:
           private: Privat
           public: Öffentlich
       edit_form:
+        entry_modal_title: Optionen zum Aktualisieren eines Eintrags
+        entry_rebuild_hint: Metadaten und Dateien neu erstellen.
+        entry_remove_and_recreate_hint: Bestehendes Werk entfernen und anschließend Metadaten und Dateien des Werks neu erstellen.
         modal_title: Optionen zum Aktualisieren des Importers
         remove_and_rerun_hint: Löschen Sie alle Ihre Arbeiten und führen Sie den Import anschließend erneut von einer leeren Seite aus. Dadurch werden alle Dateien und Verknüpfungen entfernt, und alle seit dem letzten Import vorgenommenen Änderungen gehen verloren.
         update_and_harvest_hint: Aktualisieren Sie die Werte im Importformular und aktualisieren Sie die Elemente, die sich in der Quelle geändert haben.
@@ -127,6 +134,7 @@ de:
         importer: Importeur
         limit: Limit
         name: Name
+        parser_fields: Parserfelder
         parser_klass: Parser
         total_collections: Gesamteinnahmen
         total_file_sets: Gesamtdateisätze

--- a/config/locales/bulkrax.de.yml
+++ b/config/locales/bulkrax.de.yml
@@ -398,6 +398,12 @@ de:
             errors:
               message: "Das Feld '%{field}' ist erforderlich, ist aber für diese Zeile leer."
               suggestion: "Geben Sie einen Wert für '%{field}' ein."
+          validation_error_csv_builder:
+            empty_column: "Spalte %{column} hat keine Überschrift und wird beim Import ignoriert"
+            missing_file: "Fehlende Datei: %{filename}"
+            missing_required_column: "Fehlende Pflichtspalte '%{field}' (%{model})"
+            unrecognized_column: "Unbekannte Spalte '%{column}'"
+            unrecognized_column_with_suggestion: "Unbekannte Spalte '%{column}' (meinten Sie '%{suggestion}'?)"
           unable_to_process: Die Validierungsdateien konnten nicht verarbeitet werden.
           empty_column: 'Spalte %{column} (keine Überschrift)'
           notices_desc: 'Diese Hinweise können Auswirkungen auf den Import Ihrer CSV-Datei haben:'

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -398,6 +398,12 @@ en:
             errors:
               message: "Field '%{field}' is required but is empty for this row."
               suggestion: "Add a value for '%{field}'."
+          validation_error_csv_builder:
+            empty_column: "Column %{column} has no header and will be ignored during import"
+            missing_file: "Missing file: %{filename}"
+            missing_required_column: "Missing required column '%{field}' (%{model})"
+            unrecognized_column: "Unrecognized column '%{column}'"
+            unrecognized_column_with_suggestion: "Unrecognized column '%{column}' (did you mean '%{suggestion}'?)"
           unable_to_process: Unable to process files for validation
           empty_column: 'Column %{column} (no header)'
           notices_desc: 'These notices may affect how your CSV is imported:'

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -25,6 +25,7 @@ en:
         all: All
         collection: Collection
         collection_entries: Collection Entries
+        download: Download
         export_format: Export Format
         export_from: Export From
         export_source: Export Source
@@ -67,7 +68,10 @@ en:
           one: '1 error prohibited this exporter from being saved:'
           other: "%{count} errors prohibited this exporter from being saved:"
     headings:
+      edit_exporter: Edit Exporter
       importers: Importers
+      new_exporter: New Exporter
+      new_importer: New Importer
       upload_corrected_entries: 'Upload Corrected Entries: %{name}'
     importer:
       bagit:
@@ -99,6 +103,9 @@ en:
           private: Private
           public: Public
       edit_form:
+        entry_modal_title: Options for Updating an Entry
+        entry_rebuild_hint: Rebuild metadata and files.
+        entry_remove_and_recreate_hint: Remove existing work and then recreate the works metadata and files.
         modal_title: Options for Updating the Importer
         remove_and_rerun_hint: Remove all works and then run the import again from a clean slate. This will remove all files and associations and any edits made since the last import will be lost.
         update_and_harvest_hint: Update the values in the importer form and update items that have changed at the source.
@@ -127,6 +134,7 @@ en:
         importer: Importer
         limit: Limit
         name: Name
+        parser_fields: Parser fields
         parser_klass: Parser
         total_collections: Total Collections
         total_file_sets: Total File Sets

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -69,11 +69,13 @@ en:
           other: "%{count} errors prohibited this exporter from being saved:"
     headings:
       edit_exporter: Edit Exporter
+      edit_importer: Edit Importer
       exporters: Exporters
       importers: Importers
       new_exporter: New Exporter
       new_importer: New Importer
       upload_corrected_entries: 'Upload Corrected Entries: %{name}'
+      upload_corrected_entries_action: Upload Corrected Entries
     importer:
       bagit:
         bags_to_import: 'Bag or Bags to Import:'

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -226,9 +226,20 @@ en:
           validating: Validating...
           validation_failed: Validation failed. Please try again.
           validation_timeout: Validation timed out. Your files may be too large. Please try with smaller files or contact support.
+          validation_truncated_note: truncated to %{shown} — download errors CSV for full list
+          validation_truncated_tooltip: This list is capped to keep the page readable. The full list is in the Download errors CSV file.
           visibility_institution: Institution
           visibility_private: Private
           visibility_public: Public
+          warning_category_circular_reference: Circular reference
+          warning_category_default_work_type_used: Default work type used
+          warning_category_duplicate_source_identifier: Duplicate source identifier in CSV
+          warning_category_existing_source_identifier: Existing source identifier (will update)
+          warning_category_invalid_child_reference: Invalid child reference
+          warning_category_invalid_controlled_value: Invalid controlled vocabulary value
+          warning_category_invalid_parent_reference: Invalid parent reference
+          warning_category_missing_required_value: Missing required value
+          warning_category_missing_source_identifier: Missing source identifier
           zip_limit: 'Only 1 ZIP file allowed. The following files were not added:'
         nav:
           back: Back
@@ -291,6 +302,7 @@ en:
           large_import_message_html: You're about to import <span class="total-items-count">%{count}</span> items. Large imports take longer and are harder to troubleshoot. Consider splitting into smaller batches.
           large_import_warning: Large Import Warning
           ready_to_import: Ready to Import
+          section_errors: Errors
           section_files: Files
           section_records: Records
           section_settings: Settings

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -69,6 +69,7 @@ en:
           other: "%{count} errors prohibited this exporter from being saved:"
     headings:
       edit_exporter: Edit Exporter
+      exporters: Exporters
       importers: Importers
       new_exporter: New Exporter
       new_importer: New Importer
@@ -467,6 +468,29 @@ en:
         total_work_entries: Total Work Entries
         type: Type
         updated_at: Updated At
+    datatable:
+      filters:
+        filter_by_entry_class: Filter by Entry Class
+        filter_by_status: Filter by Status
+      language:
+        empty_table: No data available in table
+        info: Showing _START_ to _END_ of _TOTAL_ entries
+        info_empty: Showing 0 to 0 of 0 entries
+        info_filtered: (filtered from _MAX_ total entries)
+        length_menu: Show _MENU_ entries
+        loading_records: Loading...
+        next: Next
+        previous: Previous
+        processing: Processing...
+        search: 'Search:'
+        zero_records: No matching records found
+      status:
+        complete: Complete
+        complete_with_failures: Complete (with failures)
+        deleted: Deleted
+        failed: Failed
+        pending: Pending
+        skipped: Skipped
   helpers:
     action:
       exporter:

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -199,9 +199,20 @@ es:
           validating: Validando...
           validation_failed: Error en la validación. Inténtalo de nuevo.
           validation_timeout: Se agotó el tiempo de validación. Es posible que sus archivos sean demasiado grandes. Intente con archivos más pequeños o contacte con el soporte técnico.
+          validation_truncated_note: truncado a %{shown} — descargue el CSV de errores para ver la lista completa
+          validation_truncated_tooltip: Esta lista está limitada para mantener la página legible. La lista completa está en el archivo CSV de errores descargable.
           visibility_institution: Institución
           visibility_private: Privado
           visibility_public: Público
+          warning_category_circular_reference: Referencia circular
+          warning_category_default_work_type_used: Tipo de obra predeterminado utilizado
+          warning_category_duplicate_source_identifier: Identificador de origen duplicado en el CSV
+          warning_category_existing_source_identifier: Identificador de origen existente (se actualizará)
+          warning_category_invalid_child_reference: Referencia secundaria no válida
+          warning_category_invalid_controlled_value: Valor de vocabulario controlado no válido
+          warning_category_invalid_parent_reference: Referencia principal no válida
+          warning_category_missing_required_value: Falta un valor obligatorio
+          warning_category_missing_source_identifier: Falta el identificador de origen
           zip_limit: 'Solo se permite un archivo ZIP. No se agregaron los siguientes archivos:'
         nav:
           back: Atrás
@@ -264,6 +275,7 @@ es:
           large_import_message_html: Está a punto de importar <span class="total-items-count">%{count}</span> artículos. Las importaciones grandes tardan más y son más difíciles de solucionar. Considere dividir el proceso en lotes más pequeños.
           large_import_warning: Advertencia sobre grandes importaciones
           ready_to_import: Listo para importar
+          section_errors: Errores
           section_files: Archivos
           section_records: Archivos
           section_settings: Ajustes

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -17,13 +17,22 @@ es:
         record_link: Enlace %{record_type}
         unknown: Desconocido
     exporter:
+      hints:
+        generated_metadata: Estos campos exportados no se pueden importar actualmente.
+        include_thumbnails: Estos campos exportados no se pueden importar actualmente.
+        limit: Deje en blanco o 0 para todos los registros
       labels:
         all: Todo
         collection: Recopilación
+        collection_entries: Entradas de colección
+        export_format: Formato de exportación
         export_from: Exportar desde
         export_source: Fuente de exportación
         export_type: Tipo de Exportación
         field_mapping: Mapeo de campos
+        file_set_entries: Entradas de conjunto de archivos
+        filter_by_date: Filtrar por fecha
+        finish_date: Fecha de finalización
         full: Metadatos y archivos
         generated_metadata: "¿Incluir metadatos generados?"
         importer: Importador
@@ -33,7 +42,20 @@ es:
         name: Nombre
         parser_fields: Campos del analizador
         parser_klass: Analizador sintáctico
+        start_date: Fecha de inicio
+        status: Estado
+        total_entries: Total de entradas
+        total_work_entries: Total de obras
         user: Usuario
+        work_entries: Entradas de obras
+        workflow_status:
+          approved: Aprobado
+          broken_url: URL rota
+          deleted: Eliminado
+          in_process: En proceso
+          ingested: Ingresado
+          needs_repair: Necesita reparación
+          unapproved: No aprobado
         worktype: Tipo de trabajo
       prompts:
         export_from: Por favor seleccione una fuente de exportación
@@ -96,8 +118,10 @@ es:
         override_rights_statement: Si está marcada, usar siempre la declaración de derechos seleccionada. Si no está marcada, usar los derechos o la declaración de derechos del registro y usar solo el valor proporcionado si dc:rights está en blanco.
       labels:
         admin_set: Conjunto administrativo
+        collection_entries: Entradas de colección
         entry_id: ID de entrada
         exporter: Exportador
+        file_set_entries: Entradas de conjunto de archivos
         frequency: Frecuencia
         identifier: Identificador
         importer: Importador
@@ -109,6 +133,7 @@ es:
         total_work_entries: Obras totales
         type: Tipo
         user: Usuario
+        work_entries: Entradas de obras
       oai:
         hints:
           metadata_prefix: Como oai_dc, dcterms o oai_qdc
@@ -185,6 +210,8 @@ es:
           review_total: "%{total} en total: %{collections} colecciones, %{works} obras, %{file_sets} conjuntos de archivos"
           review_visibility: 'Visibilidad:'
           server_error: Error del servidor durante la validación. Inténtalo de nuevo o contacta con el soporte técnico.
+          existing_record_badge: existente
+          existing_record_title: Este registro ya existe en el repositorio y se enlazará durante la importación.
           shared_badge: compartido
           starting: A partir de...
           upload_csv_and_zip: CSV + archivos cargados por separado
@@ -336,6 +363,14 @@ es:
             errors:
               message: "El elemento primario referenciado '%{value}' no existe como %{field} en este CSV."
               suggestion: "Busque errores tipográficos o añada el registro primario."
+          child_reference_validator:
+            errors:
+              message: "El elemento secundario referenciado '%{value}' no existe como %{field} en este CSV."
+              suggestion: "Busque errores tipográficos o añada el registro secundario."
+          circular_reference_validator:
+            errors:
+              message: "'%{value}' forma parte de una relación padre-hijo circular."
+              suggestion: "Revise las columnas de padre/hijo y elimine las referencias incorrectas."
           passed: Validación aprobada
           passed_warnings: Validación aprobada con advertencias
           recognized_fields: 'Campos reconocidos: %{fields}'
@@ -353,6 +388,7 @@ es:
               message: "El campo '%{field}' es obligatorio pero está vacío para esta fila."
               suggestion: "Añada un valor para '%{field}'."
           unable_to_process: No se pueden procesar archivos para su validación
+          empty_column: 'Columna %{column} (sin encabezado)'
           notices_desc: 'Estos avisos pueden afectar cómo se importa su CSV:'
           notices_title: Avisos de importación
           unrecognized_desc: 'Estas columnas se ignorarán durante la importación:'
@@ -417,6 +453,7 @@ es:
         name: Nombre
         next_run: Próxima carrera
         status: Estado
+        status_set_at: Estado establecido en
         total_collection_entries: Entradas totales de la colección
         total_file_set_entries: Entradas totales del conjunto de archivos
         total_work_entries: Total de entradas de trabajo

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -398,6 +398,12 @@ es:
             errors:
               message: "El campo '%{field}' es obligatorio pero está vacío para esta fila."
               suggestion: "Añada un valor para '%{field}'."
+          validation_error_csv_builder:
+            empty_column: "La columna %{column} no tiene encabezado y se ignorará durante la importación"
+            missing_file: "Archivo faltante: %{filename}"
+            missing_required_column: "Falta la columna obligatoria '%{field}' (%{model})"
+            unrecognized_column: "Columna no reconocida '%{column}'"
+            unrecognized_column_with_suggestion: "Columna no reconocida '%{column}' (¿quiso decir '%{suggestion}'?)"
           unable_to_process: No se pueden procesar archivos para su validación
           empty_column: 'Columna %{column} (sin encabezado)'
           notices_desc: 'Estos avisos pueden afectar cómo se importa su CSV:'

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -69,11 +69,13 @@ es:
           other: 'Los errores %{count} impidieron que se guardara este exportador:'
     headings:
       edit_exporter: Editar exportador
+      edit_importer: Editar importador
       exporters: Exportadores
       importers: Importadores
       new_exporter: Nuevo exportador
       new_importer: Nuevo importador
       upload_corrected_entries: 'Subir entradas corregidas: %{name}'
+      upload_corrected_entries_action: Subir entradas corregidas
     importer:
       bagit:
         bags_to_import: 'Bolsa o Bolsas para Importar:'

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -69,6 +69,7 @@ es:
           other: 'Los errores %{count} impidieron que se guardara este exportador:'
     headings:
       edit_exporter: Editar exportador
+      exporters: Exportadores
       importers: Importadores
       new_exporter: Nuevo exportador
       new_importer: Nuevo importador
@@ -467,6 +468,29 @@ es:
         total_work_entries: Total de entradas de trabajo
         type: Tipo
         updated_at: Actualizado en
+    datatable:
+      filters:
+        filter_by_entry_class: Filtrar por clase de entrada
+        filter_by_status: Filtrar por estado
+      language:
+        empty_table: No hay datos disponibles en la tabla
+        info: Mostrando _START_ a _END_ de _TOTAL_ entradas
+        info_empty: Mostrando 0 a 0 de 0 entradas
+        info_filtered: (filtrado de _MAX_ entradas en total)
+        length_menu: Mostrar _MENU_ entradas
+        loading_records: Cargando...
+        next: Siguiente
+        previous: Anterior
+        processing: Procesando...
+        search: 'Buscar:'
+        zero_records: No se encontraron registros coincidentes
+      status:
+        complete: Completo
+        complete_with_failures: Completo (con errores)
+        deleted: Eliminado
+        failed: Fallido
+        pending: Pendiente
+        skipped: Omitido
   helpers:
     action:
       exporter:

--- a/config/locales/bulkrax.es.yml
+++ b/config/locales/bulkrax.es.yml
@@ -25,6 +25,7 @@ es:
         all: Todo
         collection: Recopilación
         collection_entries: Entradas de colección
+        download: Descargar
         export_format: Formato de exportación
         export_from: Exportar desde
         export_source: Fuente de exportación
@@ -67,7 +68,10 @@ es:
           one: '1 error impidió que se guardara este exportador:'
           other: 'Los errores %{count} impidieron que se guardara este exportador:'
     headings:
+      edit_exporter: Editar exportador
       importers: Importadores
+      new_exporter: Nuevo exportador
+      new_importer: Nuevo importador
       upload_corrected_entries: 'Subir entradas corregidas: %{name}'
     importer:
       bagit:
@@ -99,6 +103,9 @@ es:
           private: Privado
           public: Público
       edit_form:
+        entry_modal_title: Opciones para actualizar una entrada
+        entry_rebuild_hint: Reconstruir metadatos y archivos.
+        entry_remove_and_recreate_hint: Eliminar la obra existente y luego volver a crear los metadatos y archivos de la obra.
         modal_title: Opciones para actualizar el importador
         remove_and_rerun_hint: Elimine todos los trabajos y vuelva a importar desde cero. Esto eliminará todos los archivos y asociaciones, y se perderán todas las modificaciones realizadas desde la última importación.
         update_and_harvest_hint: Actualice los valores en el formulario del importador y actualice los elementos que han cambiado en la fuente.
@@ -127,6 +134,7 @@ es:
         importer: Importador
         limit: Límite
         name: Nombre
+        parser_fields: Campos del analizador
         parser_klass: Analizador sintáctico
         total_collections: Colecciones totales
         total_file_sets: Conjuntos totales de archivos

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -398,6 +398,12 @@ fr:
             errors:
               message: "Le champ « %{field} » est obligatoire mais il est vide pour cette ligne."
               suggestion: "Ajoutez une valeur pour « %{field} »."
+          validation_error_csv_builder:
+            empty_column: "La colonne %{column} n'a pas d'en-tête et sera ignorée lors de l'importation"
+            missing_file: "Fichier manquant : %{filename}"
+            missing_required_column: "Colonne obligatoire manquante « %{field} » (%{model})"
+            unrecognized_column: "Colonne non reconnue « %{column} »"
+            unrecognized_column_with_suggestion: "Colonne non reconnue « %{column} » (vouliez-vous dire « %{suggestion} » ?)"
           unable_to_process: Impossible de traiter les fichiers pour validation
           empty_column: 'Colonne %{column} (sans en-tête)'
           notices_desc: 'Ces avis peuvent affecter la façon dont votre CSV est importé :'

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -69,10 +69,12 @@ fr:
           other: 'Des erreurs %{count} ont empêché l''enregistrement de cet exportateur :'
     headings:
       edit_exporter: Modifier l'exportateur
+      edit_importer: Modifier l'importateur
       exporters: Exportateurs
       importers: Importateurs
       new_exporter: Nouvel exportateur
       new_importer: Nouvel importateur
+      upload_corrected_entries_action: Téléverser les entrées corrigées
       upload_corrected_entries: 'Entrées corrigées à télécharger : %{name}'
     importer:
       bagit:

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -17,13 +17,22 @@ fr:
         record_link: Lien %{record_type}
         unknown: Inconnu
     exporter:
+      hints:
+        generated_metadata: Ces champs exportés ne peuvent pas être importés actuellement.
+        include_thumbnails: Ces champs exportés ne peuvent pas être importés actuellement.
+        limit: Laisser vide ou 0 pour tous les enregistrements
       labels:
         all: Tous
         collection: Collection
+        collection_entries: Entrées de collection
+        export_format: Format d'exportation
         export_from: Exporter depuis
         export_source: Source d'exportation
         export_type: Type d'exportation
         field_mapping: Cartographie de terrain
+        file_set_entries: Entrées d'ensemble de fichiers
+        filter_by_date: Filtrer par date
+        finish_date: Date de fin
         full: Métadonnées et fichiers
         generated_metadata: Inclure les métadonnées générées ?
         importer: Importateur
@@ -33,7 +42,20 @@ fr:
         name: Nom
         parser_fields: Champs de l'analyseur
         parser_klass: Analyseur syntaxique
+        start_date: Date de début
+        status: Statut
+        total_entries: Total des entrées
+        total_work_entries: Total des œuvres
         user: Utilisateur
+        work_entries: Entrées d'œuvres
+        workflow_status:
+          approved: Approuvé
+          broken_url: URL brisée
+          deleted: Supprimé
+          in_process: En cours
+          ingested: Ingéré
+          needs_repair: Nécessite une réparation
+          unapproved: Non approuvé
         worktype: Type de travail
       prompts:
         export_from: Veuillez sélectionner une source d'exportation
@@ -96,8 +118,10 @@ fr:
         override_rights_statement: Si cette option est cochée, utiliser systématiquement la déclaration de droits sélectionnée. Sinon, utiliser les droits ou la déclaration de droits de l'enregistrement et n'utiliser la valeur fournie que si dc:rights est vide.
       labels:
         admin_set: Ensemble administratif
+        collection_entries: Entrées de collection
         entry_id: ID d'entrée
         exporter: Exportateur
+        file_set_entries: Entrées d'ensemble de fichiers
         frequency: Fréquence
         identifier: Identifiant
         importer: Importateur
@@ -109,6 +133,7 @@ fr:
         total_work_entries: Travaux totaux
         type: Taper
         user: Utilisateur
+        work_entries: Entrées d'œuvres
       oai:
         hints:
           metadata_prefix: Par exemple, oai_dc, dcterms ou oai_qdc
@@ -185,6 +210,8 @@ fr:
           review_total: "%{total} au total — %{collections} collections, %{works} œuvres, %{file_sets} ensembles de fichiers"
           review_visibility: 'Visibilité:'
           server_error: Erreur serveur lors de la validation. Veuillez réessayer ou contacter l'assistance.
+          existing_record_badge: existant
+          existing_record_title: Cet enregistrement existe déjà dans le dépôt et sera lié lors de l'importation.
           shared_badge: commun
           starting: Départ...
           upload_csv_and_zip: Fichiers CSV + téléchargés séparément
@@ -336,6 +363,14 @@ fr:
             errors:
               message: "Le parent référencé « %{value} » n'existe pas en tant que %{field} dans ce CSV."
               suggestion: "Vérifiez les fautes de frappe ou ajoutez l'enregistrement parent."
+          child_reference_validator:
+            errors:
+              message: "L'enfant référencé « %{value} » n'existe pas en tant que %{field} dans ce CSV."
+              suggestion: "Vérifiez les fautes de frappe ou ajoutez l'enregistrement enfant."
+          circular_reference_validator:
+            errors:
+              message: "« %{value} » fait partie d'une relation parent-enfant circulaire."
+              suggestion: "Vérifiez les colonnes parent/enfant et supprimez les références incorrectes."
           passed: Validation réussie
           passed_warnings: Validation réussie avec avertissements
           recognized_fields: 'Champs reconnus : %{fields}'
@@ -353,6 +388,7 @@ fr:
               message: "Le champ « %{field} » est obligatoire mais il est vide pour cette ligne."
               suggestion: "Ajoutez une valeur pour « %{field} »."
           unable_to_process: Impossible de traiter les fichiers pour validation
+          empty_column: 'Colonne %{column} (sans en-tête)'
           notices_desc: 'Ces avis peuvent affecter la façon dont votre CSV est importé :'
           notices_title: Avis d'importation
           unrecognized_desc: 'Ces colonnes seront ignorées lors de l''importation :'
@@ -417,6 +453,7 @@ fr:
         name: Nom
         next_run: Prochaine course
         status: Statut
+        status_set_at: Statut défini à
         total_collection_entries: Nombre total d'entrées de la collection
         total_file_set_entries: Nombre total d'entrées du fichier
         total_work_entries: Nombre total d'entrées de travail

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -25,6 +25,7 @@ fr:
         all: Tous
         collection: Collection
         collection_entries: Entrées de collection
+        download: Télécharger
         export_format: Format d'exportation
         export_from: Exporter depuis
         export_source: Source d'exportation
@@ -67,7 +68,10 @@ fr:
           one: 'Une erreur a empêché l''enregistrement de cet exportateur :'
           other: 'Des erreurs %{count} ont empêché l''enregistrement de cet exportateur :'
     headings:
+      edit_exporter: Modifier l'exportateur
       importers: Importateurs
+      new_exporter: Nouvel exportateur
+      new_importer: Nouvel importateur
       upload_corrected_entries: 'Entrées corrigées à télécharger : %{name}'
     importer:
       bagit:
@@ -99,6 +103,9 @@ fr:
           private: Privé
           public: Publique
       edit_form:
+        entry_modal_title: Options de mise à jour d'une entrée
+        entry_rebuild_hint: Reconstruire les métadonnées et les fichiers.
+        entry_remove_and_recreate_hint: Supprimer l'œuvre existante, puis recréer les métadonnées et les fichiers de l'œuvre.
         modal_title: Options de mise à jour de l'importateur
         remove_and_rerun_hint: Supprimez tous les fichiers, puis relancez l'importation en partant de zéro. Cela supprimera tous les fichiers et associations, et toutes les modifications effectuées depuis la dernière importation seront perdues.
         update_and_harvest_hint: Mettez à jour les valeurs dans le formulaire d'importation et les éléments qui ont été modifiés à la source.
@@ -127,6 +134,7 @@ fr:
         importer: Importateur
         limit: Limite
         name: Nom
+        parser_fields: Champs de l'analyseur
         parser_klass: Analyseur syntaxique
         total_collections: Collections totales
         total_file_sets: Ensembles de fichiers totaux

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -199,9 +199,20 @@ fr:
           validating: Validation en cours...
           validation_failed: La validation a échoué. Veuillez réessayer.
           validation_timeout: La validation a expiré. Vos fichiers sont peut-être trop volumineux. Veuillez essayer avec des fichiers plus petits ou contacter l'assistance.
+          validation_truncated_note: tronqué à %{shown} — téléchargez le CSV des erreurs pour la liste complète
+          validation_truncated_tooltip: Cette liste est limitée pour garder la page lisible. La liste complète se trouve dans le fichier CSV des erreurs téléchargeable.
           visibility_institution: Institution
           visibility_private: Privé
           visibility_public: Publique
+          warning_category_circular_reference: Référence circulaire
+          warning_category_default_work_type_used: Type d'œuvre par défaut utilisé
+          warning_category_duplicate_source_identifier: Identifiant source en double dans le CSV
+          warning_category_existing_source_identifier: Identifiant source existant (sera mis à jour)
+          warning_category_invalid_child_reference: Référence enfant non valide
+          warning_category_invalid_controlled_value: Valeur de vocabulaire contrôlé non valide
+          warning_category_invalid_parent_reference: Référence parente non valide
+          warning_category_missing_required_value: Valeur obligatoire manquante
+          warning_category_missing_source_identifier: Identifiant source manquant
           zip_limit: 'Un seul fichier ZIP est autorisé. Les fichiers suivants n''ont pas été ajoutés :'
         nav:
           back: Dos
@@ -264,6 +275,7 @@ fr:
           large_import_message_html: Vous allez importer <span class="total-items-count">%{count}</span> articles. Les importations volumineuses sont plus longues et plus difficiles à dépanner. Pensez à les fractionner en lots plus petits.
           large_import_warning: Avertissement concernant les importations importantes
           ready_to_import: Prêt à importer
+          section_errors: Erreurs
           section_files: Fichiers
           section_records: Archives
           section_settings: Paramètres

--- a/config/locales/bulkrax.fr.yml
+++ b/config/locales/bulkrax.fr.yml
@@ -69,6 +69,7 @@ fr:
           other: 'Des erreurs %{count} ont empêché l''enregistrement de cet exportateur :'
     headings:
       edit_exporter: Modifier l'exportateur
+      exporters: Exportateurs
       importers: Importateurs
       new_exporter: Nouvel exportateur
       new_importer: Nouvel importateur
@@ -467,6 +468,29 @@ fr:
         total_work_entries: Nombre total d'entrées de travail
         type: Taper
         updated_at: Mise à jour le
+    datatable:
+      filters:
+        filter_by_entry_class: Filtrer par classe d'entrée
+        filter_by_status: Filtrer par statut
+      language:
+        empty_table: Aucune donnée disponible dans le tableau
+        info: Affichage de _START_ à _END_ sur _TOTAL_ entrées
+        info_empty: Affichage de 0 à 0 sur 0 entrées
+        info_filtered: (filtré à partir de _MAX_ entrées au total)
+        length_menu: Afficher _MENU_ entrées
+        loading_records: Chargement...
+        next: Suivant
+        previous: Précédent
+        processing: Traitement en cours...
+        search: 'Rechercher :'
+        zero_records: Aucun enregistrement correspondant trouvé
+      status:
+        complete: Terminé
+        complete_with_failures: Terminé (avec des échecs)
+        deleted: Supprimé
+        failed: Échoué
+        pending: En attente
+        skipped: Ignoré
   helpers:
     action:
       exporter:

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -69,11 +69,13 @@ it:
           other: "%{count} errori hanno impedito il salvataggio di questo esportatore:"
     headings:
       edit_exporter: Modifica esportatore
+      edit_importer: Modifica importatore
       exporters: Esportatori
       importers: Importatori
       new_exporter: Nuovo esportatore
       new_importer: Nuovo importatore
       upload_corrected_entries: 'Carica voci corrette: %{name}'
+      upload_corrected_entries_action: Carica voci corrette
     importer:
       bagit:
         bags_to_import: 'Borsa o borse da importare:'

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -17,13 +17,22 @@ it:
         record_link: Collegamento %{record_type}
         unknown: Sconosciuto
     exporter:
+      hints:
+        generated_metadata: Questi campi esportati non possono essere importati al momento.
+        include_thumbnails: Questi campi esportati non possono essere importati al momento.
+        limit: Lasciare vuoto o 0 per tutti i record
       labels:
         all: Tutto
         collection: Collezione
+        collection_entries: Voci di raccolta
+        export_format: Formato di esportazione
         export_from: Esporta da
         export_source: Esporta origine
         export_type: Tipo di esportazione
         field_mapping: Mappatura del campo
+        file_set_entries: Voci di insieme di file
+        filter_by_date: Filtra per data
+        finish_date: Data di fine
         full: Metadati e file
         generated_metadata: Includere metadati generati?
         importer: Importatore
@@ -33,7 +42,20 @@ it:
         name: Nome
         parser_fields: Campi del parser
         parser_klass: Analizzatore
+        start_date: Data di inizio
+        status: Stato
+        total_entries: Voci totali
+        total_work_entries: Totale opere
         user: Utente
+        work_entries: Voci di opere
+        workflow_status:
+          approved: Approvato
+          broken_url: URL non funzionante
+          deleted: Eliminato
+          in_process: In elaborazione
+          ingested: Acquisito
+          needs_repair: Da riparare
+          unapproved: Non approvato
         worktype: Tipo di lavoro
       prompts:
         export_from: Seleziona una fonte di esportazione
@@ -96,8 +118,10 @@ it:
         override_rights_statement: Se selezionata, utilizza sempre l'istruzione dei diritti selezionata. Se non selezionata, utilizza rights o rights_statement dal record e utilizza il valore fornito solo se dc:rights è vuoto.
       labels:
         admin_set: Insieme amministrativo
+        collection_entries: Voci di raccolta
         entry_id: ID di ingresso
         exporter: Esportatore
+        file_set_entries: Voci di insieme di file
         frequency: Frequenza
         identifier: Identificatore
         importer: Importatore
@@ -109,6 +133,7 @@ it:
         total_work_entries: Opere totali
         type: Tipo
         user: Utente
+        work_entries: Voci di opere
       oai:
         hints:
           metadata_prefix: Come oai_dc, dcterms o oai_qdc
@@ -185,6 +210,8 @@ it:
           review_total: "%{total} totale — %{collections} collezioni, %{works} opere, %{file_sets} set di file"
           review_visibility: 'Visibilità:'
           server_error: Errore del server durante la convalida. Riprova o contatta l'assistenza.
+          existing_record_badge: esistente
+          existing_record_title: Questo record esiste già nell'archivio e verrà collegato durante l'importazione.
           shared_badge: condiviso
           starting: Di partenza...
           upload_csv_and_zip: CSV + file caricati separatamente
@@ -336,6 +363,14 @@ it:
             errors:
               message: "Il genitore referenziato '%{value}' non esiste come %{field} in questo CSV."
               suggestion: "Controllare eventuali errori di battitura o aggiungere il record genitore."
+          child_reference_validator:
+            errors:
+              message: "Il figlio referenziato '%{value}' non esiste come %{field} in questo CSV."
+              suggestion: "Controllare eventuali errori di battitura o aggiungere il record figlio."
+          circular_reference_validator:
+            errors:
+              message: "'%{value}' fa parte di una relazione padre-figlio circolare."
+              suggestion: "Rivedere le colonne padre/figlio e rimuovere i riferimenti errati."
           passed: Validazione superata
           passed_warnings: Validazione superata con avvisi
           recognized_fields: 'Campi riconosciuti: %{fields}'
@@ -353,6 +388,7 @@ it:
               message: "Il campo '%{field}' è obbligatorio ma è vuoto per questa riga."
               suggestion: "Aggiungi un valore per '%{field}'."
           unable_to_process: Impossibile elaborare i file per la convalida
+          empty_column: 'Colonna %{column} (senza intestazione)'
           notices_desc: 'Questi avvisi potrebbero influire sul modo in cui il tuo CSV viene importato:'
           notices_title: Avvisi di importazione
           unrecognized_desc: 'Queste colonne verranno ignorate durante l''importazione:'
@@ -417,6 +453,7 @@ it:
         name: Nome
         next_run: Prossima corsa
         status: Stato
+        status_set_at: Stato impostato il
         total_collection_entries: Totale voci di raccolta
         total_file_set_entries: Numero totale di voci del set di file
         total_work_entries: Totale voci di lavoro

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -69,6 +69,7 @@ it:
           other: "%{count} errori hanno impedito il salvataggio di questo esportatore:"
     headings:
       edit_exporter: Modifica esportatore
+      exporters: Esportatori
       importers: Importatori
       new_exporter: Nuovo esportatore
       new_importer: Nuovo importatore
@@ -467,6 +468,29 @@ it:
         total_work_entries: Totale voci di lavoro
         type: Tipo
         updated_at: Aggiornato alle
+    datatable:
+      filters:
+        filter_by_entry_class: Filtra per classe di voce
+        filter_by_status: Filtra per stato
+      language:
+        empty_table: Nessun dato disponibile nella tabella
+        info: Visualizzazione da _START_ a _END_ di _TOTAL_ voci
+        info_empty: Visualizzazione da 0 a 0 di 0 voci
+        info_filtered: (filtrato da _MAX_ voci totali)
+        length_menu: Mostra _MENU_ voci
+        loading_records: Caricamento...
+        next: Successivo
+        previous: Precedente
+        processing: Elaborazione in corso...
+        search: 'Cerca:'
+        zero_records: Nessun record corrispondente trovato
+      status:
+        complete: Completato
+        complete_with_failures: Completato (con errori)
+        deleted: Eliminato
+        failed: Fallito
+        pending: In attesa
+        skipped: Saltato
   helpers:
     action:
       exporter:

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -398,6 +398,12 @@ it:
             errors:
               message: "Il campo '%{field}' è obbligatorio ma è vuoto per questa riga."
               suggestion: "Aggiungi un valore per '%{field}'."
+          validation_error_csv_builder:
+            empty_column: "La colonna %{column} non ha intestazione e verrà ignorata durante l'importazione"
+            missing_file: "File mancante: %{filename}"
+            missing_required_column: "Colonna obbligatoria mancante '%{field}' (%{model})"
+            unrecognized_column: "Colonna non riconosciuta '%{column}'"
+            unrecognized_column_with_suggestion: "Colonna non riconosciuta '%{column}' (intendevi '%{suggestion}'?)"
           unable_to_process: Impossibile elaborare i file per la convalida
           empty_column: 'Colonna %{column} (senza intestazione)'
           notices_desc: 'Questi avvisi potrebbero influire sul modo in cui il tuo CSV viene importato:'

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -25,6 +25,7 @@ it:
         all: Tutto
         collection: Collezione
         collection_entries: Voci di raccolta
+        download: Scarica
         export_format: Formato di esportazione
         export_from: Esporta da
         export_source: Esporta origine
@@ -67,7 +68,10 @@ it:
           one: '1 errore ha impedito il salvataggio di questo esportatore:'
           other: "%{count} errori hanno impedito il salvataggio di questo esportatore:"
     headings:
+      edit_exporter: Modifica esportatore
       importers: Importatori
+      new_exporter: Nuovo esportatore
+      new_importer: Nuovo importatore
       upload_corrected_entries: 'Carica voci corrette: %{name}'
     importer:
       bagit:
@@ -99,6 +103,9 @@ it:
           private: Privato
           public: Pubblico
       edit_form:
+        entry_modal_title: Opzioni per l'aggiornamento di una voce
+        entry_rebuild_hint: Ricostruire metadati e file.
+        entry_remove_and_recreate_hint: Rimuovere l'opera esistente e ricreare metadati e file dell'opera.
         modal_title: Opzioni per l'aggiornamento dell'importatore
         remove_and_rerun_hint: Rimuovi tutti i lavori e poi esegui nuovamente l'importazione da zero. Questo rimuoverà tutti i file e le associazioni e tutte le modifiche apportate dall'ultima importazione andranno perse.
         update_and_harvest_hint: Aggiorna i valori nel modulo di importazione e aggiorna gli elementi che sono stati modificati all'origine.
@@ -127,6 +134,7 @@ it:
         importer: Importatore
         limit: Limite
         name: Nome
+        parser_fields: Campi del parser
         parser_klass: Analizzatore
         total_collections: Raccolte totali
         total_file_sets: Set di file totali

--- a/config/locales/bulkrax.it.yml
+++ b/config/locales/bulkrax.it.yml
@@ -199,9 +199,20 @@ it:
           validating: Convalida in corso...
           validation_failed: Convalida non riuscita. Riprova.
           validation_timeout: Validazione scaduta. I file potrebbero essere troppo grandi. Prova con file più piccoli o contatta l'assistenza.
+          validation_truncated_note: troncato a %{shown} — scarica il CSV degli errori per l'elenco completo
+          validation_truncated_tooltip: Questo elenco è limitato per mantenere la pagina leggibile. L'elenco completo si trova nel file CSV degli errori scaricabile.
           visibility_institution: Istituzione
           visibility_private: Privato
           visibility_public: Pubblico
+          warning_category_circular_reference: Riferimento circolare
+          warning_category_default_work_type_used: Tipo di opera predefinito utilizzato
+          warning_category_duplicate_source_identifier: Identificatore di origine duplicato nel CSV
+          warning_category_existing_source_identifier: Identificatore di origine esistente (verrà aggiornato)
+          warning_category_invalid_child_reference: Riferimento figlio non valido
+          warning_category_invalid_controlled_value: Valore di vocabolario controllato non valido
+          warning_category_invalid_parent_reference: Riferimento genitore non valido
+          warning_category_missing_required_value: Valore obbligatorio mancante
+          warning_category_missing_source_identifier: Identificatore di origine mancante
           zip_limit: 'È consentito un solo file ZIP. I seguenti file non sono stati aggiunti:'
         nav:
           back: Indietro
@@ -264,6 +275,7 @@ it:
           large_import_message_html: Stai per importare <span class="total-items-count">%{count}</span> articoli. Le importazioni di grandi dimensioni richiedono più tempo e sono più difficili da risolvere. Valuta la possibilità di suddividere i lotti in lotti più piccoli.
           large_import_warning: Avviso di importazione di grandi dimensioni
           ready_to_import: Pronto per l'importazione
+          section_errors: Errori
           section_files: File
           section_records: Registrazioni
           section_settings: Impostazioni

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -199,9 +199,20 @@ pt-BR:
           validating: Validando...
           validation_failed: A validação falhou. Tente novamente.
           validation_timeout: A validação expirou. Seus arquivos podem ser muito grandes. Tente com arquivos menores ou entre em contato com o suporte.
+          validation_truncated_note: truncado para %{shown} — baixe o CSV de erros para ver a lista completa
+          validation_truncated_tooltip: Esta lista é limitada para manter a página legível. A lista completa está no arquivo CSV de erros para download.
           visibility_institution: Instituição
           visibility_private: Privado
           visibility_public: Público
+          warning_category_circular_reference: Referência circular
+          warning_category_default_work_type_used: Tipo de obra padrão utilizado
+          warning_category_duplicate_source_identifier: Identificador de origem duplicado no CSV
+          warning_category_existing_source_identifier: Identificador de origem existente (será atualizado)
+          warning_category_invalid_child_reference: Referência filha inválida
+          warning_category_invalid_controlled_value: Valor de vocabulário controlado inválido
+          warning_category_invalid_parent_reference: Referência-pai inválida
+          warning_category_missing_required_value: Valor obrigatório ausente
+          warning_category_missing_source_identifier: Identificador de origem ausente
           zip_limit: 'Apenas 1 arquivo ZIP permitido. Os seguintes arquivos não foram adicionados:'
         nav:
           back: Voltar
@@ -264,6 +275,7 @@ pt-BR:
           large_import_message_html: Você está prestes a importar <span class="total-items-count">%{count}</span> itens. Importações grandes levam mais tempo e são mais difíceis de solucionar problemas. Considere dividi-las em lotes menores.
           large_import_warning: Aviso de Importação de Grande Porte
           ready_to_import: Pronto para importar
+          section_errors: Erros
           section_files: Arquivos
           section_records: Registros
           section_settings: Configurações

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -69,11 +69,13 @@ pt-BR:
           other: "%{count} erros impediram que este exportador fosse salvo:"
     headings:
       edit_exporter: Editar exportador
+      edit_importer: Editar importador
       exporters: Exportadores
       importers: Importadores
       new_exporter: Novo exportador
       new_importer: Novo importador
       upload_corrected_entries: 'Enviar entradas corrigidas: %{name}'
+      upload_corrected_entries_action: Enviar entradas corrigidas
     importer:
       bagit:
         bags_to_import: 'Mala ou malas para importar:'

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -398,6 +398,12 @@ pt-BR:
             errors:
               message: "O campo '%{field}' é obrigatório, mas está vazio para esta linha."
               suggestion: "Adicione um valor para '%{field}'."
+          validation_error_csv_builder:
+            empty_column: "A coluna %{column} não tem cabeçalho e será ignorada durante a importação"
+            missing_file: "Arquivo ausente: %{filename}"
+            missing_required_column: "Falta a coluna obrigatória '%{field}' (%{model})"
+            unrecognized_column: "Coluna não reconhecida '%{column}'"
+            unrecognized_column_with_suggestion: "Coluna não reconhecida '%{column}' (você quis dizer '%{suggestion}'?)"
           unable_to_process: Não foi possível processar os arquivos para validação.
           empty_column: 'Coluna %{column} (sem cabeçalho)'
           notices_desc: 'Estes avisos podem afetar como o seu CSV é importado:'

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -69,6 +69,7 @@ pt-BR:
           other: "%{count} erros impediram que este exportador fosse salvo:"
     headings:
       edit_exporter: Editar exportador
+      exporters: Exportadores
       importers: Importadores
       new_exporter: Novo exportador
       new_importer: Novo importador
@@ -467,6 +468,29 @@ pt-BR:
         total_work_entries: Total de entradas de trabalho
         type: Tipo
         updated_at: Atualizado em
+    datatable:
+      filters:
+        filter_by_entry_class: Filtrar por classe de entrada
+        filter_by_status: Filtrar por status
+      language:
+        empty_table: Nenhum dado disponível na tabela
+        info: Mostrando _START_ a _END_ de _TOTAL_ entradas
+        info_empty: Mostrando 0 a 0 de 0 entradas
+        info_filtered: (filtrado de _MAX_ entradas no total)
+        length_menu: Mostrar _MENU_ entradas
+        loading_records: Carregando...
+        next: Próximo
+        previous: Anterior
+        processing: Processando...
+        search: 'Pesquisar:'
+        zero_records: Nenhum registro correspondente encontrado
+      status:
+        complete: Concluído
+        complete_with_failures: Concluído (com falhas)
+        deleted: Excluído
+        failed: Falhou
+        pending: Pendente
+        skipped: Ignorado
   helpers:
     action:
       exporter:

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -25,6 +25,7 @@ pt-BR:
         all: Todos
         collection: Coleção
         collection_entries: Entradas de coleção
+        download: Baixar
         export_format: Formato de exportação
         export_from: Exportar de
         export_source: Fonte de exportação
@@ -67,7 +68,10 @@ pt-BR:
           one: '1 erro impediu que este exportador fosse salvo:'
           other: "%{count} erros impediram que este exportador fosse salvo:"
     headings:
+      edit_exporter: Editar exportador
       importers: Importadores
+      new_exporter: Novo exportador
+      new_importer: Novo importador
       upload_corrected_entries: 'Enviar entradas corrigidas: %{name}'
     importer:
       bagit:
@@ -99,6 +103,9 @@ pt-BR:
           private: Privado
           public: Público
       edit_form:
+        entry_modal_title: Opções para atualizar uma entrada
+        entry_rebuild_hint: Reconstruir metadados e arquivos.
+        entry_remove_and_recreate_hint: Remover a obra existente e depois recriar os metadados e arquivos da obra.
         modal_title: Opções para atualizar o importador
         remove_and_rerun_hint: Remova todos os trabalhos e execute a importação novamente a partir de um ponto de partida limpo. Isso removerá todos os arquivos e associações, e quaisquer edições feitas desde a última importação serão perdidas.
         update_and_harvest_hint: Atualize os valores no formulário do importador e atualize os itens que foram alterados na origem.
@@ -127,6 +134,7 @@ pt-BR:
         importer: Importador
         limit: Limite
         name: Nome
+        parser_fields: Campos do analisador
         parser_klass: Analisador sintático
         total_collections: Total de Coleções
         total_file_sets: Conjuntos de arquivos totais

--- a/config/locales/bulkrax.pt-BR.yml
+++ b/config/locales/bulkrax.pt-BR.yml
@@ -17,13 +17,22 @@ pt-BR:
         record_link: Link %{record_type}
         unknown: Desconhecido
     exporter:
+      hints:
+        generated_metadata: Esses campos exportados não podem ser importados no momento.
+        include_thumbnails: Esses campos exportados não podem ser importados no momento.
+        limit: Deixe em branco ou 0 para todos os registros
       labels:
         all: Todos
         collection: Coleção
+        collection_entries: Entradas de coleção
+        export_format: Formato de exportação
         export_from: Exportar de
         export_source: Fonte de exportação
         export_type: Tipo de exportação
         field_mapping: Mapeamento de Campo
+        file_set_entries: Entradas de conjunto de arquivos
+        filter_by_date: Filtrar por data
+        finish_date: Data de término
         full: Metadados e Arquivos
         generated_metadata: Incluir metadados gerados?
         importer: Importador
@@ -33,7 +42,20 @@ pt-BR:
         name: Nome
         parser_fields: Campos do analisador sintático
         parser_klass: Analisador sintático
+        start_date: Data de início
+        status: Status
+        total_entries: Total de entradas
+        total_work_entries: Total de obras
         user: Usuário
+        work_entries: Entradas de obras
+        workflow_status:
+          approved: Aprovado
+          broken_url: URL quebrada
+          deleted: Excluído
+          in_process: Em processamento
+          ingested: Ingerido
+          needs_repair: Precisa de reparo
+          unapproved: Não aprovado
         worktype: Tipo de trabalho
       prompts:
         export_from: Por favor, selecione uma fonte de exportação.
@@ -96,8 +118,10 @@ pt-BR:
         override_rights_statement: Se selecionada, sempre use a declaração de direitos escolhida. Se desmarcada, use os direitos ou a declaração de direitos do registro e utilize o valor fornecido somente se dc:rights estiver em branco.
       labels:
         admin_set: Conjunto administrativo
+        collection_entries: Entradas de coleção
         entry_id: ID de entrada
         exporter: Exportador
+        file_set_entries: Entradas de conjunto de arquivos
         frequency: Freqüência
         identifier: Identificador
         importer: Importador
@@ -109,6 +133,7 @@ pt-BR:
         total_work_entries: Total Works
         type: Tipo
         user: Usuário
+        work_entries: Entradas de obras
       oai:
         hints:
           metadata_prefix: Como oai_dc, dcterms ou oai_qdc
@@ -185,6 +210,8 @@ pt-BR:
           review_total: "%{total} total — %{collections} coleções, %{works} obras, %{file_sets} conjuntos de arquivos"
           review_visibility: 'Visibilidade:'
           server_error: Erro do servidor durante a validação. Tente novamente ou entre em contato com o suporte.
+          existing_record_badge: existente
+          existing_record_title: Este registro já existe no repositório e será vinculado durante a importação.
           shared_badge: compartilhado
           starting: Começando...
           upload_csv_and_zip: Arquivos CSV + arquivos enviados separadamente
@@ -336,6 +363,14 @@ pt-BR:
             errors:
               message: "O pai referenciado '%{value}' não existe como %{field} neste CSV."
               suggestion: "Verifique se há erros de digitação ou adicione o registro pai."
+          child_reference_validator:
+            errors:
+              message: "O filho referenciado '%{value}' não existe como %{field} neste CSV."
+              suggestion: "Verifique se há erros de digitação ou adicione o registro filho."
+          circular_reference_validator:
+            errors:
+              message: "'%{value}' faz parte de uma relação pai-filho circular."
+              suggestion: "Revise as colunas de pai/filho e remova as referências incorretas."
           passed: Validação aprovada
           passed_warnings: Validação aprovada com advertências.
           recognized_fields: 'Campos reconhecidos: %{fields}'
@@ -353,6 +388,7 @@ pt-BR:
               message: "O campo '%{field}' é obrigatório, mas está vazio para esta linha."
               suggestion: "Adicione um valor para '%{field}'."
           unable_to_process: Não foi possível processar os arquivos para validação.
+          empty_column: 'Coluna %{column} (sem cabeçalho)'
           notices_desc: 'Estes avisos podem afetar como o seu CSV é importado:'
           notices_title: Avisos de importação
           unrecognized_desc: 'Estas colunas serão ignoradas durante a importação:'
@@ -417,6 +453,7 @@ pt-BR:
         name: Nome
         next_run: Próxima corrida
         status: Status
+        status_set_at: Status definido em
         total_collection_entries: Total de entradas da coleção
         total_file_set_entries: Total de entradas do conjunto de arquivos
         total_work_entries: Total de entradas de trabalho

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -199,9 +199,20 @@ zh:
           validating: 正在验证……
           validation_failed: 验证失败，请重试。
           validation_timeout: 验证超时。您的文件可能过大。请尝试上传较小的文件或联系技术支持。
+          validation_truncated_note: 已截断至 %{shown} 条 — 请下载错误 CSV 以查看完整列表
+          validation_truncated_tooltip: 为保持页面整洁，此列表已限制显示条数。完整列表包含在可下载的错误 CSV 文件中。
           visibility_institution: 机构
           visibility_private: 私人的
           visibility_public: 民众
+          warning_category_circular_reference: 循环引用
+          warning_category_default_work_type_used: 使用了默认的作品类型
+          warning_category_duplicate_source_identifier: CSV 中的源标识符重复
+          warning_category_existing_source_identifier: 已存在的源标识符（将被更新）
+          warning_category_invalid_child_reference: 无效的子引用
+          warning_category_invalid_controlled_value: 无效的受控词汇值
+          warning_category_invalid_parent_reference: 无效的父引用
+          warning_category_missing_required_value: 缺少必填值
+          warning_category_missing_source_identifier: 缺少源标识符
           zip_limit: 仅允许上传 1 个 ZIP 文件。以下文件未添加：
         nav:
           back: 后退
@@ -263,6 +274,7 @@ zh:
           large_import_message_html: 您即将导入<span class="total-items-count">%{count}</span>个项目。大量导入操作耗时更长，且更难排查问题。建议您分批导入。
           large_import_warning: 大量进口警告
           ready_to_import: 准备进口
+          section_errors: 错误
           section_files: 文件
           section_records: 记录
           section_settings: 设置

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -398,6 +398,12 @@ zh:
             errors:
               message: "字段 '%{field}' 是必填项，但此行中该字段为空。"
               suggestion: "请为 '%{field}' 添加一个值。"
+          validation_error_csv_builder:
+            empty_column: "第 %{column} 列没有标题，将在导入时被忽略"
+            missing_file: "缺少文件：%{filename}"
+            missing_required_column: "缺少必填列 '%{field}' (%{model})"
+            unrecognized_column: "无法识别的列 '%{column}'"
+            unrecognized_column_with_suggestion: "无法识别的列 '%{column}'（是否想输入 '%{suggestion}'？）"
           unable_to_process: 无法处理文件进行验证
           empty_column: '第 %{column} 列（无标题）'
           notices_desc: '这些通知可能会影响您的 CSV 的导入方式：'

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -25,6 +25,7 @@ zh:
         all: 全部
         collection: 收藏
         collection_entries: 收藏条目
+        download: 下载
         export_format: 导出格式
         export_from: 导出
         export_source: 出口来源
@@ -67,7 +68,10 @@ zh:
           one: 1 个错误导致此导出器无法保存：
           other: "%{count} 错误导致无法保存此导出器："
     headings:
+      edit_exporter: 编辑导出程序
       importers: 进口商
+      new_exporter: 新建导出程序
+      new_importer: 新建导入程序
       upload_corrected_entries: 上传更正后的条目：%{name}
     importer:
       bagit:
@@ -99,6 +103,9 @@ zh:
           private: 私人的
           public: 民众
       edit_form:
+        entry_modal_title: 更新条目的选项
+        entry_rebuild_hint: 重新构建元数据和文件。
+        entry_remove_and_recreate_hint: 删除现有作品，然后重新创建作品的元数据和文件。
         modal_title: 更新导入程序的选项
         remove_and_rerun_hint: 删除所有作品，然后从头开始重新导入。这将删除所有文件和关联关系，并且自上次导入以来所做的任何编辑都将丢失。
         update_and_harvest_hint: 更新导入器表单中的值，并更新源中已更改的项目。
@@ -127,6 +134,7 @@ zh:
         importer: 进口商
         limit: 限制
         name: 姓名
+        parser_fields: 解析器字段
         parser_klass: 解析器
         total_collections: 总收藏
         total_file_sets: 文件集总数

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -69,6 +69,7 @@ zh:
           other: "%{count} 错误导致无法保存此导出器："
     headings:
       edit_exporter: 编辑导出程序
+      exporters: 导出程序
       importers: 进口商
       new_exporter: 新建导出程序
       new_importer: 新建导入程序
@@ -467,6 +468,29 @@ zh:
         total_work_entries: 总工作条目
         type: 类型
         updated_at: 更新于
+    datatable:
+      filters:
+        filter_by_entry_class: 按条目类筛选
+        filter_by_status: 按状态筛选
+      language:
+        empty_table: 表中没有可用数据
+        info: 显示第 _START_ 至 _END_ 项，共 _TOTAL_ 项
+        info_empty: 显示第 0 至 0 项，共 0 项
+        info_filtered: （从 _MAX_ 项中筛选）
+        length_menu: 显示 _MENU_ 项
+        loading_records: 加载中...
+        next: 下一页
+        previous: 上一页
+        processing: 处理中...
+        search: '搜索：'
+        zero_records: 未找到匹配的记录
+      status:
+        complete: 完成
+        complete_with_failures: 完成（含失败）
+        deleted: 已删除
+        failed: 失败
+        pending: 待处理
+        skipped: 已跳过
   helpers:
     action:
       exporter:

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -69,11 +69,13 @@ zh:
           other: "%{count} 错误导致无法保存此导出器："
     headings:
       edit_exporter: 编辑导出程序
+      edit_importer: 编辑导入程序
       exporters: 导出程序
       importers: 进口商
       new_exporter: 新建导出程序
       new_importer: 新建导入程序
       upload_corrected_entries: 上传更正后的条目：%{name}
+      upload_corrected_entries_action: 上传更正后的条目
     importer:
       bagit:
         bags_to_import: 进口袋或包：

--- a/config/locales/bulkrax.zh.yml
+++ b/config/locales/bulkrax.zh.yml
@@ -17,13 +17,22 @@ zh:
         record_link: "%{record_type} 链接"
         unknown: 未知
     exporter:
+      hints:
+        generated_metadata: 这些导出的字段目前无法导入。
+        include_thumbnails: 这些导出的字段目前无法导入。
+        limit: 留空或填 0 表示所有记录
       labels:
         all: 全部
         collection: 收藏
+        collection_entries: 收藏条目
+        export_format: 导出格式
         export_from: 导出
         export_source: 出口来源
         export_type: 出口类型
         field_mapping: 田间测绘
+        file_set_entries: 文件集条目
+        filter_by_date: 按日期筛选
+        finish_date: 结束日期
         full: 元数据和文件
         generated_metadata: 是否包含生成的元数据？
         importer: 进口商
@@ -33,7 +42,20 @@ zh:
         name: 姓名
         parser_fields: 解析器字段
         parser_klass: 解析器
+        start_date: 开始日期
+        status: 状态
+        total_entries: 条目总数
+        total_work_entries: 作品总数
         user: 用户
+        work_entries: 作品条目
+        workflow_status:
+          approved: 已批准
+          broken_url: URL 失效
+          deleted: 已删除
+          in_process: 处理中
+          ingested: 已摄入
+          needs_repair: 需要修复
+          unapproved: 未批准
         worktype: 工作类型
       prompts:
         export_from: 请选择导出源
@@ -96,8 +118,10 @@ zh:
         override_rights_statement: 如果选中，则始终使用选定的权限语句。如果未选中，则使用记录中的权限或权限语句，并且仅当 dc:rights 为空时才使用提供的值。
       labels:
         admin_set: 管理集
+        collection_entries: 收藏条目
         entry_id: 条目 ID
         exporter: 出口商
+        file_set_entries: 文件集条目
         frequency: 频率
         identifier: 标识符
         importer: 进口商
@@ -109,6 +133,7 @@ zh:
         total_work_entries: 总作品
         type: 类型
         user: 用户
+        work_entries: 作品条目
       oai:
         hints:
           metadata_prefix: 例如 oai_dc、dcterms 或 oai_qdc
@@ -185,6 +210,8 @@ zh:
           review_total: 总计 %{total} — %{collections} 个收藏集，%{works} 个作品，%{file_sets} 个文件集
           review_visibility: 能见度：
           server_error: 验证过程中服务器出错。请重试或联系客服。
+          existing_record_badge: 已存在
+          existing_record_title: 此记录已存在于存储库中，导入时将进行关联。
           shared_badge: 共享
           starting: 开始...
           upload_csv_and_zip: CSV 文件和其他文件单独上传
@@ -220,6 +247,7 @@ zh:
           next_step: 下一个
           skip_validation: 跳过验证
           start_import: 开始导入
+        feedback_link: 报告错误 / 反馈
         page_subtitle: 通过 CSV 导入收藏集、作品和文件
         page_title: 开始批量导入
         step1:
@@ -335,6 +363,14 @@ zh:
             errors:
               message: "引用的父级 '%{value}' 在此 CSV 中不存在对应的 %{field}。"
               suggestion: "请检查拼写错误或添加父级记录。"
+          child_reference_validator:
+            errors:
+              message: "引用的子级 '%{value}' 在此 CSV 中不存在对应的 %{field}。"
+              suggestion: "请检查拼写错误或添加子级记录。"
+          circular_reference_validator:
+            errors:
+              message: "'%{value}' 属于循环的父子关系。"
+              suggestion: "请检查父级/子级列并移除错误的引用。"
           passed: 验证通过
           passed_warnings: 验证通过，但存在警告
           recognized_fields: 已识别字段：%{fields}
@@ -352,6 +388,7 @@ zh:
               message: "字段 '%{field}' 是必填项，但此行中该字段为空。"
               suggestion: "请为 '%{field}' 添加一个值。"
           unable_to_process: 无法处理文件进行验证
+          empty_column: '第 %{column} 列（无标题）'
           notices_desc: '这些通知可能会影响您的 CSV 的导入方式：'
           notices_title: 导入通知
           unrecognized_desc: 导入过程中将忽略以下列：
@@ -416,6 +453,7 @@ zh:
         name: 姓名
         next_run: 下一轮
         status: 地位
+        status_set_at: 状态设置时间
         total_collection_entries: 总收款条目
         total_file_set_entries: 文件集条目总数
         total_work_entries: 总工作条目

--- a/docs/CSV_SERVICE_ARCHITECTURE.md
+++ b/docs/CSV_SERVICE_ARCHITECTURE.md
@@ -47,7 +47,7 @@ Returns:
 }
 ```
 
-**Rights Statement Override:** When the only missing required field is `rights_statement`, the result is treated as valid with a warning rather than invalid. This supports workflows where rights statements are assigned after import.
+**Rights Statement Special Case:** When the only missing required field is `rights_statement`, `assemble_result` reports the CSV as valid with a warning (rather than invalid). This supports workflows where rights statements are assigned on the next step via the default rights statement selector.
 
 ## Architecture
 

--- a/docs/VALIDATION_RESPONSE_QUICK_REF.json
+++ b/docs/VALIDATION_RESPONSE_QUICK_REF.json
@@ -1,20 +1,39 @@
 {
   "_comment": "Quick Reference - JSON Response Structure for POST /importers/guided_import/validate",
-  "_version": "1.0",
-  "_required_fields": "All fields marked with * are required",
+  "_version": "2.0",
+  "_required_fields": "All fields marked with * are always present; others are conditional as noted.",
+  "_last_updated_behavior_notes": [
+    "v2.0: Documented row-level validator output (rowErrors + row_level_errors / row_level_warnings issues), notices issue type, emptyColumns, item `category`, and validationErrorsCacheKey. Removed the legacy string form of missingRequired (hashes are the only shape emitted now). Removed the unused 'info' severity from issues (only the file_references icon uses fa-info-circle; its severity is 'warning').",
+    "v1.0: Initial structure covered missing_required_fields / unrecognized_fields / file_references only."
+  ],
   "structure": {
     "headers*": [
       "string - CSV column names"
     ],
     "missingRequired*": [
-      "string|object - Missing required columns (legacy: strings, new: {model, field})"
+      {
+        "model": "string - Work type / model name (e.g. 'GenericWork')",
+        "field": "string - Required field name missing from the CSV headers"
+      }
     ],
     "unrecognized*": {
       "column_name": "string|null - Spell-check suggestion, or null if no suggestion"
     },
     "rowCount*": "integer - Number of data rows",
-    "isValid*": "boolean - Validation passed?",
+    "isValid*": "boolean - Validation passed? False when missingRequired (except when only rights_statement is missing), missingFiles, row-level errors, empty headers, or empty CSV.",
     "hasWarnings*": "boolean - Non-critical warnings exist?",
+    "rowErrors*": [
+      {
+        "row": "integer - 1-based row number (header is row 1; first data row is row 2)",
+        "source_identifier": "string - Value of the row's source_identifier column",
+        "severity": "error|warning",
+        "category": "string - Validator category slug (see `validator_categories`)",
+        "column": "string - CSV column the issue is attributed to",
+        "value": "string|null - The offending cell value (nil when the column is blank or absent)",
+        "message": "string - Human-readable, localized error/warning text",
+        "suggestion": "string|null - Localized suggestion for how to fix the issue"
+      }
+    ],
     "collections*": [
       {
         "id": "string",
@@ -55,6 +74,7 @@
     ],
     "foundFiles*": "integer - Files found in ZIP",
     "zipIncluded*": "boolean - ZIP file uploaded?",
+    "validationErrorsCacheKey": "string|null - Cache key passed to GET /importers/guided_import/download_validation_errors?key=<value>. Present when any errors exist (missingRequired, unrecognized, emptyColumns, missingFiles, or rowErrors). Null when validation is clean.",
     "messages*": {
       "validationStatus*": {
         "severity*": "success|warning|error",
@@ -66,20 +86,14 @@
       },
       "issues*": [
         {
-          "type*": "string - Issue type identifier",
-          "severity*": "error|warning|info",
+          "type*": "string - One of: missing_required_fields | unrecognized_fields | file_references | row_level_errors | row_level_warnings | notices",
+          "severity*": "error|warning",
           "icon*": "string - FontAwesome class",
           "title*": "string - Issue heading",
           "count*": "integer - Count badge",
           "description": "string|null - Explanatory text (optional)",
-          "summary": "string|null - Summary line (optional)",
-          "items*": [
-            {
-              "field*": "string - Field/file name",
-              "model": "string - Model name (for missing_required_fields type, used for grouping)",
-              "message": "string|null - Additional message (optional, used for non-grouped issue types)"
-            }
-          ],
+          "summary": "string|null - Summary line (optional; used by file_references)",
+          "items*": "See `issue_items_by_type` for the shape of items per issue type.",
           "details": "string|null - Additional details (optional)",
           "defaultOpen*": "boolean - Start expanded?"
         }
@@ -94,43 +108,92 @@
     ],
     "issues": [
       "error",
-      "warning",
-      "info"
+      "warning"
     ]
   },
   "common_icons": {
     "success": "fa-check-circle",
     "warning": "fa-exclamation-triangle",
     "error": "fa-times-circle",
-    "info": "fa-info-circle"
+    "info": "fa-info-circle (used on 'warning'-severity file_references and notices issues)"
   },
   "issue_types": {
-    "missing_required_fields": "Required columns missing from CSV (each item includes model name to show which models need which fields)",
-    "unrecognized_fields": "CSV columns not mapped to properties",
-    "file_references": "File validation results"
+    "missing_required_fields": "Required columns missing from the CSV headers. Severity is 'error' by default, or 'warning' when the only missing required field is 'rights_statement' (user supplies a default on Step 2).",
+    "unrecognized_fields": "CSV columns that don't map to any known property, plus columns with a blank header (emptyColumns). Severity 'warning'. Ignored during import.",
+    "file_references": "Row-level `file:` values that are missing from the ZIP, or file references when no ZIP was uploaded. Severity 'warning'.",
+    "row_level_errors": "Per-row errors from CsvRow:: validators (e.g. invalid parent reference, missing required value in a present column, invalid controlled-vocab value). Severity 'error'.",
+    "row_level_warnings": "Per-row warnings from CsvRow:: validators (e.g. default work type used, existing source_identifier will be updated). Severity 'warning'.",
+    "notices": "File-level notices — informational messages that don't block import but the user should see (e.g. model column missing or empty → default work type used for all rows). Severity 'warning'."
   },
-  "missing_required_fields_notes": {
-    "description": "Missing required fields are grouped by model for better readability",
-    "display_format": "Fields are displayed under model name headings (e.g., 'GenericWork:', 'Collection:')",
-    "example": "If GenericWork needs 'title' and 'rights_statement', both appear under 'GenericWork:' heading",
-    "benefits": [
-      "Clear visual grouping by model eliminates redundant model names",
-      "Users can quickly scan which models need which fields",
-      "Supports multi-model CSV files with different requirements per model",
-      "Cleaner, more compact display than listing model name with each field"
+  "issue_items_by_type": {
+    "missing_required_fields": {
+      "shape": {
+        "model": "string - Work type requiring this field",
+        "field": "string - Required field name"
+      },
+      "display": "Grouped by model in the UI (e.g. 'GenericWork:' heading with fields listed beneath)."
+    },
+    "unrecognized_fields": {
+      "shape": {
+        "field": "string - Column name, or a localized 'Column N (no header)' placeholder for empty-header columns",
+        "message": "string|null - \"Did you mean 'X'?\" when a spell-check suggestion is available, otherwise null"
+      }
+    },
+    "file_references": {
+      "shape": {
+        "field": "string - Filename",
+        "message": "string - Localized 'missing from ZIP' text; empty items array when the issue is 'no ZIP uploaded'"
+      }
+    },
+    "row_level_errors": {
+      "shape": {
+        "field": "string - Localized 'Row %{row} · %{column}' label",
+        "message": "string - Localized error text (concatenated with suggestion if any)",
+        "category": "string - Validator category slug; used by the UI for per-category grouping and by the downloaded errors CSV's `categories` column"
+      }
+    },
+    "row_level_warnings": {
+      "shape": "Identical to row_level_errors items."
+    },
+    "notices": {
+      "shape": {
+        "field": "string - The CSV field/column the notice relates to (e.g. 'model')",
+        "message": "string - Localized notice message (concatenated with suggestion)"
+      }
+    }
+  },
+  "validator_categories": {
+    "description": "Slug assigned by each row-level validator to identify the issue type. Exposed on rowErrors[*].category and on row_level_* items[*].category.",
+    "values": [
+      "missing_source_identifier",
+      "duplicate_source_identifier",
+      "existing_source_identifier",
+      "invalid_parent_reference",
+      "invalid_child_reference",
+      "circular_reference",
+      "missing_required_value",
+      "invalid_controlled_value",
+      "default_work_type_used"
     ]
   },
   "validation_rules": {
     "isValid_false_when": [
-      "Required fields are missing",
-      "CSV is malformed/unreadable",
-      "Critical validation errors"
+      "CSV headers are empty",
+      "CSV has zero data rows",
+      "missingRequired is non-empty (EXCEPT when the only missing field is rights_statement; see rights_statement_special_case)",
+      "missingFiles is non-empty",
+      "Any rowErrors entry has severity 'error'"
     ],
     "hasWarnings_true_when": [
       "Unrecognized columns exist",
+      "Empty-header columns exist",
       "Files referenced but missing from ZIP",
-      "Files referenced but no ZIP uploaded"
-    ]
+      "Files referenced but no ZIP uploaded",
+      "Any rowErrors entry has severity 'warning'",
+      "notices is non-empty",
+      "Only missing required field is rights_statement (in which case isValid is also true)"
+    ],
+    "rights_statement_special_case": "When the entire missingRequired list consists of rights_statement entries, the response is valid with a warning rather than invalid. The user supplies a default rights statement on Step 2, which is applied to every row lacking one. The missing_required_fields issue's severity downshifts to 'warning' and its description swaps to the 'can be supplied on Step 2' variant."
   },
   "minimal_success_example": {
     "headers": [
@@ -143,6 +206,7 @@
     "rowCount": 10,
     "isValid": true,
     "hasWarnings": false,
+    "rowErrors": [],
     "collections": [],
     "works": [],
     "fileSets": [],
@@ -151,6 +215,7 @@
     "missingFiles": [],
     "foundFiles": 0,
     "zipIncluded": false,
+    "validationErrorsCacheKey": null,
     "messages": {
       "validationStatus": {
         "severity": "success",
@@ -177,6 +242,7 @@
     "rowCount": 25,
     "isValid": true,
     "hasWarnings": true,
+    "rowErrors": [],
     "collections": [],
     "works": [],
     "fileSets": [],
@@ -185,6 +251,7 @@
     "missingFiles": [],
     "foundFiles": 0,
     "zipIncluded": false,
+    "validationErrorsCacheKey": "guided_import_errors:SESSION-ID:1776992963",
     "messages": {
       "validationStatus": {
         "severity": "warning",
@@ -202,14 +269,12 @@
           "title": "Unrecognized Fields",
           "count": 1,
           "description": "These columns will be ignored during import:",
-          "summary": null,
           "items": [
             {
               "field": "legacy_id",
               "message": null
             }
           ],
-          "details": null,
           "defaultOpen": false
         }
       ]
@@ -221,13 +286,28 @@
       "description"
     ],
     "missingRequired": [
-      "source_identifier",
-      "rights_statement"
+      {
+        "model": "GenericWork",
+        "field": "source_identifier"
+      },
+      {
+        "model": "GenericWork",
+        "field": "rights_statement"
+      },
+      {
+        "model": "Collection",
+        "field": "source_identifier"
+      },
+      {
+        "model": "Collection",
+        "field": "rights_statement"
+      }
     ],
     "unrecognized": {},
     "rowCount": 15,
     "isValid": false,
     "hasWarnings": false,
+    "rowErrors": [],
     "collections": [],
     "works": [],
     "fileSets": [],
@@ -236,6 +316,7 @@
     "missingFiles": [],
     "foundFiles": 0,
     "zipIncluded": false,
+    "validationErrorsCacheKey": "guided_import_errors:SESSION-ID:1776992963",
     "messages": {
       "validationStatus": {
         "severity": "error",
@@ -253,7 +334,6 @@
           "title": "Missing Required Fields",
           "count": 4,
           "description": "These required columns must be added to your CSV:",
-          "summary": null,
           "items": [
             {
               "model": "GenericWork",
@@ -272,7 +352,151 @@
               "field": "rights_statement"
             }
           ],
-          "details": null,
+          "defaultOpen": false
+        }
+      ]
+    }
+  },
+  "minimal_row_errors_example": {
+    "_comment": "Shows rowErrors at top level plus the row_level_errors / row_level_warnings issues derived from them.",
+    "headers": [
+      "source_identifier",
+      "title",
+      "parents",
+      "resource_type"
+    ],
+    "missingRequired": [],
+    "unrecognized": {},
+    "rowCount": 3,
+    "isValid": false,
+    "hasWarnings": true,
+    "rowErrors": [
+      {
+        "row": 2,
+        "source_identifier": "w1",
+        "severity": "error",
+        "category": "invalid_parent_reference",
+        "column": "parents",
+        "value": "ghost_parent",
+        "message": "Referenced parent 'ghost_parent' does not exist as a source_identifier in this CSV.",
+        "suggestion": "Check for typos or add the parent record."
+      },
+      {
+        "row": 3,
+        "source_identifier": "w2",
+        "severity": "warning",
+        "category": "existing_source_identifier",
+        "column": "source_identifier",
+        "value": "w2",
+        "message": "'w2' matches an existing repository record — this row will update it.",
+        "suggestion": "If you did not intend to update an existing record, change the source_identifier value."
+      }
+    ],
+    "collections": [],
+    "works": [],
+    "fileSets": [],
+    "totalItems": 0,
+    "fileReferences": 0,
+    "missingFiles": [],
+    "foundFiles": 0,
+    "zipIncluded": false,
+    "validationErrorsCacheKey": "guided_import_errors:SESSION-ID:1776992963",
+    "messages": {
+      "validationStatus": {
+        "severity": "error",
+        "icon": "fa-times-circle",
+        "title": "Validation Failed",
+        "summary": "4 columns detected · 3 records found",
+        "details": "Critical errors must be fixed before import.",
+        "defaultOpen": true
+      },
+      "issues": [
+        {
+          "type": "row_level_errors",
+          "severity": "error",
+          "icon": "fa-times-circle",
+          "title": "Row Validation Errors",
+          "count": 1,
+          "description": "The following issues exist with data in your CSV:",
+          "items": [
+            {
+              "field": "Row 2 · parents",
+              "message": "Referenced parent 'ghost_parent' does not exist as a source_identifier in this CSV. Check for typos or add the parent record.",
+              "category": "invalid_parent_reference"
+            }
+          ],
+          "defaultOpen": false
+        },
+        {
+          "type": "row_level_warnings",
+          "severity": "warning",
+          "icon": "fa-exclamation-triangle",
+          "title": "Row Validation Warnings",
+          "count": 1,
+          "description": "The following issues exist with data in your CSV:",
+          "items": [
+            {
+              "field": "Row 3 · source_identifier",
+              "message": "'w2' matches an existing repository record — this row will update it. If you did not intend to update an existing record, change the source_identifier value.",
+              "category": "existing_source_identifier"
+            }
+          ],
+          "defaultOpen": false
+        }
+      ]
+    }
+  },
+  "minimal_notices_example": {
+    "_comment": "Shows the notices issue type emitted when the model column is missing or every row's model is blank — indicating the configured default_work_type will be used for all rows.",
+    "headers": [
+      "source_identifier",
+      "title"
+    ],
+    "missingRequired": [],
+    "unrecognized": {},
+    "rowCount": 2,
+    "isValid": true,
+    "hasWarnings": true,
+    "rowErrors": [],
+    "collections": [],
+    "works": [
+      {
+        "id": "w1",
+        "title": "Parent Work",
+        "type": "work",
+        "parentIds": []
+      }
+    ],
+    "fileSets": [],
+    "totalItems": 1,
+    "fileReferences": 0,
+    "missingFiles": [],
+    "foundFiles": 0,
+    "zipIncluded": false,
+    "validationErrorsCacheKey": "guided_import_errors:SESSION-ID:1776992963",
+    "messages": {
+      "validationStatus": {
+        "severity": "warning",
+        "icon": "fa-exclamation-triangle",
+        "title": "Validation Passed with Warnings",
+        "summary": "2 columns detected · 2 records found",
+        "details": "Recognized fields: source_identifier, title",
+        "defaultOpen": true
+      },
+      "issues": [
+        {
+          "type": "notices",
+          "severity": "warning",
+          "icon": "fa-info-circle",
+          "title": "Import Notices",
+          "count": 1,
+          "description": "These notices may affect how your CSV is imported:",
+          "items": [
+            {
+              "field": "model",
+              "message": "No model column found — all rows will be imported as 'GenericWork'. Add a model column to your CSV if you want to use a different work type for some rows."
+            }
+          ],
           "defaultOpen": false
         }
       ]

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -36,7 +36,6 @@ module Bulkrax
   class Configuration
     attr_accessor :api_definition,
                   :default_field_mapping,
-                  :default_work_type,
                   :export_path,
                   :field_mappings,
                   :guided_import_enabled,
@@ -55,6 +54,21 @@ module Bulkrax
                   :required_elements,
                   :reserved_properties,
                   :server_name
+
+    ##
+    # The default work type used when a CSV row has no `model` value. Bulkrax
+    # treats this as a class name (String) — it's used for hash lookups, I18n
+    # interpolation, and `.constantize`. Consumers historically sometimes
+    # configured it as a Class constant (e.g. `config.default_work_type = MyWork`),
+    # which silently broke validators that key on String model names. The reader
+    # coerces to String so callers can stop scattering `.to_s` everywhere.
+    # @return [String, nil]
+    attr_writer :default_work_type
+
+    def default_work_type
+      return nil if @default_work_type.nil?
+      @default_work_type.to_s
+    end
 
     ##
     # @return [#call] with arity 2.  The first parameter is a {Bulkrax::ApplicationParser} and the

--- a/spec/bulkrax_spec.rb
+++ b/spec/bulkrax_spec.rb
@@ -14,6 +14,25 @@ RSpec.describe Bulkrax do
       it 'reads default work type from rails_helper' do
         expect(described_class.default_work_type).to eq('Work')
       end
+
+      context 'when assigned a Class constant' do
+        before  { described_class.default_work_type = Object }
+        after   { described_class.default_work_type = 'Work' }
+
+        it 'coerces the reader to the class name as a String' do
+          expect(described_class.default_work_type).to eq('Object')
+          expect(described_class.default_work_type).to be_a(String)
+        end
+      end
+
+      context 'when assigned nil' do
+        before  { described_class.default_work_type = nil }
+        after   { described_class.default_work_type = 'Work' }
+
+        it 'returns nil without coercing' do
+          expect(described_class.default_work_type).to be_nil
+        end
+      end
     end
 
     context 'import_path' do

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -548,4 +548,66 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       end
     end
   end
+
+  describe '#assemble_result' do
+    let(:file_validator) do
+      instance_double(
+        'Bulkrax::CsvTemplate::FileValidator',
+        missing_files: [],
+        possible_missing_files?: false,
+        count_references: 0,
+        found_files_count: 0,
+        zip_included?: false
+      )
+    end
+    let(:header_issues) { { unrecognized: {}, empty_columns: [] } }
+    let(:csv_data) { [{ source_identifier: 'w1' }] }
+    let(:headers) { %w[source_identifier title] }
+
+    def assemble(missing_required:, row_errors: [], notices: [])
+      host.send(
+        :assemble_result,
+        headers: headers, missing_required: missing_required, header_issues: header_issues,
+        row_errors: row_errors, csv_data: csv_data, file_validator: file_validator,
+        collections: [], works: [], file_sets: [], notices: notices
+      )
+    end
+
+    context 'when only rights_statement is missing' do
+      let(:missing_required) { [{ model: 'Work', field: 'rights_statement' }] }
+
+      it 'is valid-with-warnings since rights_statement can be supplied on Step 2' do
+        result = assemble(missing_required: missing_required)
+        expect(result[:isValid]).to be true
+        expect(result[:hasWarnings]).to be true
+      end
+
+      it 'is not valid when a row-level error is also present' do
+        result = assemble(
+          missing_required: missing_required,
+          row_errors: [{ severity: 'error', column: 'parent', row: 2 }]
+        )
+        expect(result[:isValid]).to be false
+      end
+
+      it 'stays valid-with-warnings when only row-level warnings are present' do
+        result = assemble(
+          missing_required: missing_required,
+          row_errors: [{ severity: 'warning', column: 'source_identifier', row: 2 }]
+        )
+        expect(result[:isValid]).to be true
+        expect(result[:hasWarnings]).to be true
+      end
+    end
+
+    context 'when another required field is missing alongside rights_statement' do
+      it 'is not valid — the Step 2 fallback only covers rights_statement' do
+        result = assemble(missing_required: [
+                            { model: 'Work', field: 'rights_statement' },
+                            { model: 'Work', field: 'title' }
+                          ])
+        expect(result[:isValid]).to be false
+      end
+    end
+  end
 end

--- a/spec/services/bulkrax/stepper_response_formatter_spec.rb
+++ b/spec/services/bulkrax/stepper_response_formatter_spec.rb
@@ -494,7 +494,11 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
         expect(error_issue[:title]).to eq('Row Validation Errors')
         expect(error_issue[:count]).to eq(1)
         expect(error_issue[:items]).to contain_exactly(
-          { field: 'Row 1 · creator', message: "Field 'creator' is required but is empty for this row. Add a value for 'creator' in row 1." }
+          { field: 'Row 1 · creator', message: "Field 'creator' is required but is empty for this row. Add a value for 'creator' in row 1.", category: 'missing_required_value' }
+        )
+
+        expect(warning_issue[:items]).to contain_exactly(
+          { field: 'Row 2 · source_identifier', message: "'DEF' matches an existing repository record. If you did not intend to update an existing record, change the source_identifier value.", category: 'existing_source_identifier' }
         )
 
         expect(warning_issue[:severity]).to eq('warning')
@@ -530,6 +534,32 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
         expect(warning_issue[:count]).to eq(1)
       end
 
+      it 'preserves the validator category on each row-warning item so the UI can group them' do
+        data = {
+          headers: ['source_identifier', 'title', 'creator', 'model'],
+          rowCount: 5,
+          isValid: true,
+          hasWarnings: true,
+          missingRequired: [],
+          unrecognized: {},
+          fileReferences: 0,
+          rowErrors: [
+            { row: 1, source_identifier: 'ABC', severity: 'warning', category: 'existing_source_identifier',
+              column: 'source_identifier', value: 'ABC', message: 'matches existing record.' },
+            { row: 2, source_identifier: 'DEF', severity: 'warning', category: 'default_work_type_used',
+              column: 'model', value: nil, message: 'using default work type.' }
+          ]
+        }
+
+        result = described_class.new(data).format
+        warning_issue = result[:messages][:issues].find { |i| i[:type] == 'row_level_warnings' }
+
+        expect(warning_issue[:items].map { |i| i[:category] }).to contain_exactly(
+          'existing_source_identifier',
+          'default_work_type_used'
+        )
+      end
+
       it 'suppresses row errors for columns already flagged in missingRequired' do
         data = {
           headers: ['source_identifier', 'title', 'model'],
@@ -554,7 +584,7 @@ RSpec.describe Bulkrax::StepperResponseFormatter do
 
         expect(issue[:count]).to eq(1)
         expect(issue[:items]).to contain_exactly(
-          { field: 'Row 1 · creator', message: "Field 'creator' is required but is empty for this row. Add a value for 'creator' in row 1." }
+          { field: 'Row 1 · creator', message: "Field 'creator' is required but is empty for this row. Add a value for 'creator' in row 1.", category: 'missing_required_value' }
         )
       end
 

--- a/spec/services/bulkrax/validation_error_csv_builder_spec.rb
+++ b/spec/services/bulkrax/validation_error_csv_builder_spec.rb
@@ -40,17 +40,24 @@ RSpec.describe Bulkrax::ValidationErrorCsvBuilder do
       it 'preserves the original row values in subsequent columns' do
         result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
         rows = CSV.parse(result)
-        expect(rows[1][2]).to eq('GenericWork')
-        expect(rows[1][3]).to eq('id-001')
-        expect(rows[1][4]).to eq('My Title')
+        expect(rows[1][3]).to eq('GenericWork')
+        expect(rows[1][4]).to eq('id-001')
+        expect(rows[1][5]).to eq('My Title')
+      end
+
+      it 'puts the error category in column 3' do
+        result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
+        rows = CSV.parse(result)
+        expect(rows[1][2]).to eq('missing_required_value')
       end
 
       it 'includes clean rows with a blank errors cell' do
         result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
         rows = CSV.parse(result)
-        clean_row = rows.find { |r| r[3] == 'id-002' }
+        clean_row = rows.find { |r| r[4] == 'id-002' }
         expect(clean_row).not_to be_nil
         expect(clean_row[1]).to be_nil
+        expect(clean_row[2]).to be_nil
       end
     end
 
@@ -66,6 +73,27 @@ RSpec.describe Bulkrax::ValidationErrorCsvBuilder do
         result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
         rows = CSV.parse(result)
         expect(rows[3][1]).to eq('Title is required | Description is required')
+      end
+
+      it 'deduplicates the category column when multiple errors share a category' do
+        result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
+        rows = CSV.parse(result)
+        expect(rows[3][2]).to eq('missing_required_value')
+      end
+    end
+
+    context 'when row errors have distinct categories' do
+      let(:row_errors) do
+        [
+          { row: 2, severity: 'warning', category: 'existing_source_identifier', column: 'source_identifier', value: 'id-001', message: 'Exists' },
+          { row: 2, severity: 'warning', category: 'default_work_type_used', column: 'model', value: nil, message: 'Using default' }
+        ]
+      end
+
+      it 'joins distinct category values with " | " in the categories column' do
+        result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
+        rows = CSV.parse(result)
+        expect(rows[1][2]).to eq('existing_source_identifier | default_work_type_used')
       end
     end
 
@@ -86,7 +114,7 @@ RSpec.describe Bulkrax::ValidationErrorCsvBuilder do
       it 'outputs rows in original order with errors on the correct rows' do
         result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
         rows = CSV.parse(result)
-        row_by_id = rows[1..].index_by { |r| r[3] }
+        row_by_id = rows[1..].index_by { |r| r[4] }
         expect(row_by_id['id-001'][1]).to eq('Duplicate source_identifier')
         expect(row_by_id['id-003'][1]).to eq('Title is required')
         expect(row_by_id['id-002'][1]).to be_nil
@@ -96,17 +124,18 @@ RSpec.describe Bulkrax::ValidationErrorCsvBuilder do
     context 'header row' do
       let(:row_errors) { [{ row: 2, severity: 'error', category: 'test', column: 'title', value: nil, message: 'Error' }] }
 
-      it 'has "row" as the first column and "errors" as the second' do
+      it 'has "row", "errors", and "categories" as the first three columns' do
         result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
         rows = CSV.parse(result)
         expect(rows.first[0]).to eq('row')
         expect(rows.first[1]).to eq('errors')
+        expect(rows.first[2]).to eq('categories')
       end
 
-      it 'preserves the original headers after the row and errors columns' do
+      it 'preserves the original headers after the row, errors, and categories columns' do
         result = described_class.build(headers: headers, csv_data: csv_data, row_errors: row_errors)
         rows = CSV.parse(result)
-        expect(rows.first[2..]).to eq(headers)
+        expect(rows.first[3..]).to eq(headers)
       end
     end
 
@@ -161,13 +190,22 @@ RSpec.describe Bulkrax::ValidationErrorCsvBuilder do
         expect(rows[1][0]).to be_nil
       end
 
+      it 'leaves the category cell blank for file-level rows' do
+        result = described_class.build(
+          headers: headers, csv_data: csv_data, row_errors: row_errors,
+          file_errors: { missing_files: ['photo.jpg'] }
+        )
+        rows = CSV.parse(result)
+        expect(rows[1][2]).to be_nil
+      end
+
       it 'leaves data columns blank for file-level rows' do
         result = described_class.build(
           headers: headers, csv_data: csv_data, row_errors: row_errors,
           file_errors: { missing_files: ['photo.jpg'] }
         )
         rows = CSV.parse(result)
-        expect(rows[1][2..]).to all(be_nil)
+        expect(rows[1][3..]).to all(be_nil)
       end
 
       context 'when both file-level and row-level errors are present' do

--- a/spec/validators/bulkrax/csv_row/required_values_spec.rb
+++ b/spec/validators/bulkrax/csv_row/required_values_spec.rb
@@ -26,12 +26,18 @@ RSpec.describe Bulkrax::CsvRow::RequiredValues do
     expect(context[:errors]).to be_empty
   end
 
-  it 'adds an error when a required field is missing' do
+  it 'adds an error when the required column is present but blank' do
     context = make_context
-    described_class.call(make_record({}), 2, context)
+    described_class.call(make_record('title' => ''), 2, context)
     expect(context[:errors].length).to eq(1)
     expect(context[:errors].first[:category]).to eq('missing_required_value')
     expect(context[:errors].first[:column]).to eq('title')
+  end
+
+  it 'does not add a row-level error when the required column is absent from the CSV entirely' do
+    context = make_context
+    described_class.call(make_record({}), 2, context)
+    expect(context[:errors]).to be_empty
   end
 
   it 'accepts a numbered column for a required field (title_1 satisfies title)' do
@@ -63,9 +69,9 @@ RSpec.describe Bulkrax::CsvRow::RequiredValues do
         expect(warning[:column]).to eq('model')
       end
 
-      it 'also emits a missing_required_value error when a required field is absent' do
+      it 'also emits a missing_required_value error when a required column is present but blank' do
         context = make_context
-        described_class.call(make_blank_model_record({}), 2, context)
+        described_class.call(make_blank_model_record('title' => ''), 2, context)
         categories = context[:errors].map { |e| e[:category] }
         expect(categories).to include('default_work_type_used', 'missing_required_value')
       end
@@ -86,9 +92,9 @@ RSpec.describe Bulkrax::CsvRow::RequiredValues do
         expect(context[:errors]).to be_empty
       end
 
-      it 'still emits missing_required_value errors for blank required fields' do
+      it 'still emits missing_required_value errors for blank required fields whose columns are present' do
         context = make_context(notices: [{ field: 'model', default_work_type: 'GenericWork' }])
-        described_class.call(make_blank_model_record({}), 2, context)
+        described_class.call(make_blank_model_record('title' => ''), 2, context)
         expect(context[:errors].map { |e| e[:category] }).to eq(['missing_required_value'])
       end
     end


### PR DESCRIPTION
# Summary

Cleans up the Bulkrax UI

- truncates the number of duplicated errors shown in the UI to 10
- presents validation errors more completely in the submit page so they summarize the initial validation results in a usable format
- adds use of translations throughout Bulkrax where missing previously (breadcrumbs, datatables, error csv download, etc)
- ensures all languages have all needed i18n keys

# Screenshots

<details>
<summary>UI Views</summary>

<img width="911" height="636" alt="Screenshot 2026-04-23 at 9 27 05 PM" src="https://github.com/user-attachments/assets/06065387-c50b-4d7e-af96-b056545d9485" />


<img width="860" height="264" alt="Screenshot 2026-04-23 at 9 27 17 PM" src="https://github.com/user-attachments/assets/2d2b1375-24ec-4e2d-879d-074dd8fec6c3" />

<img width="1322" height="623" alt="Screenshot 2026-04-23 at 9 53 01 PM" src="https://github.com/user-attachments/assets/5c54cd3f-94ee-4a6d-a93c-dfe4090c1f8f" />

<img width="1352" height="602" alt="Screenshot 2026-04-23 at 9 53 07 PM" src="https://github.com/user-attachments/assets/64778e35-c5ab-4a15-902c-7ce74370f5b7" />

<img width="967" height="616" alt="Screenshot 2026-04-23 at 9 52 39 PM" src="https://github.com/user-attachments/assets/137cf118-06b2-4e29-8b53-f5ff569f21ad" />

</details>
