### PR TITLE
feat(exporter): scope export Solr queries to user permission filters via ExportSearchBuilder

### DIFF
--- a/app/models/bulkrax/export_scope.rb
+++ b/app/models/bulkrax/export_scope.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  # A minimal scope adapter that satisfies the Blacklight::SearchBuilder and
+  # Hydra::AccessControlsEnforcement interface for export permission filtering.
+  #
+  # Blacklight::SearchBuilder expects the scope to respond to +blacklight_config+
+  # and +current_ability+. In the Hyrax catalog this is the controller; for
+  # Bulkrax exports a lightweight PORO is sufficient.
+  class ExportScope
+    attr_reader :current_ability
+
+    def initialize(ability)
+      @current_ability = ability
+    end
+
+    def blacklight_config
+      @blacklight_config ||= Blacklight::Configuration.new
+    end
+  end
+end

--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -120,7 +120,10 @@ module Bulkrax
       #
       # No sense attempting to query for more than the limit.
       def query_kwargs
-        { fl: "id,#{Bulkrax.solr_key_for_member_file_ids}", method: :post, rows: row_limit }
+        base = { fl: "id,#{Bulkrax.solr_key_for_member_file_ids}", method: :post, rows: row_limit }
+        filters = permission_filters
+        return base if filters.empty?
+        base.merge(fq: filters)
       end
 
       # If we have a limit, we need not query beyond that limit
@@ -175,10 +178,25 @@ module Bulkrax
         @file_sets ||= ParserExportRecordSet.in_batches(candidate_file_set_ids) do |batch_of_ids|
           fsq = "has_model_ssim:\"#{Bulkrax.file_model_internal_resource.demodulize}\" AND id:(\"" + batch_of_ids.join('" OR "') + "\")"
           fsq += extra_filters if extra_filters.present?
-          Bulkrax.object_factory.query(
-            fsq,
-            fl: "id", method: :post, rows: batch_of_ids.size
-          )
+          fq = permission_filters
+          kwargs = { fl: "id", method: :post, rows: batch_of_ids.size }
+          kwargs[:fq] = fq unless fq.empty?
+          Bulkrax.object_factory.query(fsq, **kwargs)
+        end
+      end
+
+      def exporting_user
+        importerexporter.user || Bulkrax.fallback_user_for_importer_exporter_processing
+      end
+
+      def permission_filters
+        @permission_filters ||= begin
+          ability = ::Ability.new(exporting_user)
+          return [] if ability.can_admin_exporters?
+
+          scope   = Bulkrax::ExportScope.new(ability)
+          builder = Bulkrax::ExportSearchBuilder.new(scope)
+          builder.to_h.fetch(:fq, [])
         end
       end
 
@@ -246,7 +264,7 @@ module Bulkrax
           Bulkrax.object_factory.query(
             extra_filters.to_s,
             **query_kwargs.merge(
-              fq: [
+              fq: (query_kwargs[:fq] || []) + [
                 %(#{solr_name(work_identifier)}:("#{ids.join('" OR "')}")),
                 "has_model_ssim:(#{Bulkrax.curation_concern_internal_resources.join(' OR ')})"
               ],
@@ -261,7 +279,7 @@ module Bulkrax
           Bulkrax.object_factory.query(
             "has_model_ssim:#{Bulkrax.collection_model_internal_resource} #{extra_filters}",
             **query_kwargs.merge(
-              fq: [
+              fq: (query_kwargs[:fq] || []) + [
                 %(#{solr_name(work_identifier)}:("#{ids.join('" OR "')}")),
                 "has_model_ssim:#{Bulkrax.collection_model_internal_resource}"
               ],
@@ -280,7 +298,7 @@ module Bulkrax
           Bulkrax.object_factory.query(
             extra_filters,
             **query_kwargs.merge(
-              fq: [
+              fq: (query_kwargs[:fq] || []) + [
                 %(#{solr_name(work_identifier)}:("#{ids.join('" OR "')}")),
                 "has_model_ssim:#{Bulkrax.file_model_internal_resource}"
               ],

--- a/app/search_builders/bulkrax/export_search_builder.rb
+++ b/app/search_builders/bulkrax/export_search_builder.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  class ExportSearchBuilder < Blacklight::SearchBuilder
+    include Hydra::AccessControlsEnforcement
+
+    self.default_processor_chain = [:add_access_controls_to_solr_params]
+  end
+end

--- a/spec/models/bulkrax/export_scope_spec.rb
+++ b/spec/models/bulkrax/export_scope_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::ExportScope do
+  let(:user) { User.new(email: 'user@example.com') }
+  let(:ability) { Ability.new(user) }
+
+  subject(:scope) { described_class.new(ability) }
+
+  describe '#current_ability' do
+    it 'returns the ability passed to the constructor' do
+      expect(scope.current_ability).to eq(ability)
+    end
+  end
+
+  describe '#blacklight_config' do
+    it 'returns a Blacklight::Configuration' do
+      expect(scope.blacklight_config).to be_a(Blacklight::Configuration)
+    end
+
+    it 'is memoized' do
+      expect(scope.blacklight_config).to be(scope.blacklight_config)
+    end
+  end
+end

--- a/spec/parsers/bulkrax/parser_export_record_set_permission_spec.rb
+++ b/spec/parsers/bulkrax/parser_export_record_set_permission_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'bulkrax/entry_spec_helper'
+
+RSpec.describe Bulkrax::ParserExportRecordSet::Base, '#permission_filters' do
+  let(:user) { instance_double(User, id: 1, user_key: 'user@example.com') }
+  let(:admin_user) { instance_double(User, id: 2, user_key: 'admin@example.com') }
+  let(:exporter) { Bulkrax::EntrySpecHelper.exporter_for(parser_class_name: "Bulkrax::CsvParser") }
+  let(:parser) { exporter.parser }
+  let(:record_set) { Bulkrax::ParserExportRecordSet::All.new(parser: parser) }
+
+  before { allow(exporter).to receive(:user).and_return(user) }
+
+  describe '#permission_filters' do
+    context 'when the exporting user is a regular user' do
+      let(:fq_filters) { ['read_access_group_ssim:public OR access_filter'] }
+
+      before do
+        fake_ability = instance_double(Ability, can_admin_exporters?: false)
+        fake_scope = instance_double(Bulkrax::ExportScope)
+        fake_builder = instance_double(Bulkrax::ExportSearchBuilder, to_h: { fq: fq_filters })
+        allow(Ability).to receive(:new).and_return(fake_ability)
+        allow(Bulkrax::ExportScope).to receive(:new).and_return(fake_scope)
+        allow(Bulkrax::ExportSearchBuilder).to receive(:new).with(fake_scope).and_return(fake_builder)
+      end
+
+      it 'returns fq clauses from ExportSearchBuilder' do
+        expect(record_set.send(:permission_filters)).to eq(fq_filters)
+      end
+
+      it 'is memoized (builder is not re-instantiated)' do
+        record_set.send(:permission_filters)
+        record_set.send(:permission_filters)
+        expect(Bulkrax::ExportSearchBuilder).to have_received(:new).once
+      end
+    end
+
+    context 'when the exporting user can_admin_exporters?' do
+      before do
+        fake_ability = instance_double(Ability, can_admin_exporters?: true)
+        allow(Ability).to receive(:new).and_return(fake_ability)
+      end
+
+      it 'returns an empty array (no permission scoping)' do
+        expect(record_set.send(:permission_filters)).to eq([])
+      end
+    end
+
+    context 'when exporter has no user (nil)' do
+      before do
+        allow(exporter).to receive(:user).and_return(nil)
+        fallback_user = instance_double(User, id: 99, user_key: 'batch@example.com')
+        allow(Bulkrax).to receive(:fallback_user_for_importer_exporter_processing).and_return(fallback_user)
+        fake_ability = instance_double(Ability, can_admin_exporters?: true)
+        allow(Ability).to receive(:new).with(fallback_user).and_return(fake_ability)
+      end
+
+      it 'falls back to Bulkrax.fallback_user_for_importer_exporter_processing' do
+        expect(record_set.send(:permission_filters)).to eq([])
+      end
+    end
+  end
+
+  describe 'query_kwargs with permission filters' do
+    let(:fq_filters) { ['read_access_group_ssim:public'] }
+
+    before { allow(record_set).to receive(:permission_filters).and_return(fq_filters) }
+
+    it 'includes permission filters in fq' do
+      expect(record_set.send(:query_kwargs)[:fq]).to eq(fq_filters)
+    end
+  end
+
+  describe '#file_sets includes permission filters' do
+    let(:fq_filters) { ['read_access_group_ssim:public'] }
+
+    before do
+      allow(record_set).to receive(:permission_filters).and_return(fq_filters)
+      allow(record_set).to receive(:candidate_file_set_ids).and_return(['id1'])
+      allow(Bulkrax.object_factory).to receive(:query).and_return([])
+    end
+
+    it 'passes fq to object_factory.query' do
+      record_set.send(:file_sets)
+      expect(Bulkrax.object_factory).to have_received(:query).with(anything, hash_including(fq: fq_filters))
+    end
+  end
+end
+
+RSpec.describe Bulkrax::ParserExportRecordSet::Importer, 'additive fq merge' do
+  let(:exporter) { Bulkrax::EntrySpecHelper.exporter_for(parser_class_name: "Bulkrax::CsvParser") }
+  let(:parser) { exporter.parser }
+  let(:record_set) { described_class.new(parser: parser) }
+  let(:user) { instance_double(User, id: 1, user_key: 'user@example.com') }
+  let(:fq_filters) { ['read_access_group_ssim:public'] }
+
+  before do
+    allow(exporter).to receive(:user).and_return(user)
+    allow(record_set).to receive(:permission_filters).and_return(fq_filters)
+    allow(record_set).to receive(:complete_entry_identifiers).and_return(['id1'])
+    allow(record_set).to receive(:solr_name).and_return('identifier_tesim')
+    allow(Bulkrax.object_factory).to receive(:query).and_return([])
+  end
+
+  describe '#works merges fq additively' do
+    it 'includes permission filters AND work-specific filters in fq' do
+      record_set.send(:works)
+      expect(Bulkrax.object_factory).to have_received(:query).with(
+        anything,
+        hash_including(fq: array_including('read_access_group_ssim:public'))
+      )
+    end
+  end
+
+  describe '#collections merges fq additively' do
+    it 'includes permission filters AND collection-specific filters in fq' do
+      record_set.send(:collections)
+      expect(Bulkrax.object_factory).to have_received(:query).with(
+        anything,
+        hash_including(fq: array_including('read_access_group_ssim:public'))
+      )
+    end
+  end
+
+  describe '#file_sets merges fq additively' do
+    it 'includes permission filters AND file-set-specific filters in fq' do
+      record_set.send(:file_sets)
+      expect(Bulkrax.object_factory).to have_received(:query).with(
+        anything,
+        hash_including(fq: array_including('read_access_group_ssim:public'))
+      )
+    end
+  end
+end

--- a/spec/search_builders/bulkrax/export_search_builder_spec.rb
+++ b/spec/search_builders/bulkrax/export_search_builder_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::ExportSearchBuilder do
+  subject(:builder) { described_class.new(scope) }
+
+  let(:user) { User.new(email: 'user@example.com') }
+  let(:ability) { Ability.new(user) }
+  let(:scope) { Bulkrax::ExportScope.new(ability) }
+
+  describe '#to_h' do
+    it 'returns a hash with fq access control filters' do
+      result = builder.to_h
+      expect(result[:fq]).to be_an(Array)
+      expect(result[:fq].join).to include('read_access')
+    end
+  end
+end

--- a/spec/test_app/app/models/ability.rb
+++ b/spec/test_app/app/models/ability.rb
@@ -29,6 +29,10 @@ class Ability
     can_create_any_work?
   end
 
+  def can_admin_exporters?
+    false
+  end
+
   def can_create_any_work?
     true
   end


### PR DESCRIPTION
## For Release Notes

Add new permission classes for Bulkrax and enforces permissions on exported items. Previously if you had permission to create exports you could export any item in the repository. ** if you are using Bulkrax without hydra-permissions or Blacklight ** you will need to provide your own ExportSearchBuilder.

## Summary

- Adds `Bulkrax::ExportSearchBuilder` — a `Blacklight::SearchBuilder` subclass that includes `Hydra::AccessControlsEnforcement` with a single-method processor chain (`add_access_controls_to_solr_params`)
- Adds `Bulkrax::ExportScope` — a minimal PORO that satisfies the `Blacklight::SearchBuilder` scope interface (`current_ability`, `blacklight_config`) without requiring a controller
- Wires both into `ParserExportRecordSet::Base#permission_filters`: non-admin exporters get Solr `fq` clauses scoped to records they can read; admin exporters (via `can_admin_exporters?`) bypass the filter entirely
- Updates `Base#query_kwargs` and `Base#file_sets` to include permission filters in all Solr queries
- Updates `Importer#works`, `Importer#collections`, and `Importer#file_sets` to merge permission filters additively rather than replacing them
- Includes the prerequisite `Bulkrax::Ability` / importer-exporter ownership scoping commit, then adds the SearchBuilder export scoping implementation on top

## Notes

- `ExportSearchBuilder.new(scope)` (single-argument form) is used so Blacklight uses `default_processor_chain`; passing `[]` as the first argument would result in an empty processor chain and no access controls applied
- `Blacklight::AccessControls::Enforcement` (aliased as `Hydra::AccessControlsEnforcement`) emits a deprecation warning in the current gem version — this is expected upstream behavior
- No changes to the engine load path are needed; Rails engines automatically add all `app/` subdirectories to the autoload path

🤖 Generated with [Claude Code](https://claude.com/claude-code), with final verification/rubocop cleanup by Betty