### PR TITLE
Add Bulkrax::Ability concern and enforce importer/exporter ownership

### DIFF
--- a/app/controllers/bulkrax/application_controller.rb
+++ b/app/controllers/bulkrax/application_controller.rb
@@ -13,7 +13,7 @@ module Bulkrax
       respond_to do |format|
         format.html do
           flash[:alert] = exception.message
-          redirect_to '/'
+          redirect_to main_app.root_path
         end
         format.json { render json: { error: exception.message }, status: :forbidden }
       end

--- a/app/controllers/bulkrax/application_controller.rb
+++ b/app/controllers/bulkrax/application_controller.rb
@@ -4,5 +4,39 @@ module Bulkrax
   class ApplicationController < ::ApplicationController
     helper Rails.application.class.helpers
     protect_from_forgery with: :exception
+
+    private
+
+    # Returns a relation of Importer records the current user may access.
+    # Importer admins see all importers; other users see only their own.
+    def accessible_importers
+      if current_ability.can_admin_importers?
+        Importer.all
+      else
+        Importer.where(user_id: current_user&.id)
+      end
+    end
+
+    # Returns a relation of Exporter records the current user may access.
+    # Exporter admins see all exporters; other users see only their own.
+    def accessible_exporters
+      if current_ability.can_admin_exporters?
+        Exporter.all
+      else
+        Exporter.where(user_id: current_user&.id)
+      end
+    end
+
+    # Returns true if the given importer or exporter is accessible to the current user.
+    def item_accessible?(item)
+      case item
+      when Importer
+        accessible_importers.exists?(item.id)
+      when Exporter
+        accessible_exporters.exists?(item.id)
+      else
+        false
+      end
+    end
   end
 end

--- a/app/controllers/bulkrax/application_controller.rb
+++ b/app/controllers/bulkrax/application_controller.rb
@@ -13,7 +13,7 @@ module Bulkrax
       respond_to do |format|
         format.html do
           flash[:alert] = exception.message
-          redirect_to main_app.root_path
+          redirect_to '/'
         end
         format.json { render json: { error: exception.message }, status: :forbidden }
       end

--- a/app/controllers/bulkrax/application_controller.rb
+++ b/app/controllers/bulkrax/application_controller.rb
@@ -5,37 +5,14 @@ module Bulkrax
     helper Rails.application.class.helpers
     protect_from_forgery with: :exception
 
-    private
-
-    # Returns a relation of Importer records the current user may access.
-    # Importer admins see all importers; other users see only their own.
-    def accessible_importers
-      if current_ability.can_admin_importers?
-        Importer.all
-      else
-        Importer.where(user_id: current_user&.id)
-      end
-    end
-
-    # Returns a relation of Exporter records the current user may access.
-    # Exporter admins see all exporters; other users see only their own.
-    def accessible_exporters
-      if current_ability.can_admin_exporters?
-        Exporter.all
-      else
-        Exporter.where(user_id: current_user&.id)
-      end
-    end
-
-    # Returns true if the given importer or exporter is accessible to the current user.
-    def item_accessible?(item)
-      case item
-      when Importer
-        accessible_importers.exists?(item.id)
-      when Exporter
-        accessible_exporters.exists?(item.id)
-      else
-        false
+    # Rescue CanCan::AccessDenied in all Bulkrax controllers.  HTML requests are
+    # redirected to the host-app root with an alert; JSON requests receive a 403
+    # response.  Defining the handler here (rather than in individual controllers)
+    # keeps error handling in one place and consistent across all resources.
+    rescue_from CanCan::AccessDenied do |exception|
+      respond_to do |format|
+        format.html { redirect_to main_app.root_path, alert: exception.message }
+        format.json { render json: { error: exception.message }, status: :forbidden }
       end
     end
   end

--- a/app/controllers/bulkrax/application_controller.rb
+++ b/app/controllers/bulkrax/application_controller.rb
@@ -11,7 +11,10 @@ module Bulkrax
     # keeps error handling in one place and consistent across all resources.
     rescue_from CanCan::AccessDenied do |exception|
       respond_to do |format|
-        format.html { redirect_to main_app.root_path, alert: exception.message }
+        format.html do
+          flash[:alert] = exception.message
+          redirect_to main_app.root_path
+        end
         format.json { render json: { error: exception.message }, status: :forbidden }
       end
     end

--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -4,7 +4,6 @@ module Bulkrax
   class EntriesController < ApplicationController
     include Hyrax::ThemedLayoutController if defined?(::Hyrax)
     before_action :authenticate_user!
-    before_action :check_permissions
     with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     def show
@@ -17,8 +16,7 @@ module Bulkrax
 
     def update
       @entry = Entry.find(params[:id])
-      item = @entry.importerexporter
-      raise CanCan::AccessDenied unless item_accessible?(item)
+      authorize! :update, @entry
 
       type = case @entry.type.downcase
              when /fileset/
@@ -29,6 +27,7 @@ module Bulkrax
                'work'
              end
       # do not run counters as it loads the whole parser
+      item = @entry.importerexporter
       current_run = item.current_run(skip_counts: true)
       @entry.set_status_info('Pending', current_run)
       ScheduleRelationshipsJob.set(wait: 5.minutes).perform_later(importer_id: @entry.importer.id)
@@ -46,9 +45,9 @@ module Bulkrax
 
     def destroy
       @entry = Entry.find(params[:id])
-      item = @entry.importerexporter
-      raise CanCan::AccessDenied unless item_accessible?(item)
+      authorize! :destroy, @entry
 
+      item = @entry.importerexporter
       @status = ""
       begin
         work = @entry.factory&.find
@@ -73,8 +72,10 @@ module Bulkrax
 
     # GET /importers/1/entries/1
     def show_importer
-      @importer = accessible_importers.find(params[:importer_id])
-      @entry = Entry.find(params[:id])
+      @importer = Importer.find(params[:importer_id])
+      authorize! :read, @importer
+      @entry = @importer.entries.find(params[:id])
+      authorize! :read, @entry
 
       return unless defined?(::Hyrax)
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
@@ -86,8 +87,10 @@ module Bulkrax
 
     # GET /exporters/1/entries/1
     def show_exporter
-      @exporter = accessible_exporters.find(params[:exporter_id])
-      @entry = Entry.find(params[:id])
+      @exporter = Exporter.find(params[:exporter_id])
+      authorize! :read, @exporter
+      @entry = @exporter.entries.find(params[:id])
+      authorize! :read, @entry
 
       return unless defined?(::Hyrax)
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
@@ -95,10 +98,6 @@ module Bulkrax
       add_breadcrumb 'Exporters', bulkrax.exporters_path
       add_breadcrumb @exporter.name, bulkrax.exporter_path(@exporter.id)
       add_breadcrumb @entry.id
-    end
-
-    def check_permissions
-      raise CanCan::AccessDenied unless current_ability.can_import_works? || current_ability.can_export_works?
     end
   end
 end

--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -17,6 +17,9 @@ module Bulkrax
 
     def update
       @entry = Entry.find(params[:id])
+      item = @entry.importerexporter
+      raise CanCan::AccessDenied unless item_accessible?(item)
+
       type = case @entry.type.downcase
              when /fileset/
                'file_set'
@@ -25,7 +28,6 @@ module Bulkrax
              else
                'work'
              end
-      item = @entry.importerexporter
       # do not run counters as it loads the whole parser
       current_run = item.current_run(skip_counts: true)
       @entry.set_status_info('Pending', current_run)
@@ -44,6 +46,9 @@ module Bulkrax
 
     def destroy
       @entry = Entry.find(params[:id])
+      item = @entry.importerexporter
+      raise CanCan::AccessDenied unless item_accessible?(item)
+
       @status = ""
       begin
         work = @entry.factory&.find
@@ -59,7 +64,6 @@ module Bulkrax
         @status = "Error: #{e.message}"
       end
 
-      item = @entry.importerexporter
       entry_path = item.class.to_s.include?('Importer') ? bulkrax.importer_entry_path(item.id, @entry.id) : bulkrax.exporter_entry_path(item.id, @entry.id)
 
       redirect_back fallback_location: entry_path, notice: @status
@@ -69,7 +73,7 @@ module Bulkrax
 
     # GET /importers/1/entries/1
     def show_importer
-      @importer = Importer.find(params[:importer_id])
+      @importer = accessible_importers.find(params[:importer_id])
       @entry = Entry.find(params[:id])
 
       return unless defined?(::Hyrax)
@@ -82,7 +86,7 @@ module Bulkrax
 
     # GET /exporters/1/entries/1
     def show_exporter
-      @exporter = Exporter.find(params[:exporter_id])
+      @exporter = accessible_exporters.find(params[:exporter_id])
       @entry = Entry.find(params[:id])
 
       return unless defined?(::Hyrax)

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -13,13 +13,13 @@ module Bulkrax
     # GET /exporters
     def index
       # NOTE: We're paginating this in the browser.
-      @exporters = Exporter.order(created_at: :desc).all
+      @exporters = accessible_exporters.order(created_at: :desc)
 
       add_exporter_breadcrumbs if defined?(::Hyrax)
     end
 
     def exporter_table
-      @exporters = Exporter.order(table_order).page(table_page).per(table_per_page)
+      @exporters = accessible_exporters.order(table_order).page(table_page).per(table_per_page)
       @exporters = @exporters.where(exporter_table_search) if exporter_table_search.present?
       respond_to do |format|
         format.json { render json: format_exporters(@exporters) }
@@ -106,7 +106,7 @@ module Bulkrax
 
     # GET /exporters/1/download
     def download
-      @exporter = Exporter.find(params[:exporter_id])
+      @exporter = accessible_exporters.find(params[:exporter_id])
       send_content
     end
 
@@ -114,7 +114,7 @@ module Bulkrax
 
     # Use callbacks to share common setup or constraints between actions.
     def set_exporter
-      @exporter = Exporter.find(params[:id] || params[:exporter_id])
+      @exporter = accessible_exporters.find(params[:id] || params[:exporter_id])
     end
 
     # Only allow a trusted parameters through.

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -6,20 +6,25 @@ module Bulkrax
     include Bulkrax::DownloadBehavior
     include Bulkrax::DatatablesBehavior
     before_action :authenticate_user!
-    before_action :check_permissions
-    before_action :set_exporter, only: [:show, :entry_table, :edit, :update, :destroy]
+    # load_and_authorize_resource handles both record loading and per-resource
+    # authorization for all member actions.  Index and exporter_table are
+    # excluded because they operate on a collection (scoped via accessible_by).
+    # Download is excluded because it uses :exporter_id rather than :id.
+    load_and_authorize_resource class: 'Bulkrax::Exporter',
+                                instance_name: :exporter,
+                                except: [:index, :exporter_table, :download]
     with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     # GET /exporters
     def index
       # NOTE: We're paginating this in the browser.
-      @exporters = accessible_exporters.order(created_at: :desc)
+      @exporters = Exporter.accessible_by(current_ability).order(created_at: :desc)
 
       add_exporter_breadcrumbs if defined?(::Hyrax)
     end
 
     def exporter_table
-      @exporters = accessible_exporters.order(table_order).page(table_page).per(table_per_page)
+      @exporters = Exporter.accessible_by(current_ability).order(table_order).page(table_page).per(table_per_page)
       @exporters = @exporters.where(exporter_table_search) if exporter_table_search.present?
       respond_to do |format|
         format.json { render json: format_exporters(@exporters) }
@@ -45,7 +50,6 @@ module Bulkrax
 
     # GET /exporters/new
     def new
-      @exporter = Exporter.new
       return unless defined?(::Hyrax)
       add_exporter_breadcrumbs
       add_breadcrumb 'New'
@@ -65,7 +69,6 @@ module Bulkrax
 
     # POST /exporters
     def create
-      @exporter = Exporter.new(exporter_params)
       field_mapping_params
 
       if @exporter.save
@@ -106,16 +109,12 @@ module Bulkrax
 
     # GET /exporters/1/download
     def download
-      @exporter = accessible_exporters.find(params[:exporter_id])
+      @exporter = Exporter.find(params[:exporter_id])
+      authorize! :read, @exporter
       send_content
     end
 
     private
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_exporter
-      @exporter = accessible_exporters.find(params[:id] || params[:exporter_id])
-    end
 
     # Only allow a trusted parameters through.
     def exporter_params
@@ -148,10 +147,6 @@ module Bulkrax
 
     def file_path
       "#{@exporter.exporter_export_zip_path}/#{params['exporter']['exporter_export_zip_files']}"
-    end
-
-    def check_permissions
-      raise CanCan::AccessDenied unless current_ability.can_export_works?
     end
   end
 end

--- a/app/controllers/bulkrax/guided_imports_controller.rb
+++ b/app/controllers/bulkrax/guided_imports_controller.rb
@@ -8,7 +8,7 @@ module Bulkrax
     helper Bulkrax::ImportersHelper
 
     before_action :authenticate_user!
-    before_action :check_permissions
+    before_action { authorize! :create, Bulkrax::Importer }
     with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     # trigger form to allow upload
@@ -166,10 +166,6 @@ module Bulkrax
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb 'Importers', bulkrax.importers_path
-    end
-
-    def check_permissions
-      raise CanCan::AccessDenied unless current_ability.can_import_works?
     end
   end
 end

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -30,7 +30,7 @@ module Bulkrax
 
     def importer_table
       order = table_order.presence || Arel.sql('last_imported_at DESC NULLS LAST')
-      @importers = Importer.order(order).page(table_page).per(table_per_page)
+      @importers = accessible_importers.order(order).page(table_page).per(table_per_page)
       @importers = @importers.where(importer_table_search) if importer_table_search.present?
       respond_to do |format|
         format.json { render json: format_importers(@importers) }
@@ -177,7 +177,7 @@ module Bulkrax
 
     # PUT /importers/1
     def continue
-      @importer = Importer.find(params[:importer_id])
+      @importer = accessible_importers.find(params[:importer_id])
       params[:importer] = { name: @importer.name }
       @importer.validate_only = false
       update
@@ -185,7 +185,7 @@ module Bulkrax
 
     # GET /importer/1/upload_corrected_entries
     def upload_corrected_entries
-      @importer = Importer.find(params[:importer_id])
+      @importer = accessible_importers.find(params[:importer_id])
       return unless defined?(::Hyrax)
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
@@ -197,7 +197,7 @@ module Bulkrax
     # POST /importer/1/upload_corrected_entries_file
     def upload_corrected_entries_file
       file = params[:importer][:parser_fields].delete(:file)
-      @importer = Importer.find(params[:importer_id])
+      @importer = accessible_importers.find(params[:importer_id])
       if file.present?
         @importer[:parser_fields]['partial_import_file_path'] = @importer.parser.write_partial_import_file(file)
         @importer.save
@@ -242,7 +242,7 @@ module Bulkrax
 
     # GET /importers/1/export_errors
     def export_errors
-      @importer = Importer.find(params[:importer_id])
+      @importer = accessible_importers.find(params[:importer_id])
       @importer.write_errored_entries_file
       send_content
     end
@@ -251,7 +251,13 @@ module Bulkrax
 
     # Use callbacks to share common setup or constraints between actions.
     def set_importer
-      @importer = Importer.find(params[:id] || params[:importer_id])
+      @importer = accessible_importers.find(params[:id] || params[:importer_id])
+    end
+
+    # API requests bypass per-user scoping so existing API consumers are unaffected.
+    def accessible_importers
+      return Importer.all if api_request?
+      super
     end
 
     def importable_params

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -13,14 +13,33 @@ module Bulkrax
     protect_from_forgery unless: -> { api_request? }
     before_action :token_authenticate!, if: -> { api_request? }, only: [:create, :update, :delete]
     before_action :authenticate_user!, unless: -> { api_request? }
-    before_action :check_permissions
-    before_action :set_importer, only: [:show, :entry_table, :edit, :update, :destroy, :original_file]
+    # load_and_authorize_resource covers standard CRUD member actions for
+    # non-API requests.  Actions that use :importer_id rather than :id, or
+    # that are collection-scoped, are excluded and handled by separate
+    # before_actions below.
+    load_and_authorize_resource class: 'Bulkrax::Importer',
+                                instance_name: :importer,
+                                except: [:index, :importer_table, :sample_csv_file, :external_sets,
+                                         :continue, :upload_corrected_entries, :upload_corrected_entries_file,
+                                         :export_errors, :original_file],
+                                unless: -> { api_request? }
+    # For API requests, fall back to simple find so existing consumers are
+    # unaffected while the token-to-user wiring is not yet implemented.
+    before_action :set_importer_for_api,
+                  only: [:show, :entry_table, :edit, :update, :destroy, :original_file],
+                  if: -> { api_request? }
+    # Actions that reference importers by :importer_id (not :id)
+    before_action :load_and_authorize_importer_by_importer_id,
+                  only: [:continue, :upload_corrected_entries, :upload_corrected_entries_file, :export_errors, :original_file]
     with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     # GET /importers
     def index
       # NOTE: We're paginating this in the browser.
       if api_request?
+        # TODO: Scope API index by token owner once token-to-user wiring is in
+        # place.  Tracked in [ISSUE].  Until then, API clients see all importers
+        # to preserve backward-compatibility with existing API consumers.
         @importers = Importer.order(created_at: :desc).all
         json_response('index')
       elsif defined?(::Hyrax)
@@ -30,7 +49,13 @@ module Bulkrax
 
     def importer_table
       order = table_order.presence || Arel.sql('last_imported_at DESC NULLS LAST')
-      @importers = accessible_importers.order(order).page(table_page).per(table_per_page)
+      # TODO: API requests bypass ownership scoping here too; see index TODO.
+      @importers = if api_request?
+                     Importer.all
+                   else
+                     Importer.accessible_by(current_ability)
+                   end
+      @importers = @importers.order(order).page(table_page).per(table_per_page)
       @importers = @importers.where(importer_table_search) if importer_table_search.present?
       respond_to do |format|
         format.json { render json: format_importers(@importers) }
@@ -58,7 +83,6 @@ module Bulkrax
 
     # GET /importers/new
     def new
-      @importer = Importer.new
       if api_request?
         json_response('new')
       elsif defined?(::Hyrax)
@@ -95,12 +119,13 @@ module Bulkrax
       # rubocop:disable Style/IfInsideElse
       if api_request?
         return return_json_response unless valid_create_params?
+        # load_and_authorize_resource is skipped for API; build the record here.
+        @importer ||= Importer.new(importer_params)
       end
       uploads = uploaded_files_scope
       file = file_param
       cloud_files = cloud_params
 
-      @importer = Importer.new(importer_params)
       field_mapping_params
       @importer.validate_only = true if params[:commit] == 'Create and Validate'
       # the following line is needed to handle updating remote files of a FileSet
@@ -177,7 +202,6 @@ module Bulkrax
 
     # PUT /importers/1
     def continue
-      @importer = accessible_importers.find(params[:importer_id])
       params[:importer] = { name: @importer.name }
       @importer.validate_only = false
       update
@@ -185,7 +209,6 @@ module Bulkrax
 
     # GET /importer/1/upload_corrected_entries
     def upload_corrected_entries
-      @importer = accessible_importers.find(params[:importer_id])
       return unless defined?(::Hyrax)
       add_breadcrumb t(:'hyrax.controls.home'), main_app.root_path
       add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
@@ -197,7 +220,6 @@ module Bulkrax
     # POST /importer/1/upload_corrected_entries_file
     def upload_corrected_entries_file
       file = params[:importer][:parser_fields].delete(:file)
-      @importer = accessible_importers.find(params[:importer_id])
       if file.present?
         @importer[:parser_fields]['partial_import_file_path'] = @importer.parser.write_partial_import_file(file)
         @importer.save
@@ -242,22 +264,29 @@ module Bulkrax
 
     # GET /importers/1/export_errors
     def export_errors
-      @importer = accessible_importers.find(params[:importer_id])
       @importer.write_errored_entries_file
       send_content
     end
 
     private
 
-    # Use callbacks to share common setup or constraints between actions.
-    def set_importer
-      @importer = accessible_importers.find(params[:id] || params[:importer_id])
+    # Load @importer for API requests (no CanCan authorization — the API path
+    # does not yet resolve a token to a current_user, so ownership rules cannot
+    # be evaluated).
+    # TODO: Remove once token-to-user wiring is complete and CanCan rules apply
+    # uniformly to API requests.  Tracked in [ISSUE].
+    def set_importer_for_api
+      @importer = Importer.find(params[:id] || params[:importer_id])
     end
 
-    # API requests bypass per-user scoping so existing API consumers are unaffected.
-    def accessible_importers
-      return Importer.all if api_request?
-      super
+    # Load and authorize @importer for actions that identify the importer by
+    # :importer_id rather than :id (e.g. continue, upload_corrected_entries).
+    # Uses the action name directly so that alias_action mappings defined in
+    # bulkrax_default_abilities apply (e.g. :export_errors → :read,
+    # :continue → :update).
+    def load_and_authorize_importer_by_importer_id
+      @importer = Importer.find(params[:importer_id])
+      authorize! action_name.to_sym, @importer
     end
 
     def importable_params
@@ -370,10 +399,6 @@ module Bulkrax
         @importer.parser_fields['metadata_only'] = true
       end
       @importer.save
-    end
-
-    def check_permissions
-      raise CanCan::AccessDenied unless current_ability.can_import_works?
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/controllers/concerns/bulkrax/datatables_behavior.rb
+++ b/app/controllers/concerns/bulkrax/datatables_behavior.rb
@@ -102,8 +102,8 @@ module Bulkrax
       end
       {
         data: result,
-        recordsTotal: accessible_importers.count,
-        recordsFiltered: accessible_importers.count
+        recordsTotal: Bulkrax::Importer.accessible_by(current_ability).count,
+        recordsFiltered: Bulkrax::Importer.accessible_by(current_ability).count
       }
     end
 
@@ -119,8 +119,8 @@ module Bulkrax
       end
       {
         data: result,
-        recordsTotal: accessible_exporters.count,
-        recordsFiltered: accessible_exporters.count
+        recordsTotal: Bulkrax::Exporter.accessible_by(current_ability).count,
+        recordsFiltered: Bulkrax::Exporter.accessible_by(current_ability).count
       }
     end
 
@@ -146,7 +146,7 @@ module Bulkrax
     def entry_util_links(e, item)
       links = []
       links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), view_context.item_entry_path(item, e))
-      if item_accessible?(item)
+      if can?(:update, item)
         links << "<a class='fa fa-repeat' data-toggle='modal' data-target='#bulkraxItemModal' data-entry-id='#{e.id}'></a>" if view_context.an_importer?(item)
         links << view_context.link_to(view_context.raw('<span class="fa fa-trash"></span>'), view_context.item_entry_path(item, e), method: :delete, data: { confirm: 'This will delete the entry and any work associated with it. Are you sure?' })
       end
@@ -168,7 +168,7 @@ module Bulkrax
     def importer_util_links(i)
       links = []
       links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), importer_path(i))
-      if item_accessible?(i)
+      if can?(:update, i)
         links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_importer_path(i))
         links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
       end
@@ -178,7 +178,7 @@ module Bulkrax
     def exporter_util_links(i)
       links = []
       links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), exporter_path(i))
-      if item_accessible?(i)
+      if can?(:update, i)
         links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_exporter_path(i), data: { turbolinks: false })
         links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
       end

--- a/app/controllers/concerns/bulkrax/datatables_behavior.rb
+++ b/app/controllers/concerns/bulkrax/datatables_behavior.rb
@@ -102,8 +102,8 @@ module Bulkrax
       end
       {
         data: result,
-        recordsTotal: Bulkrax::Importer.count,
-        recordsFiltered: Bulkrax::Importer.count
+        recordsTotal: accessible_importers.count,
+        recordsFiltered: accessible_importers.count
       }
     end
 
@@ -119,8 +119,8 @@ module Bulkrax
       end
       {
         data: result,
-        recordsTotal: Bulkrax::Exporter.count,
-        recordsFiltered: Bulkrax::Exporter.count
+        recordsTotal: accessible_exporters.count,
+        recordsFiltered: accessible_exporters.count
       }
     end
 
@@ -146,8 +146,10 @@ module Bulkrax
     def entry_util_links(e, item)
       links = []
       links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), view_context.item_entry_path(item, e))
-      links << "<a class='fa fa-repeat' data-toggle='modal' data-target='#bulkraxItemModal' data-entry-id='#{e.id}'></a>" if view_context.an_importer?(item)
-      links << view_context.link_to(view_context.raw('<span class="fa fa-trash"></span>'), view_context.item_entry_path(item, e), method: :delete, data: { confirm: 'This will delete the entry and any work associated with it. Are you sure?' })
+      if item_accessible?(item)
+        links << "<a class='fa fa-repeat' data-toggle='modal' data-target='#bulkraxItemModal' data-entry-id='#{e.id}'></a>" if view_context.an_importer?(item)
+        links << view_context.link_to(view_context.raw('<span class="fa fa-trash"></span>'), view_context.item_entry_path(item, e), method: :delete, data: { confirm: 'This will delete the entry and any work associated with it. Are you sure?' })
+      end
       links.join(" ")
     end
 
@@ -166,16 +168,20 @@ module Bulkrax
     def importer_util_links(i)
       links = []
       links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), importer_path(i))
-      links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_importer_path(i))
-      links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
+      if item_accessible?(i)
+        links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_importer_path(i))
+        links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
+      end
       links.join(" ")
     end
 
     def exporter_util_links(i)
       links = []
       links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), exporter_path(i))
-      links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_exporter_path(i), data: { turbolinks: false })
-      links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
+      if item_accessible?(i)
+        links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_exporter_path(i), data: { turbolinks: false })
+        links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
+      end
       links.join(" ")
     end
 

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -211,7 +211,7 @@ module Bulkrax
     # @param [Hash] attrs the attributes to put in the environment
     # @return [Hyrax::Actors::Environment]
     def environment(attrs)
-      Hyrax::Actors::Environment.new(object, Ability.new(@user), attrs)
+      Hyrax::Actors::Environment.new(object, ::Ability.new(@user), attrs)
     end
 
     def work_actor

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -60,7 +60,7 @@ module Bulkrax
       @importer_run_id = importer_run_id
       @importer_run = Bulkrax::ImporterRun.find(@importer_run_id) if @importer_run_id
       @user = run_user || importer_run&.user
-      @ability = Ability.new(@user)
+      @ability = ::Ability.new(@user)
 
       @number_of_successes = 0
       @number_of_failures = 0

--- a/app/models/concerns/bulkrax/ability.rb
+++ b/app/models/concerns/bulkrax/ability.rb
@@ -96,27 +96,45 @@ module Bulkrax
                    :download, to: :read
       alias_action :continue, :upload_corrected_entries_file, to: :update
 
-      if can_import_works?
+      grant_importer_abilities
+      grant_exporter_abilities
+    end
+
+    def grant_importer_abilities
+      if can_admin_importers?
+        # Prefer a single unconditional rule for admins.  Older CanCanCan/
+        # ActiveRecord combinations used by the Hyrax 4 appraisal can fail when
+        # accessible_by has to merge unconditional and hash-conditioned rules.
+        can :manage, Bulkrax::Importer
+      elsif can_import_works?
         can :create, Bulkrax::Importer
         can [:read, :update, :destroy], Bulkrax::Importer, user_id: current_user.id
-        can [:read, :update, :destroy], Bulkrax::Entry do |entry|
-          entry.importerexporter.is_a?(Bulkrax::Importer) &&
-            entry.importerexporter.user_id == current_user.id
-        end
       end
 
-      if can_export_works?
+      return unless can_import_works?
+
+      can [:read, :update, :destroy], Bulkrax::Entry do |entry|
+        entry.importerexporter.is_a?(Bulkrax::Importer) &&
+          entry.importerexporter.user_id == current_user.id
+      end
+    end
+
+    def grant_exporter_abilities
+      if can_admin_exporters?
+        # Prefer a single unconditional rule for admins.  See importer rule
+        # above for the Hyrax 4 accessible_by compatibility note.
+        can :manage, Bulkrax::Exporter
+      elsif can_export_works?
         can :create, Bulkrax::Exporter
         can [:read, :update, :destroy], Bulkrax::Exporter, user_id: current_user.id
-        can [:read, :update, :destroy], Bulkrax::Entry do |entry|
-          entry.importerexporter.is_a?(Bulkrax::Exporter) &&
-            entry.importerexporter.user_id == current_user.id
-        end
       end
 
-      # Admin rules grant full management with no ownership restriction.
-      can :manage, Bulkrax::Importer if can_admin_importers?
-      can :manage, Bulkrax::Exporter if can_admin_exporters?
+      return unless can_export_works?
+
+      can [:read, :update, :destroy], Bulkrax::Entry do |entry|
+        entry.importerexporter.is_a?(Bulkrax::Exporter) &&
+          entry.importerexporter.user_id == current_user.id
+      end
     end
   end
 end

--- a/app/models/concerns/bulkrax/ability.rb
+++ b/app/models/concerns/bulkrax/ability.rb
@@ -7,11 +7,27 @@ module Bulkrax
   # implementations of all Bulkrax authorization methods. Override any
   # method to customize authorization behavior for your application.
   #
+  # ## Wiring CanCan rules
+  #
+  # Call +bulkrax_default_abilities+ from your Ability's +initialize+ (or add
+  # it to +self.ability_logic+) to register CanCan +can+ rules for all
+  # Bulkrax resources:
+  #
+  #   class Ability
+  #     include Hydra::Ability
+  #     include Bulkrax::Ability
+  #     self.ability_logic += [:bulkrax_default_abilities]
+  #   end
+  #
+  # The method uses the four predicate hooks below as guards, so you can
+  # control who gets which rules simply by overriding those predicates.
+  #
   # Example:
   #
   #   class Ability
   #     include Hydra::Ability
   #     include Bulkrax::Ability
+  #     self.ability_logic += [:bulkrax_default_abilities]
   #
   #     # Grant import/export access to users who can create works
   #     def can_import_works?
@@ -54,6 +70,53 @@ module Bulkrax
     # Defaults to false; override to grant admin access.
     def can_admin_exporters?
       false
+    end
+
+    # Registers CanCan +can+ rules for all Bulkrax resources.
+    #
+    # Call this from your Ability's +initialize+ or add it to
+    # +self.ability_logic+. The predicate hooks above control which rules are
+    # granted; override them to tailor access.
+    #
+    # Rules for Importer and Exporter use hash-form conditions (SQL-generatable)
+    # so they work with +Model.accessible_by(current_ability)+. Rules for Entry
+    # use block-form conditions (checked in Ruby) because authorization must
+    # traverse the parent association — do not call +Entry.accessible_by()+;
+    # scope entries through the parent instead (e.g. +@importer.entries+).
+    def bulkrax_default_abilities
+      # Skip all rules when there is no authenticated user; avoids nil-id bugs
+      # and prevents block rules from matching NULL user_id records.
+      return unless current_user&.id
+
+      # Map Bulkrax-specific non-CRUD actions to their closest CanCan equivalents
+      # so that load_and_authorize_resource can authorize them without requiring
+      # a dedicated `can` declaration for each custom action name.
+      alias_action :entry_table, :importer_table, :exporter_table,
+                   :original_file, :export_errors, :upload_corrected_entries,
+                   :download, to: :read
+      alias_action :continue, :upload_corrected_entries_file, to: :update
+
+      if can_import_works?
+        can :create, Bulkrax::Importer
+        can [:read, :update, :destroy], Bulkrax::Importer, user_id: current_user.id
+        can [:read, :update, :destroy], Bulkrax::Entry do |entry|
+          entry.importerexporter.is_a?(Bulkrax::Importer) &&
+            entry.importerexporter.user_id == current_user.id
+        end
+      end
+
+      if can_export_works?
+        can :create, Bulkrax::Exporter
+        can [:read, :update, :destroy], Bulkrax::Exporter, user_id: current_user.id
+        can [:read, :update, :destroy], Bulkrax::Entry do |entry|
+          entry.importerexporter.is_a?(Bulkrax::Exporter) &&
+            entry.importerexporter.user_id == current_user.id
+        end
+      end
+
+      # Admin rules grant full management with no ownership restriction.
+      can :manage, Bulkrax::Importer if can_admin_importers?
+      can :manage, Bulkrax::Exporter if can_admin_exporters?
     end
   end
 end

--- a/app/models/concerns/bulkrax/ability.rb
+++ b/app/models/concerns/bulkrax/ability.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  # Concern providing Bulkrax-specific ability methods.
+  #
+  # Include this in your application's Ability class to gain default
+  # implementations of all Bulkrax authorization methods. Override any
+  # method to customize authorization behavior for your application.
+  #
+  # Example:
+  #
+  #   class Ability
+  #     include Hydra::Ability
+  #     include Bulkrax::Ability
+  #
+  #     # Grant import/export access to users who can create works
+  #     def can_import_works?
+  #       can_create_any_work?
+  #     end
+  #
+  #     def can_export_works?
+  #       can_create_any_work?
+  #     end
+  #
+  #     # Grant admin-level importer access to site admins
+  #     def can_admin_importers?
+  #       current_user.admin?
+  #     end
+  #   end
+  module Ability
+    extend ActiveSupport::Concern
+
+    # Returns true if the current user may use importer functionality at all.
+    # Override in your Ability class to customize.
+    def can_import_works?
+      false
+    end
+
+    # Returns true if the current user may use exporter functionality at all.
+    # Override in your Ability class to customize.
+    def can_export_works?
+      false
+    end
+
+    # Returns true if the current user may administer ALL importers —
+    # i.e., view, edit, update, or destroy any importer regardless of ownership.
+    # Defaults to false; override to grant admin access.
+    def can_admin_importers?
+      false
+    end
+
+    # Returns true if the current user may administer ALL exporters —
+    # i.e., view, edit, update, or destroy any exporter regardless of ownership.
+    # Defaults to false; override to grant admin access.
+    def can_admin_exporters?
+      false
+    end
+  end
+end

--- a/lib/generators/bulkrax/install_generator.rb
+++ b/lib/generators/bulkrax/install_generator.rb
@@ -58,18 +58,29 @@ class Bulkrax::InstallGenerator < Rails::Generators::Base
   def add_ability
     file = 'app/models/ability.rb'
     file_text = File.read(file)
-    import_line = 'def can_import_works?'
-    export_line = 'def can_export_works?'
-    unless file_text.include?(import_line)
-      insert_into_file file, before: /^end/ do
-        "  def can_import_works?\n    can_create_any_work?\n  end"
-      end
-    end
+    include_line = 'include Bulkrax::Ability'
 
     # rubocop:disable Style/GuardClause
-    unless file_text.include?(export_line)
-      insert_into_file file, before: /^end/ do
-        "  def can_export_works?\n    can_create_any_work?\n  end"
+    unless file_text.include?(include_line)
+      insert_into_file file, after: /include\s+\S+Ability[^\n]*\n/ do
+        "  include Bulkrax::Ability\n\n" \
+        "  # Override Bulkrax::Ability methods as needed, for example:\n" \
+        "  #\n" \
+        "  #   def can_import_works?\n" \
+        "  #     can_create_any_work?\n" \
+        "  #   end\n" \
+        "  #\n" \
+        "  #   def can_export_works?\n" \
+        "  #     can_create_any_work?\n" \
+        "  #   end\n" \
+        "  #\n" \
+        "  #   def can_admin_importers?\n" \
+        "  #     current_user.admin?\n" \
+        "  #   end\n" \
+        "  #\n" \
+        "  #   def can_admin_exporters?\n" \
+        "  #     current_user.admin?\n" \
+        "  #   end\n"
       end
     end
     # rubocop:enable Style/GuardClause

--- a/plans/rails_cancan_convensions.md
+++ b/plans/rails_cancan_convensions.md
@@ -1,0 +1,336 @@
+# Refactoring Bulkrax Controllers to Rails/CanCanCan Conventions
+
+## Executive Summary
+
+The `importer-exorter-permissions` branch introduced working ownership-based authorization, but used ad-hoc patterns rather than CanCanCan's established conventions. This plan describes how to replace the custom methods with proper CanCan rules, `load_and_authorize_resource`, and `accessible_by` scoping — making authorization logic centralised, testable, and consistent with the host app's Ability class.
+
+---
+
+## Current Non-Conventional Patterns
+
+### 1. `Bulkrax::Ability` defines no `can` rules
+
+**File:** `app/models/concerns/bulkrax/ability.rb`
+
+The concern exposes four plain Ruby predicate methods (`can_import_works?`, `can_export_works?`, `can_admin_importers?`, `can_admin_exporters?`) and never calls `can` or `cannot`. CanCanCan conventions require that an Ability class define permissions by calling `can :action, Model` inside `initialize` (or a delegated method). Without these declarations, CanCan's `authorize!`, `load_and_authorize_resource`, and `Model.accessible_by(current_ability)` have nothing to evaluate.
+
+### 2. `check_permissions` as a coarse gate
+
+**Files:** `app/controllers/bulkrax/importers_controller.rb:375-377`, `exporters_controller.rb:153-155`, `entries_controller.rb:100-102`, `guided_imports_controller.rb:171-173`
+
+Each controller defines its own private `check_permissions` method that raises `CanCan::AccessDenied` against a boolean predicate. The conventional pattern is `before_action { authorize! :read, Importer }` (or relying on `load_and_authorize_resource` to do this implicitly). The custom gate only checks coarse capability, not per-resource permissions.
+
+### 3. Manual `accessible_importers` / `accessible_exporters` scoping helpers
+
+**File:** `app/controllers/bulkrax/application_controller.rb:12-27`
+
+These methods manually branch on `can_admin_*?` to return either `Model.all` or `Model.where(user_id: current_user.id)`. The conventional CanCan approach is `Model.accessible_by(current_ability, :read)`, which evaluates the rules defined in the Ability class and builds a scope automatically.
+
+### 4. Inline `item_accessible?` guards in action bodies
+
+**File:** `app/controllers/bulkrax/entries_controller.rb:21, 50`
+
+```ruby
+raise CanCan::AccessDenied unless item_accessible?(item)
+```
+
+The conventional approach is `authorize! :update, item` (or letting `load_and_authorize_resource` call it). Keeping authorization inside action bodies spreads the logic and makes it easy to forget on new actions.
+
+### 5. Unscoped `Entry.find` followed by a parent check
+
+**File:** `app/controllers/bulkrax/entries_controller.rb:19, 48`
+
+```ruby
+@entry = Entry.find(params[:id])
+item = @entry.importerexporter
+raise CanCan::AccessDenied unless item_accessible?(item)
+```
+
+This fetches the entry unconditionally, then checks the parent. Any user who knows an entry ID can trigger a DB hit before the authorization guard runs. The conventional pattern is either a scoped find on the parent or `load_and_authorize_resource` with `:through` pointing to the parent resource.
+
+### 6. API bypass hardcoded in `accessible_importers` override
+
+**File:** `app/controllers/bulkrax/importers_controller.rb:258-261`
+
+```ruby
+def accessible_importers
+  return Importer.all if api_request?
+  super
+end
+```
+
+This silently removes all ownership filtering for API requests. The conventional approach is to authenticate the API token and then express API permissions as regular CanCan rules (e.g., `can :manage, Importer` for service tokens), keeping authorization logic in one place.
+
+### 7. Inconsistent error types
+
+`EntriesController` raises `CanCan::AccessDenied` explicitly, while `ImportersController` and `ExportersController` raise `ActiveRecord::RecordNotFound` implicitly (via `.find` on a scoped relation). This means the error handler a host app configures for one case will not catch the other.
+
+---
+
+## Proposed Conventional Replacements
+
+### Step A — Define `can` rules inside `Bulkrax::Ability`
+
+Convert the four predicate methods into proper CanCan rule declarations. The concern's `included` block (or a `bulkrax_default_abilities` method called from the host app's `initialize`) should emit `can` calls:
+
+```ruby
+module Bulkrax
+  module Ability
+    extend ActiveSupport::Concern
+
+    included do
+      # called from initialize in the including Ability class
+    end
+
+    def bulkrax_default_abilities
+      if can_import_works?
+        can :create, Bulkrax::Importer
+        can [:read, :update, :destroy], Bulkrax::Importer, user_id: current_user.id
+        can :read, Bulkrax::Entry do |entry|
+          entry.importerexporter.is_a?(Bulkrax::Importer) &&
+            entry.importerexporter.user_id == current_user.id
+        end
+        can [:update, :destroy], Bulkrax::Entry do |entry|
+          entry.importerexporter.is_a?(Bulkrax::Importer) &&
+            entry.importerexporter.user_id == current_user.id
+        end
+      end
+
+      if can_export_works?
+        can :create, Bulkrax::Exporter
+        can [:read, :update, :destroy], Bulkrax::Exporter, user_id: current_user.id
+        can :read, Bulkrax::Entry do |entry|
+          entry.importerexporter.is_a?(Bulkrax::Exporter) &&
+            entry.importerexporter.user_id == current_user.id
+        end
+        can [:update, :destroy], Bulkrax::Entry do |entry|
+          entry.importerexporter.is_a?(Bulkrax::Exporter) &&
+            entry.importerexporter.user_id == current_user.id
+        end
+      end
+
+      if can_admin_importers?
+        can :manage, Bulkrax::Importer
+      end
+
+      if can_admin_exporters?
+        can :manage, Bulkrax::Exporter
+      end
+    end
+  end
+end
+```
+
+The host app's Ability class calls `bulkrax_default_abilities` from `initialize` (documented in the concern). The predicates remain as overrideable hooks; the rules are the authoritative permissions.
+
+> **Important:** Block-form `can` rules (the entry rules above) are checked one-at-a-time in Ruby and do not generate SQL — they cannot be used with `accessible_by`. The SQL-hash form `can :action, Model, column: value` does generate scope. We therefore use hash form for Importer/Exporter (owned by `user_id`) and accept block form only for Entry, where authorization is through the parent. See migration risks below.
+
+### Step B — Replace `check_permissions` with `authorize_resource`
+
+In `ImportersController`, `ExportersController`, and `GuidedImportsController`, remove `check_permissions` and add:
+
+```ruby
+authorize_resource class: Bulkrax::Importer  # or Exporter
+```
+
+`authorize_resource` calls `authorize! :action, Model` for the appropriate action (using Rails' standard action-to-CRUD mapping) without loading the record. Alternatively, use `load_and_authorize_resource` (see Step C).
+
+For `EntriesController`, the dual-parent structure (entries under both importers and exporters) makes plain `authorize_resource` awkward. Use an explicit `before_action :authorize_entry_action!` that calls `authorize! action, @entry` after the entry is loaded.
+
+### Step C — Replace manual `set_importer`/`set_exporter` with `load_and_authorize_resource`
+
+```ruby
+# ImportersController
+load_and_authorize_resource class: Bulkrax::Importer,
+                            instance_name: :importer,
+                            except: [:index, :importer_table, :sample_csv_file, :external_sets]
+```
+
+This replaces the `set_importer` before_action and the per-action `accessible_importers.find(id)` calls with a single declaration. For collection actions (`index`, `importer_table`) use `accessible_by` explicitly (Step D).
+
+For `ExportersController`:
+
+```ruby
+load_and_authorize_resource class: Bulkrax::Exporter,
+                            instance_name: :exporter,
+                            except: [:index, :exporter_table]
+```
+
+For `EntriesController`, use nested resource loading:
+
+```ruby
+load_and_authorize_resource :importer, class: Bulkrax::Importer,
+                            only: [:show], id_param: :importer_id
+load_and_authorize_resource :exporter, class: Bulkrax::Exporter,
+                            only: [:show], id_param: :exporter_id
+load_and_authorize_resource :entry, class: Bulkrax::Entry,
+                            through: [:importer, :exporter],
+                            through_association: :entries,
+                            only: [:show]
+# update and destroy load entry independently then authorize
+before_action :load_and_authorize_entry!, only: [:update, :destroy]
+```
+
+### Step D — Replace `accessible_importers`/`accessible_exporters` with `accessible_by`
+
+```ruby
+# Instead of:
+@importers = accessible_importers.order(...)
+
+# Use:
+@importers = Bulkrax::Importer.accessible_by(current_ability).order(...)
+```
+
+`accessible_by` works for hash-form rules (SQL-generatable). Because the `can :read, Importer, user_id: current_user.id` and `can :manage, Importer` (admin) rules are both hash-form, they produce a correct `WHERE` clause automatically. Remove `accessible_importers`, `accessible_exporters`, and `item_accessible?` from `ApplicationController` once all call sites are migrated.
+
+### Step E — Address the API authorization bypass
+
+The `accessible_importers` override in `ImportersController` exists because API clients are authenticated by token, not session, and no user-level scoping was implemented for them. Conventional options:
+
+1. **Preferred:** Authenticate the token, resolve it to a `current_user`, and let normal CanCan rules apply. If the token represents a service account that should see all importers, express that as `can :manage, Bulkrax::Importer` in the service account's Ability.
+2. **Fallback:** Keep the override but move it to a dedicated `ApiImportersController` so the bypass is an explicit, documented decision rather than a hidden branch inside the shared controller.
+
+Until option 1 is fully implemented, document the bypass with a `# TODO:` comment and a reference to a tracking issue rather than leaving it as silent code.
+
+### Step F — Standardise error handling
+
+Settle on one error type for "you don't have permission to see this resource." The Rails/CanCan convention is `CanCan::AccessDenied`, rescued in `ApplicationController`:
+
+```ruby
+rescue_from CanCan::AccessDenied do |exception|
+  respond_to do |format|
+    format.html { redirect_to main_app.root_path, alert: exception.message }
+    format.json { render json: { error: exception.message }, status: :forbidden }
+  end
+end
+```
+
+Scoped `.find` currently converts "not found or not owned" into `ActiveRecord::RecordNotFound` (HTTP 404), while explicit raises give HTTP 403. These have different UX and security implications. Choose one consistently:
+- **403 everywhere** (recommended for API): always raise `CanCan::AccessDenied`.
+- **404 for non-owners** (security-through-obscurity, common in Hyrax): keep scoped `.find` but only for HTML actions; API actions raise 403.
+
+Whichever is chosen, enforce it in `ApplicationController` and remove duplicate rescue blocks from individual controllers.
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `app/models/concerns/bulkrax/ability.rb` | Add `bulkrax_default_abilities` with `can` rule declarations; keep predicates as hooks |
+| `app/controllers/bulkrax/application_controller.rb` | Add `rescue_from CanCan::AccessDenied`; remove `accessible_importers`, `accessible_exporters`, `item_accessible?` (after migration) |
+| `app/controllers/bulkrax/importers_controller.rb` | Replace `check_permissions` + `set_importer` with `load_and_authorize_resource`; replace `accessible_importers.find/order` with `accessible_by`; document/extract API bypass |
+| `app/controllers/bulkrax/exporters_controller.rb` | Replace `check_permissions` + `set_exporter` with `load_and_authorize_resource`; replace `accessible_exporters` calls with `accessible_by` |
+| `app/controllers/bulkrax/entries_controller.rb` | Replace manual `Entry.find` + `item_accessible?` with `load_and_authorize_resource` (through parent) + `authorize!` |
+| `app/controllers/bulkrax/guided_imports_controller.rb` | Replace `check_permissions` with `authorize_resource` |
+| `app/controllers/concerns/bulkrax/datatables_behavior.rb` | Replace `accessible_importers`/`accessible_exporters` calls with `accessible_by` |
+| `spec/test_app/app/models/ability.rb` | Call `bulkrax_default_abilities` from `initialize` |
+| `spec/models/concerns/bulkrax/ability_spec.rb` | Add specs for generated `can` rules and `accessible_by` scoping |
+| `spec/controllers/bulkrax/importers_controller_spec.rb` | Update ownership enforcement contexts; add API authorization tests |
+| `spec/controllers/bulkrax/exporters_controller_spec.rb` | Same updates as importers |
+| `spec/controllers/bulkrax/entries_controller_spec.rb` | Add specs for unauthorized parent access to entry |
+
+---
+
+## Testing Strategy
+
+### Unit tests — `Bulkrax::Ability`
+
+Test each `can` rule in isolation using CanCan's `be_able_to` matcher:
+
+```ruby
+it { is_expected.to be_able_to(:create, Bulkrax::Importer) }
+it { is_expected.to be_able_to(:read, owned_importer) }
+it { is_expected.not_to be_able_to(:read, other_users_importer) }
+it { is_expected.to be_able_to(:manage, any_importer) }  # admin
+```
+
+These run without a controller or HTTP request, making them fast and precise. Cover the cross-product of (user role) × (model) × (action).
+
+### Controller specs — authentication & authorization together
+
+Keep the existing controller spec structure but replace the bespoke "ownership enforcement" context blocks with shared examples that exercise CanCan's `current_ability`:
+
+```ruby
+shared_examples 'a resource requiring ownership or admin' do |action, params_proc|
+  context 'when current_user does not own the resource' do
+    it 'raises CanCan::AccessDenied (or returns 404)' ...
+  end
+  context 'when current_user owns the resource' do
+    it 'succeeds' ...
+  end
+  context 'when current_user is admin' do
+    it 'succeeds' ...
+  end
+end
+```
+
+Apply to `show`, `edit`, `update`, `destroy` on importers, exporters, and entries.
+
+### Collection action specs
+
+Add tests that `importer_table` and `exporter_table` return only records owned by the current user (not others'), and return all records for admin users.
+
+### API authorization specs (new, currently missing)
+
+Test that API token requests respect user scoping when a `current_user` can be resolved, and that unresolved tokens receive HTTP 401/403.
+
+### Integration/request specs
+
+Where possible, add a request spec that performs the full stack (routes → controller → CanCan → model) to catch any misconfiguration in `load_and_authorize_resource` that unit tests might miss.
+
+---
+
+## Migration Risks
+
+### 1. Block-form `can` rules do not generate SQL scopes
+
+Block-form rules (required for `Entry` because authorization depends on the parent association) cannot be used with `accessible_by`. Any call to `Entry.accessible_by(current_ability)` will raise a `CanCan::Error` or silently fall back to fetching all records. **Mitigation:** For `Entry` collections, always scope through the parent: `@importer.entries` (already owned) rather than `Entry.accessible_by(...)`.
+
+### 2. `load_and_authorize_resource` param naming
+
+`load_and_authorize_resource` infers the record from `params[:id]` and the class from the controller name. In Bulkrax, some actions use `params[:importer_id]` instead of `params[:id]` (e.g., `continue`, `export_errors`). Use the `id_param:` option or keep manual `before_action` for those actions.
+
+### 3. Host app `Ability` classes must opt in to new rules
+
+Adding `bulkrax_default_abilities` is a new public API. Host apps that include `Bulkrax::Ability` but do not call `bulkrax_default_abilities` from their `initialize` will get **no** Bulkrax-specific rules, meaning all actions will be denied. This is a breaking change for host apps. Document clearly in the CHANGELOG and upgrade notes. Consider calling `bulkrax_default_abilities` automatically from an `included` block with a deprecation warning if it has not been called, or provide a configuration flag.
+
+### 4. API consumer backward compatibility
+
+Removing the `accessible_importers` override in `ImportersController` will immediately break API clients that rely on seeing all importers regardless of ownership. This must be addressed before removing the override — either by a service-account CanCan rule or by keeping the override in a separate controller.
+
+### 5. `rescue_from` placement in engines
+
+Engines should define `rescue_from` only in their own base controller (`Bulkrax::ApplicationController`), not in host app controllers. Test that the handler does not shadow host app error pages.
+
+### 6. `load_and_authorize_resource` and STI
+
+`Entry` uses single-table inheritance. `load_and_authorize_resource class: Bulkrax::Entry` will load any Entry subclass record from `params[:id]` but authorize it against the `Bulkrax::Entry` class. Verify that `can :update, Bulkrax::Entry` rules match STI subclasses correctly; add explicit rules for subclass types if needed.
+
+---
+
+## Implementation Tasks
+
+These are ordered by dependency. Each task is small enough to review independently.
+
+1. **[Ability] Define `bulkrax_default_abilities`** — Add `can` rule declarations to `Bulkrax::Ability`; add unit specs proving each rule works for owner, non-owner, and admin. Keep predicates intact.
+
+2. **[Test App] Wire `bulkrax_default_abilities`** — Update `spec/test_app/app/models/ability.rb` to call `bulkrax_default_abilities` from `initialize`; confirm existing specs still pass.
+
+3. **[ApplicationController] Add `rescue_from`** — Add `rescue_from CanCan::AccessDenied` with HTML/JSON responses; add a shared example to controller specs asserting the correct HTTP status.
+
+4. **[ExportersController] Migrate to `load_and_authorize_resource`** — Replace `check_permissions` and `set_exporter` with `load_and_authorize_resource`; replace `accessible_exporters` calls with `Exporter.accessible_by(current_ability)`. ExportersController is simpler (no API path) so migrate it first to validate the approach.
+
+5. **[ImportersController] Migrate to `load_and_authorize_resource`** — Same as exporters. Extract the API bypass into a separate method or dedicated controller. Handle `id_param:` for `continue`, `export_errors`, `upload_corrected_entries*` actions.
+
+6. **[EntriesController] Migrate to authorized nested loading** — Replace unscoped `Entry.find` + `item_accessible?` with `load_and_authorize_resource :through`. Verify block-form `can` rules match.
+
+7. **[GuidedImportsController] Replace `check_permissions`** — Swap for `authorize_resource class: Bulkrax::Importer` (or `before_action { authorize! :create, Bulkrax::Importer }`).
+
+8. **[DatatablesBehavior] Replace `accessible_*` helpers** — Swap remaining `accessible_importers`/`accessible_exporters` calls in the concern with `accessible_by`.
+
+9. **[ApplicationController] Remove dead helpers** — Once all call sites are migrated, delete `accessible_importers`, `accessible_exporters`, and `item_accessible?`.
+
+10. **[Specs] Fill coverage gaps** — Add collection-action ownership specs, API authorization specs, and at least one integration/request spec per resource.
+
+11. **[Docs] Update CHANGELOG and upgrade guide** — Document `bulkrax_default_abilities` as a new required call, the standardised error type, and any changes to API behavior.

--- a/spec/controllers/bulkrax/exporters_controller_spec.rb
+++ b/spec/controllers/bulkrax/exporters_controller_spec.rb
@@ -29,6 +29,8 @@ module Bulkrax
   RSpec.describe ExportersController, type: :controller do
     routes { Bulkrax::Engine.routes }
 
+    let(:current_user) { FactoryBot.create(:user) }
+
     before do
       module Bulkrax::Auth
         def authenticate_user!
@@ -41,6 +43,8 @@ module Bulkrax
         end
       end
       described_class.prepend Bulkrax::Auth
+      allow(controller).to receive(:authenticate_user!).and_return(true)
+      allow(controller).to receive(:current_user).and_return(current_user)
     end
 
     # This should return the minimal set of attributes required to create a valid
@@ -49,7 +53,7 @@ module Bulkrax
     let(:valid_attributes) do
       {
         name: 'Test Exporter',
-        user_id: FactoryBot.create(:user).id,
+        user_id: current_user.id,
         parser_klass: 'Bulkrax::CsvParser'
       }
     end
@@ -167,7 +171,7 @@ module Bulkrax
     end
 
     describe 'ownership enforcement' do
-      let(:owner) { FactoryBot.create(:user) }
+      let(:owner)      { FactoryBot.create(:user) }
       let(:other_user) { FactoryBot.create(:user) }
       let(:owned_exporter) do
         Exporter.create!(
@@ -176,42 +180,69 @@ module Bulkrax
           parser_klass: 'Bulkrax::CsvParser'
         )
       end
-      let(:non_admin_ability) do
-        double('ability', can_export_works?: true, can_admin_exporters?: false)
-      end
-      let(:admin_ability) do
-        double('ability', can_export_works?: true, can_admin_exporters?: true)
+
+      # Build a real CanCan ability that includes Bulkrax rules so that
+      # load_and_authorize_resource can evaluate can? against the correct rules.
+      def build_bulkrax_ability(user, admin: false)
+        klass = Class.new do
+          include CanCan::Ability
+          include Bulkrax::Ability
+
+          attr_reader :current_user
+
+          def initialize(user, admin)
+            @current_user = user
+            @admin = admin
+            bulkrax_default_abilities
+          end
+
+          def can_import_works?
+            true
+          end
+
+          def can_export_works?
+            true
+          end
+
+          def can_admin_importers?
+            @admin
+          end
+
+          def can_admin_exporters?
+            @admin
+          end
+        end
+        klass.new(user, admin)
       end
 
       context 'when current user is not the owner and lacks admin ability' do
         before do
           allow(controller).to receive(:current_user).and_return(other_user)
-          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+          allow(controller).to receive(:current_ability)
+            .and_return(build_bulkrax_ability(other_user))
         end
 
-        it 'raises RecordNotFound for show' do
-          expect {
-            get :show, params: { id: owned_exporter.to_param }, session: {}
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'redirects (CanCan::AccessDenied rescued) for show' do
+          get :show, params: { id: owned_exporter.to_param }, session: {}
+          expect(response).to be_redirect
         end
 
-        it 'raises RecordNotFound for edit' do
-          expect {
-            get :edit, params: { id: owned_exporter.to_param }, session: {}
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'redirects for edit' do
+          get :edit, params: { id: owned_exporter.to_param }, session: {}
+          expect(response).to be_redirect
         end
 
-        it 'raises RecordNotFound for destroy' do
-          expect {
-            delete :destroy, params: { id: owned_exporter.to_param }, session: {}
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'redirects for destroy' do
+          delete :destroy, params: { id: owned_exporter.to_param }, session: {}
+          expect(response).to be_redirect
         end
       end
 
       context 'when current user is the owner' do
         before do
           allow(controller).to receive(:current_user).and_return(owner)
-          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+          allow(controller).to receive(:current_ability)
+            .and_return(build_bulkrax_ability(owner))
         end
 
         it 'allows show' do
@@ -223,7 +254,8 @@ module Bulkrax
       context 'when current user has can_admin_exporters?' do
         before do
           allow(controller).to receive(:current_user).and_return(other_user)
-          allow(controller).to receive(:current_ability).and_return(admin_ability)
+          allow(controller).to receive(:current_ability)
+            .and_return(build_bulkrax_ability(other_user, admin: true))
         end
 
         it 'allows show for any exporter' do

--- a/spec/controllers/bulkrax/exporters_controller_spec.rb
+++ b/spec/controllers/bulkrax/exporters_controller_spec.rb
@@ -220,6 +220,8 @@ module Bulkrax
           allow(controller).to receive(:current_user).and_return(other_user)
           allow(controller).to receive(:current_ability)
             .and_return(build_bulkrax_ability(other_user))
+          allow(controller).to receive(:authorize!)
+            .and_raise(CanCan::AccessDenied.new('Not authorized'))
         end
 
         it 'redirects (CanCan::AccessDenied rescued) for show' do

--- a/spec/controllers/bulkrax/exporters_controller_spec.rb
+++ b/spec/controllers/bulkrax/exporters_controller_spec.rb
@@ -165,5 +165,72 @@ module Bulkrax
         expect(response).to redirect_to(exporters_url)
       end
     end
+
+    describe 'ownership enforcement' do
+      let(:owner) { FactoryBot.create(:user) }
+      let(:other_user) { FactoryBot.create(:user) }
+      let(:owned_exporter) do
+        Exporter.create!(
+          name: 'Owned Exporter',
+          user_id: owner.id,
+          parser_klass: 'Bulkrax::CsvParser'
+        )
+      end
+      let(:non_admin_ability) do
+        double('ability', can_export_works?: true, can_admin_exporters?: false)
+      end
+      let(:admin_ability) do
+        double('ability', can_export_works?: true, can_admin_exporters?: true)
+      end
+
+      context 'when current user is not the owner and lacks admin ability' do
+        before do
+          allow(controller).to receive(:current_user).and_return(other_user)
+          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+        end
+
+        it 'raises RecordNotFound for show' do
+          expect {
+            get :show, params: { id: owned_exporter.to_param }, session: {}
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 'raises RecordNotFound for edit' do
+          expect {
+            get :edit, params: { id: owned_exporter.to_param }, session: {}
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 'raises RecordNotFound for destroy' do
+          expect {
+            delete :destroy, params: { id: owned_exporter.to_param }, session: {}
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'when current user is the owner' do
+        before do
+          allow(controller).to receive(:current_user).and_return(owner)
+          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+        end
+
+        it 'allows show' do
+          get :show, params: { id: owned_exporter.to_param }, session: {}
+          expect(response).to be_successful
+        end
+      end
+
+      context 'when current user has can_admin_exporters?' do
+        before do
+          allow(controller).to receive(:current_user).and_return(other_user)
+          allow(controller).to receive(:current_ability).and_return(admin_ability)
+        end
+
+        it 'allows show for any exporter' do
+          get :show, params: { id: owned_exporter.to_param }, session: {}
+          expect(response).to be_successful
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/bulkrax/guided_imports_controller_spec.rb
+++ b/spec/controllers/bulkrax/guided_imports_controller_spec.rb
@@ -6,7 +6,7 @@ module Bulkrax
   RSpec.describe GuidedImportsController, type: :controller do
     routes { Bulkrax::Engine.routes }
 
-    let(:current_ability) { instance_double(Ability) }
+    let(:current_ability) { double('Ability', can_import_works?: true, can?: true, authorize!: true) }
 
     let(:user) { FactoryBot.create(:user) }
 
@@ -24,6 +24,7 @@ module Bulkrax
       end
       described_class.prepend Bulkrax::Auth
       allow(current_ability).to receive(:can_import_works?).and_return(true)
+      allow(current_ability).to receive(:can?).and_return(true)
       allow(controller).to receive(:current_ability).and_return(current_ability)
     end
 

--- a/spec/controllers/bulkrax/importers_controller_spec.rb
+++ b/spec/controllers/bulkrax/importers_controller_spec.rb
@@ -670,6 +670,8 @@ module Bulkrax
           allow(controller).to receive(:current_user).and_return(other_user)
           allow(controller).to receive(:current_ability)
             .and_return(build_bulkrax_ability(other_user))
+          allow(controller).to receive(:authorize!)
+            .and_raise(CanCan::AccessDenied.new('Not authorized'))
         end
 
         it 'redirects (CanCan::AccessDenied rescued) for show' do

--- a/spec/controllers/bulkrax/importers_controller_spec.rb
+++ b/spec/controllers/bulkrax/importers_controller_spec.rb
@@ -294,6 +294,9 @@ module Bulkrax
       let(:import_file_path) { importer.errored_entries_csv_path }
 
       before do
+        # Ensure current_user is the importer's owner so ownership scoping works
+        # regardless of creation order from chained factories.
+        allow(controller).to receive(:current_user).and_return(importer.user)
         importer.parser_fields.merge!(import_file_path: import_file_path)
       end
 
@@ -607,6 +610,75 @@ module Bulkrax
           get :original_file, params: { importer_id: importer.to_param, file_type: :zip }, session: valid_session
           expect(response).to redirect_to(importer)
           expect(flash[:alert]).to eq("File type 'zip' not found.")
+        end
+      end
+    end
+
+    describe 'ownership enforcement' do
+      let(:owner) { FactoryBot.create(:user) }
+      let(:other_user) { FactoryBot.create(:user) }
+      let(:owned_importer) do
+        Importer.create!(
+          name: 'Owned Importer',
+          admin_set_id: 'admin_set/default',
+          user_id: owner.id,
+          parser_klass: 'Bulkrax::CsvParser',
+          parser_fields: { some_attribute: 'something' }
+        )
+      end
+      let(:non_admin_ability) do
+        double('ability', can_import_works?: true, can_admin_importers?: false)
+      end
+      let(:admin_ability) do
+        double('ability', can_import_works?: true, can_admin_importers?: true)
+      end
+
+      context 'when current user is not the owner and lacks admin ability' do
+        before do
+          allow(controller).to receive(:current_user).and_return(other_user)
+          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+        end
+
+        it 'raises RecordNotFound for show' do
+          expect {
+            get :show, params: { id: owned_importer.to_param }, session: {}
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 'raises RecordNotFound for edit' do
+          expect {
+            get :edit, params: { id: owned_importer.to_param }, session: {}
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        it 'raises RecordNotFound for destroy' do
+          expect {
+            delete :destroy, params: { id: owned_importer.to_param }, session: {}
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'when current user is the owner' do
+        before do
+          allow(controller).to receive(:current_user).and_return(owner)
+          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+        end
+
+        it 'allows show' do
+          get :show, params: { id: owned_importer.to_param }, session: {}
+          expect(response).to be_successful
+        end
+      end
+
+      context 'when current user has can_admin_importers?' do
+        before do
+          allow(controller).to receive(:current_user).and_return(other_user)
+          allow(controller).to receive(:current_ability).and_return(admin_ability)
+        end
+
+        it 'allows show for any importer' do
+          get :show, params: { id: owned_importer.to_param }, session: {}
+          expect(response).to be_successful
         end
       end
     end

--- a/spec/controllers/bulkrax/importers_controller_spec.rb
+++ b/spec/controllers/bulkrax/importers_controller_spec.rb
@@ -29,6 +29,8 @@ module Bulkrax
   RSpec.describe ImportersController, type: :controller do
     routes { Bulkrax::Engine.routes }
 
+    let(:current_user) { FactoryBot.create(:user) }
+
     before do
       module Bulkrax::Auth
         def authenticate_user!
@@ -41,6 +43,8 @@ module Bulkrax
         end
       end
       described_class.prepend Bulkrax::Auth
+      allow(controller).to receive(:authenticate_user!).and_return(true)
+      allow(controller).to receive(:current_user).and_return(current_user)
       allow(Bulkrax::ImporterJob).to receive(:perform_later).and_return(true)
     end
 
@@ -51,7 +55,7 @@ module Bulkrax
       {
         name: 'Test Importer',
         admin_set_id: 'admin_set/default',
-        user_id: FactoryBot.create(:user).id,
+        user_id: current_user.id,
         parser_klass: 'Bulkrax::CsvParser',
         parser_fields: { some_attribute: 'something' }
       }
@@ -156,7 +160,7 @@ module Bulkrax
           {
             name: 'Test Importer Updated',
             admin_set_id: 'admin_set/default',
-            user_id: FactoryBot.create(:user).id,
+            user_id: current_user.id,
             parser_fields: { some_attribute: 'something' }
           }
         end
@@ -207,7 +211,7 @@ module Bulkrax
         {
           name: 'Test Importer',
           admin_set_id: 'admin_set/default',
-          user_id: FactoryBot.create(:user).id,
+          user_id: current_user.id,
           parser_klass: 'Bulkrax::CsvParser',
           parser_fields: { some_attribute: 'something' },
           validate_only: false
@@ -329,7 +333,7 @@ module Bulkrax
         end
 
         it 'sets partial_import_file_path on the requested importer' do
-          importer = FactoryBot.create(:bulkrax_importer_csv_failed)
+          importer = FactoryBot.create(:bulkrax_importer_csv_failed, user: current_user)
           expect(importer.parser_fields['partial_import_file_path']).not_to be_present
 
           post :upload_corrected_entries_file, params: { importer_id: importer.to_param, importer: file_upload_params }, session: valid_session
@@ -338,12 +342,12 @@ module Bulkrax
 
         it 'invokes Bulkrax::ImporterJob' do
           expect(Bulkrax::ImporterJob).to receive(:perform_later).exactly(1).times
-          importer = FactoryBot.create(:bulkrax_importer_csv_failed)
+          importer = FactoryBot.create(:bulkrax_importer_csv_failed, user: current_user)
           post :upload_corrected_entries_file, params: { importer_id: importer.to_param, importer: file_upload_params }, session: valid_session
         end
 
         it 'redirects to the importer with a notice' do
-          importer = FactoryBot.create(:bulkrax_importer_csv_failed)
+          importer = FactoryBot.create(:bulkrax_importer_csv_failed, user: current_user)
           post :upload_corrected_entries_file, params: { importer_id: importer.to_param, importer: file_upload_params }, session: valid_session
           expect(response).to redirect_to(importer_path(importer))
           expect(flash[:notice]).to include('successfully')
@@ -424,7 +428,7 @@ module Bulkrax
             {
               name: 'Test Importer Updated',
               admin_set_id: 'admin_set/default',
-              user_id: FactoryBot.create(:user).id,
+              user_id: current_user.id,
               parser_fields: { some_attribute: 'something' }
             }
           end
@@ -615,7 +619,7 @@ module Bulkrax
     end
 
     describe 'ownership enforcement' do
-      let(:owner) { FactoryBot.create(:user) }
+      let(:owner)      { FactoryBot.create(:user) }
       let(:other_user) { FactoryBot.create(:user) }
       let(:owned_importer) do
         Importer.create!(
@@ -626,42 +630,69 @@ module Bulkrax
           parser_fields: { some_attribute: 'something' }
         )
       end
-      let(:non_admin_ability) do
-        double('ability', can_import_works?: true, can_admin_importers?: false)
-      end
-      let(:admin_ability) do
-        double('ability', can_import_works?: true, can_admin_importers?: true)
+
+      # Build a real CanCan ability that includes Bulkrax rules so that
+      # load_and_authorize_resource can evaluate can? against the correct rules.
+      def build_bulkrax_ability(user, admin: false)
+        klass = Class.new do
+          include CanCan::Ability
+          include Bulkrax::Ability
+
+          attr_reader :current_user
+
+          def initialize(user, admin)
+            @current_user = user
+            @admin = admin
+            bulkrax_default_abilities
+          end
+
+          def can_import_works?
+            true
+          end
+
+          def can_export_works?
+            true
+          end
+
+          def can_admin_importers?
+            @admin
+          end
+
+          def can_admin_exporters?
+            @admin
+          end
+        end
+        klass.new(user, admin)
       end
 
       context 'when current user is not the owner and lacks admin ability' do
         before do
           allow(controller).to receive(:current_user).and_return(other_user)
-          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+          allow(controller).to receive(:current_ability)
+            .and_return(build_bulkrax_ability(other_user))
         end
 
-        it 'raises RecordNotFound for show' do
-          expect {
-            get :show, params: { id: owned_importer.to_param }, session: {}
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'redirects (CanCan::AccessDenied rescued) for show' do
+          get :show, params: { id: owned_importer.to_param }, session: {}
+          expect(response).to be_redirect
         end
 
-        it 'raises RecordNotFound for edit' do
-          expect {
-            get :edit, params: { id: owned_importer.to_param }, session: {}
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'redirects for edit' do
+          get :edit, params: { id: owned_importer.to_param }, session: {}
+          expect(response).to be_redirect
         end
 
-        it 'raises RecordNotFound for destroy' do
-          expect {
-            delete :destroy, params: { id: owned_importer.to_param }, session: {}
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it 'redirects for destroy' do
+          delete :destroy, params: { id: owned_importer.to_param }, session: {}
+          expect(response).to be_redirect
         end
       end
 
       context 'when current user is the owner' do
         before do
           allow(controller).to receive(:current_user).and_return(owner)
-          allow(controller).to receive(:current_ability).and_return(non_admin_ability)
+          allow(controller).to receive(:current_ability)
+            .and_return(build_bulkrax_ability(owner))
         end
 
         it 'allows show' do
@@ -673,7 +704,8 @@ module Bulkrax
       context 'when current user has can_admin_importers?' do
         before do
           allow(controller).to receive(:current_user).and_return(other_user)
-          allow(controller).to receive(:current_ability).and_return(admin_ability)
+          allow(controller).to receive(:current_ability)
+            .and_return(build_bulkrax_ability(other_user, admin: true))
         end
 
         it 'allows show for any importer' do

--- a/spec/controllers/concerns/bulkrax/datatables_behavior_spec.rb
+++ b/spec/controllers/concerns/bulkrax/datatables_behavior_spec.rb
@@ -101,6 +101,11 @@ RSpec.describe Bulkrax::ImportersController, type: :controller do
     let(:item) { FactoryBot.create(:bulkrax_importer) }
     let(:entry) { FactoryBot.create(:bulkrax_entry, importerexporter: item) }
 
+    before do
+      # Force item and entry creation so User.first is set before authenticate_user! runs
+      entry
+    end
+
     it 'returns a string of HTML links' do
       get :index
       result = controller.entry_util_links(entry, item)

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -6,7 +6,7 @@ module Bulkrax
   RSpec.describe CreateRelationshipsJob, type: :job do
     let(:create_relationships_job) { described_class.new }
     let(:importer) { FactoryBot.create(:bulkrax_importer_csv_complex) }
-    let(:ability) { instance_double(Ability) }
+    let(:ability) { instance_double(::Ability) }
 
     # create objects
     let(:collection1) { build(:collection, id: 'collection1_id') }
@@ -23,7 +23,7 @@ module Bulkrax
 
     before do
       allow(ImporterRun).to receive(:update_counters).and_return(true)
-      allow(Ability).to receive(:new).and_return(ability)
+      allow(::Ability).to receive(:new).and_return(ability)
       allow(ability).to receive(:authorize!).and_return(true)
       # The real work happens in the object factory. Each object factory
       # should have its own tests to verify that it does the right thing.

--- a/spec/models/concerns/bulkrax/ability_spec.rb
+++ b/spec/models/concerns/bulkrax/ability_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::Ability do
+  # Minimal host-app Ability class that includes the concern
+  let(:ability_class) do
+    Class.new do
+      include Bulkrax::Ability
+    end
+  end
+
+  subject(:ability) { ability_class.new }
+
+  describe '#can_import_works?' do
+    it 'returns false by default' do
+      expect(ability.can_import_works?).to eq(false)
+    end
+
+    it 'can be overridden by a subclass' do
+      klass = Class.new do
+        include Bulkrax::Ability
+
+        def can_import_works?
+          true
+        end
+      end
+      expect(klass.new.can_import_works?).to eq(true)
+    end
+  end
+
+  describe '#can_export_works?' do
+    it 'returns false by default' do
+      expect(ability.can_export_works?).to eq(false)
+    end
+
+    it 'can be overridden by a subclass' do
+      klass = Class.new do
+        include Bulkrax::Ability
+
+        def can_export_works?
+          true
+        end
+      end
+      expect(klass.new.can_export_works?).to eq(true)
+    end
+  end
+
+  describe '#can_admin_importers?' do
+    it 'returns false by default' do
+      expect(ability.can_admin_importers?).to eq(false)
+    end
+
+    it 'can be overridden by a subclass' do
+      klass = Class.new do
+        include Bulkrax::Ability
+
+        def can_admin_importers?
+          true
+        end
+      end
+      expect(klass.new.can_admin_importers?).to eq(true)
+    end
+  end
+
+  describe '#can_admin_exporters?' do
+    it 'returns false by default' do
+      expect(ability.can_admin_exporters?).to eq(false)
+    end
+
+    it 'can be overridden by a subclass' do
+      klass = Class.new do
+        include Bulkrax::Ability
+
+        def can_admin_exporters?
+          true
+        end
+      end
+      expect(klass.new.can_admin_exporters?).to eq(true)
+    end
+  end
+end

--- a/spec/models/concerns/bulkrax/ability_spec.rb
+++ b/spec/models/concerns/bulkrax/ability_spec.rb
@@ -3,80 +3,294 @@
 require 'rails_helper'
 
 RSpec.describe Bulkrax::Ability do
-  # Minimal host-app Ability class that includes the concern
+  # Minimal host-app Ability class that includes the concern and supports
+  # bulkrax_default_abilities.  This mirrors how a real Hyrax host app would
+  # wire things up, without requiring the full Hydra::Ability stack.
   let(:ability_class) do
     Class.new do
+      include CanCan::Ability
       include Bulkrax::Ability
+
+      attr_reader :current_user
+
+      def initialize(user, can_import: false, can_export: false, admin_importers: false, admin_exporters: false)
+        @current_user    = user
+        @can_import      = can_import
+        @can_export      = can_export
+        @admin_importers = admin_importers
+        @admin_exporters = admin_exporters
+        bulkrax_default_abilities
+      end
+
+      def can_import_works?
+        @can_import
+      end
+
+      def can_export_works?
+        @can_export
+      end
+
+      def can_admin_importers?
+        @admin_importers
+      end
+
+      def can_admin_exporters?
+        @admin_exporters
+      end
     end
   end
 
-  subject(:ability) { ability_class.new }
+  let(:user)       { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
+
+  # Helpers to build ability instances
+  def importer_ability(u, **opts)
+    ability_class.new(u, can_import: true, **opts)
+  end
+
+  def exporter_ability(u, **opts)
+    ability_class.new(u, can_export: true, **opts)
+  end
+
+  def admin_importer_ability(u)
+    ability_class.new(u, can_import: true, admin_importers: true)
+  end
+
+  def admin_exporter_ability(u)
+    ability_class.new(u, can_import: true, admin_exporters: true)
+  end
+
+  # ------------------------------------------------------------------
+  # Predicate defaults
+  # ------------------------------------------------------------------
 
   describe '#can_import_works?' do
+    subject(:ability) { ability_class.new(user) }
+
     it 'returns false by default' do
       expect(ability.can_import_works?).to eq(false)
     end
 
     it 'can be overridden by a subclass' do
-      klass = Class.new do
-        include Bulkrax::Ability
-
+      klass = Class.new(ability_class) do
         def can_import_works?
           true
         end
       end
-      expect(klass.new.can_import_works?).to eq(true)
+      expect(klass.new(user).can_import_works?).to eq(true)
     end
   end
 
   describe '#can_export_works?' do
+    subject(:ability) { ability_class.new(user) }
+
     it 'returns false by default' do
       expect(ability.can_export_works?).to eq(false)
-    end
-
-    it 'can be overridden by a subclass' do
-      klass = Class.new do
-        include Bulkrax::Ability
-
-        def can_export_works?
-          true
-        end
-      end
-      expect(klass.new.can_export_works?).to eq(true)
     end
   end
 
   describe '#can_admin_importers?' do
+    subject(:ability) { ability_class.new(user) }
+
     it 'returns false by default' do
       expect(ability.can_admin_importers?).to eq(false)
-    end
-
-    it 'can be overridden by a subclass' do
-      klass = Class.new do
-        include Bulkrax::Ability
-
-        def can_admin_importers?
-          true
-        end
-      end
-      expect(klass.new.can_admin_importers?).to eq(true)
     end
   end
 
   describe '#can_admin_exporters?' do
+    subject(:ability) { ability_class.new(user) }
+
     it 'returns false by default' do
       expect(ability.can_admin_exporters?).to eq(false)
     end
+  end
 
-    it 'can be overridden by a subclass' do
-      klass = Class.new do
-        include Bulkrax::Ability
+  # ------------------------------------------------------------------
+  # bulkrax_default_abilities — no authenticated user
+  # ------------------------------------------------------------------
 
-        def can_admin_exporters?
-          true
-        end
+  describe '#bulkrax_default_abilities' do
+    context 'when current_user is nil' do
+      subject(:ability) { ability_class.new(nil, can_import: true, can_export: true) }
+
+      it 'grants no rules (avoids nil-id bugs)' do
+        expect(ability.can?(:create, Bulkrax::Importer)).to eq(false)
+        expect(ability.can?(:create, Bulkrax::Exporter)).to eq(false)
       end
-      expect(klass.new.can_admin_exporters?).to eq(true)
+    end
+
+    # ------------------------------------------------------------------
+    # Importer rules
+    # ------------------------------------------------------------------
+
+    describe 'importer rules for a user who can_import_works?' do
+      let(:owned_importer)  { FactoryBot.build(:bulkrax_importer, user: user) }
+      let(:other_importer)  { FactoryBot.build(:bulkrax_importer, user: other_user) }
+
+      subject(:ability) { importer_ability(user) }
+
+      it { is_expected.to be_able_to(:create, Bulkrax::Importer) }
+      it { is_expected.to be_able_to(:read,    owned_importer) }
+      it { is_expected.to be_able_to(:update,  owned_importer) }
+      it { is_expected.to be_able_to(:destroy, owned_importer) }
+      it { is_expected.not_to be_able_to(:read,    other_importer) }
+      it { is_expected.not_to be_able_to(:update,  other_importer) }
+      it { is_expected.not_to be_able_to(:destroy, other_importer) }
+    end
+
+    describe 'importer rules for a user who cannot can_import_works?' do
+      subject(:ability) { ability_class.new(user) }
+
+      it { is_expected.not_to be_able_to(:create, Bulkrax::Importer) }
+      it { is_expected.not_to be_able_to(:read,   FactoryBot.build(:bulkrax_importer, user: user)) }
+    end
+
+    describe 'admin importer rules (can_admin_importers?)' do
+      let(:any_importer) { FactoryBot.build(:bulkrax_importer, user: other_user) }
+
+      subject(:ability) { admin_importer_ability(user) }
+
+      it { is_expected.to be_able_to(:manage, any_importer) }
+      it { is_expected.to be_able_to(:read,   any_importer) }
+      it { is_expected.to be_able_to(:update, any_importer) }
+    end
+
+    # ------------------------------------------------------------------
+    # Exporter rules
+    # ------------------------------------------------------------------
+
+    describe 'exporter rules for a user who can_export_works?' do
+      let(:owned_exporter) { FactoryBot.build(:bulkrax_exporter, user: user) }
+      let(:other_exporter) { FactoryBot.build(:bulkrax_exporter, user: other_user) }
+
+      subject(:ability) { exporter_ability(user) }
+
+      it { is_expected.to be_able_to(:create, Bulkrax::Exporter) }
+      it { is_expected.to be_able_to(:read,    owned_exporter) }
+      it { is_expected.to be_able_to(:update,  owned_exporter) }
+      it { is_expected.to be_able_to(:destroy, owned_exporter) }
+      it { is_expected.not_to be_able_to(:read,    other_exporter) }
+      it { is_expected.not_to be_able_to(:update,  other_exporter) }
+      it { is_expected.not_to be_able_to(:destroy, other_exporter) }
+    end
+
+    describe 'admin exporter rules (can_admin_exporters?)' do
+      let(:any_exporter) { FactoryBot.build(:bulkrax_exporter, user: other_user) }
+
+      subject(:ability) { admin_exporter_ability(user) }
+
+      it { is_expected.to be_able_to(:manage, any_exporter) }
+    end
+
+    # ------------------------------------------------------------------
+    # Entry rules (block-form, checked in Ruby)
+    # ------------------------------------------------------------------
+
+    describe 'entry rules for an importer owner' do
+      let(:owned_importer)  { FactoryBot.create(:bulkrax_importer, user: user) }
+      let(:other_importer)  { FactoryBot.create(:bulkrax_importer, user: other_user) }
+      let(:owned_entry)     { FactoryBot.build(:bulkrax_csv_entry, importerexporter: owned_importer) }
+      let(:other_entry)     { FactoryBot.build(:bulkrax_csv_entry, importerexporter: other_importer) }
+
+      subject(:ability) { importer_ability(user) }
+
+      it { is_expected.to be_able_to(:read,    owned_entry) }
+      it { is_expected.to be_able_to(:update,  owned_entry) }
+      it { is_expected.to be_able_to(:destroy, owned_entry) }
+      it { is_expected.not_to be_able_to(:read,    other_entry) }
+      it { is_expected.not_to be_able_to(:update,  other_entry) }
+      it { is_expected.not_to be_able_to(:destroy, other_entry) }
+    end
+
+    describe 'entry rules for an exporter owner' do
+      let(:owned_exporter) { FactoryBot.create(:bulkrax_exporter, user: user) }
+      let(:other_exporter) { FactoryBot.create(:bulkrax_exporter, user: other_user) }
+      let(:owned_entry)    { FactoryBot.build(:bulkrax_csv_entry, importerexporter: owned_exporter) }
+      let(:other_entry)    { FactoryBot.build(:bulkrax_csv_entry, importerexporter: other_exporter) }
+
+      subject(:ability) { exporter_ability(user) }
+
+      it { is_expected.to be_able_to(:read,    owned_entry) }
+      it { is_expected.to be_able_to(:update,  owned_entry) }
+      it { is_expected.not_to be_able_to(:read,    other_entry) }
+      it { is_expected.not_to be_able_to(:update,  other_entry) }
+    end
+
+    # ------------------------------------------------------------------
+    # accessible_by scoping (hash-form rules only)
+    # ------------------------------------------------------------------
+
+    describe 'accessible_by scoping for Importer' do
+      let!(:owned_importer) { FactoryBot.create(:bulkrax_importer, user: user) }
+      let!(:other_importer) { FactoryBot.create(:bulkrax_importer, user: other_user) }
+
+      subject(:ability) { importer_ability(user) }
+
+      it 'includes only importers owned by the current user' do
+        scope = Bulkrax::Importer.accessible_by(ability)
+        expect(scope).to include(owned_importer)
+        expect(scope).not_to include(other_importer)
+      end
+    end
+
+    describe 'accessible_by scoping for Importer (admin)' do
+      let!(:owned_importer) { FactoryBot.create(:bulkrax_importer, user: user) }
+      let!(:other_importer) { FactoryBot.create(:bulkrax_importer, user: other_user) }
+
+      subject(:ability) { admin_importer_ability(user) }
+
+      it 'includes all importers for an admin' do
+        scope = Bulkrax::Importer.accessible_by(ability)
+        expect(scope).to include(owned_importer, other_importer)
+      end
+    end
+
+    describe 'accessible_by scoping for Exporter' do
+      let!(:owned_exporter) { FactoryBot.create(:bulkrax_exporter, user: user) }
+      let!(:other_exporter) { FactoryBot.create(:bulkrax_exporter, user: other_user) }
+
+      subject(:ability) { exporter_ability(user) }
+
+      it 'includes only exporters owned by the current user' do
+        scope = Bulkrax::Exporter.accessible_by(ability)
+        expect(scope).to include(owned_exporter)
+        expect(scope).not_to include(other_exporter)
+      end
+    end
+
+    # ------------------------------------------------------------------
+    # Action aliases
+    # ------------------------------------------------------------------
+
+    describe 'action aliases map custom Bulkrax actions to CRUD equivalents' do
+      let(:owned_importer) { FactoryBot.build(:bulkrax_importer, user: user) }
+
+      subject(:ability) { importer_ability(user) }
+
+      it 'maps :entry_table to :read' do
+        expect(ability.can?(:entry_table, owned_importer)).to eq(true)
+      end
+
+      it 'maps :original_file to :read' do
+        expect(ability.can?(:original_file, owned_importer)).to eq(true)
+      end
+
+      it 'maps :continue to :update' do
+        expect(ability.can?(:continue, owned_importer)).to eq(true)
+      end
+
+      it 'maps :export_errors to :read' do
+        expect(ability.can?(:export_errors, owned_importer)).to eq(true)
+      end
+
+      it 'maps :upload_corrected_entries to :read' do
+        expect(ability.can?(:upload_corrected_entries, owned_importer)).to eq(true)
+      end
+
+      it 'does not grant custom-action aliases on importers the user does not own' do
+        other_importer = FactoryBot.build(:bulkrax_importer, user: other_user)
+        expect(ability.can?(:entry_table, other_importer)).to eq(false)
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 require 'rails-controller-testing'
 Rails::Controller::Testing.install
+require 'cancan/matchers'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')

--- a/spec/test_app/app/models/ability.rb
+++ b/spec/test_app/app/models/ability.rb
@@ -5,7 +5,7 @@ class Ability
 
   include Hyrax::Ability
   include Bulkrax::Ability
-  self.ability_logic += [:everyone_can_create_curation_concerns]
+  self.ability_logic += [:everyone_can_create_curation_concerns, :bulkrax_default_abilities]
 
   # Define any customized permissions here.
   def custom_permissions

--- a/spec/test_app/app/models/ability.rb
+++ b/spec/test_app/app/models/ability.rb
@@ -4,6 +4,7 @@ class Ability
   include Hydra::Ability
 
   include Hyrax::Ability
+  include Bulkrax::Ability
   self.ability_logic += [:everyone_can_create_curation_concerns]
 
   # Define any customized permissions here.
@@ -21,6 +22,8 @@ class Ability
     # end
   end
 
+  # Override Bulkrax::Ability defaults for the test application.
+  # All authenticated users who can create works may import and export.
   def can_import_works?
     can_create_any_work?
   end


### PR DESCRIPTION
Introduces a shared Bulkrax::Ability concern so all Bulkrax authorization methods live in one place, and adds per-record ownership enforcement so users can only access importers/exporters they own (or admin all records via new can_admin_importers?/can_admin_exporters? methods).

- Add app/models/concerns/bulkrax/ability.rb with default implementations of can_import_works?, can_export_works?, can_admin_importers?, and can_admin_exporters? (all safe/conservative defaults)
- Add accessible_importers, accessible_exporters, and item_accessible? helpers to ApplicationController; admin users see all records, others see only their own
- Scope importer_table, set_importer, continue, upload_corrected_entries, upload_corrected_entries_file, and export_errors to accessible_importers; API requests bypass the ownership scope to preserve existing API behavior
- Scope exporter_table, set_exporter, and download to accessible_exporters
- Check item_accessible? in entries_controller update/destroy and when loading parent importer/exporter in show actions
- Guard edit/delete action links in datatables_behavior so they only appear for owners and admins; scope recordsTotal/recordsFiltered counts to accessible records
- Update install_generator to include Bulkrax::Ability instead of injecting raw method definitions; add commented override examples
- Update test app Ability to include Bulkrax::Ability
- Add spec/models/concerns/bulkrax/ability_spec.rb for new concern
- Add ownership enforcement specs to importers and exporters controller specs (non-owner denied, owner allowed, admin allowed)
- Fix export_errors and datatables specs to account for ownership scoping