### PR TITLE
Add migration to remove old field

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,6 @@ jobs:
       matrix:
         include:
           - ruby: '2.7'
-            rails: '~> 5.1'
-            hyrax: '~> 3.0'
-          - ruby: '2.7'
             rails: '~> 6.1'
             hyrax: '~> 4.0'
           - ruby: '3.3'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         include:
           - ruby: '2.7'
+            rails: '~> 5.1'
+            hyrax: '~> 3.0'
+          - ruby: '2.7'
             rails: '~> 6.1'
             hyrax: '~> 4.0'
           - ruby: '3.3'

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ This project is intended to be a safe, welcoming space for collaboration, and co
 - Decide on your version of Hyrax & Rails to test against and export it to your environment, then bundle install. The Hyrax version should be greater or equal to 2.3.
 
 You can find version combinations that should work in [.github/workflows/test.yml](.github/workflows/test.yml)
+
+If you have previously bundle installed with a different combination of versions, you may need to remove your Gemfile.lock `rm Gemfile.lock`
+
 ```bash
 export RAILS_GEM_VERSION="~> 7.2"
 export HYRAX_VERSION="~> 5.2"

--- a/README.md
+++ b/README.md
@@ -225,9 +225,12 @@ This project is intended to be a safe, welcoming space for collaboration, and co
 ```bash
 /path/to/ruby/install/bin/gem install bundler -v '~> 2.4.0'
 ```
-- Decide on your version of Hyrax to test against and export it to your environment, then bundle install. The Hyrax version should be greater or equal to 2.3.
+- Decide on your version of Hyrax & Rails to test against and export it to your environment, then bundle install. The Hyrax version should be greater or equal to 2.3.
+
+You can find version combinations that should work in [.github/workflows/test.yml](.github/workflows/test.yml)
 ```bash
-export HYRAX_VERSION="~> 4.0.0"
+export RAILS_GEM_VERSION="~> 7.2"
+export HYRAX_VERSION="~> 5.2"
 bundle install
 ```
 - Run the test migrations

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'simple_form'
 
   s.add_development_dependency 'dry-monads'
-  s.add_development_dependency 'sqlite3', '~> 1.3.13'
+  s.add_development_dependency 'sqlite3', '~> 1.4'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'redis', '~> 4.2'
   s.add_development_dependency 'psych', '~> 3.3'

--- a/db/migrate/20260424081537_remove_parents_from_bulkrax_importer_runs.rb
+++ b/db/migrate/20260424081537_remove_parents_from_bulkrax_importer_runs.rb
@@ -1,0 +1,9 @@
+class RemoveParentsFromBulkraxImporterRuns < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :bulkrax_importer_runs, :parents, if_exists: true
+  end
+
+  def down
+    add_column :bulkrax_importer_runs, :parents, :text, array: true, default: "{}", unless_exists: true
+  end
+end


### PR DESCRIPTION
A previous migration was improperly removed, rather than a new migration added to drop the field, leading to databases in a bad state.

Related to https://github.com/notch8/palni_palci_knapsack/issues/590