### PR TITLE
Drop orphan importer_runs columns and rescue all job errors

### DIFF
--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -15,6 +15,9 @@ module Bulkrax
       schedule(importer) if importer.schedulable?
     rescue ::CSV::MalformedCSVError, Bulkrax::UnzipError => e
       importer.set_status_info(e)
+    rescue StandardError => e
+      importer&.set_status_info(e)
+      raise
     end
 
     private

--- a/db/migrate/20260429000000_remove_orphan_columns_from_bulkrax_importer_runs.rb
+++ b/db/migrate/20260429000000_remove_orphan_columns_from_bulkrax_importer_runs.rb
@@ -1,0 +1,11 @@
+class RemoveOrphanColumnsFromBulkraxImporterRuns < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :bulkrax_importer_runs, :processed_children, if_exists: true
+    remove_column :bulkrax_importer_runs, :failed_children, if_exists: true
+    remove_column :bulkrax_importer_runs, :parents, if_exists: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/jobs/bulkrax/importer_job_spec.rb
+++ b/spec/jobs/bulkrax/importer_job_spec.rb
@@ -63,6 +63,27 @@ module Bulkrax
         end
       end
 
+      context 'when current_run fails with an unexpected database error' do
+        let(:importer) { FactoryBot.create(:bulkrax_importer_oai) }
+        let(:db_error) { ActiveRecord::StatementInvalid.new('PG::UndefinedColumn: ERROR: column "processed_children" does not exist') }
+
+        before do
+          importer.importer_runs.create!
+          allow(importer).to receive(:current_run).and_raise(db_error)
+        end
+
+        it 'records the error class and message on the importer status' do
+          expect { importer_job.perform(importer.id) }.to raise_error(ActiveRecord::StatementInvalid)
+          expect(importer.reload.status).to eq('Failed')
+          expect(importer.current_status.error_class).to eq('ActiveRecord::StatementInvalid')
+          expect(importer.current_status.error_message).to match(/processed_children/)
+        end
+
+        it 're-raises so the failure is visible to the job runner' do
+          expect { importer_job.perform(importer.id) }.to raise_error(ActiveRecord::StatementInvalid)
+        end
+      end
+
       context 'when the zip cannot be interpreted (e.g. no CSV inside)' do
         let(:zip_tmp) { Tempfile.new(['import', '.zip']) }
         let(:importer) do

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_05_212513) do
-
+ActiveRecord::Schema.define(version: 2026_04_29_000000) do
   create_table "accounts", force: :cascade do |t|
     t.string "name"
   end
@@ -104,8 +103,6 @@ ActiveRecord::Schema.define(version: 2024_12_05_212513) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
-    t.integer "processed_children", default: 0
-    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 


### PR DESCRIPTION
# Summary

Addresses https://github.com/notch8/palni_palci_knapsack/issues/631

# Details

Importers were silently stuck in "Pending" when ImporterJob crashed before reaching its narrow rescue (CSV::MalformedCSVError / Bulkrax::UnzipError). The customer report showed
ActiveRecord::StatementInvalid on insert into bulkrax_importer_runs because processed_children/failed_children still existed in the schema cache but had been dropped from the column set.

This is the same class of bug as #1183: a rename migration (#487's update to the 2021 children->relationships rename added a guard "unless column_exists?(:processed_relationships)") could silently skip the rename, leaving processed_children/failed_children orphaned alongside processed_relationships/failed_relationships. Originally introduced in #371, the rename was hardened in #487 in a way that could leave half-renamed state behind.

Changes:

- New migration 20260429000000 drops processed_children, failed_children, and parents (idempotent via if_exists). The parents drop overlaps with #1183's 20260424081537 -- harmless on fresh DBs (second run is a no-op), self-healing on DBs that upgraded straight past 9.4.2. down raises IrreversibleMigration since reintroducing these columns recreates the broken state.
- ImporterJob#perform now rescues StandardError after the existing narrow rescue: known input errors continue to swallow as before, any other failure records the error on the importer status and re-raises so GoodJob/Sentry see it instead of leaving the importer permanently pending.
- spec/test_app/db/schema.rb: remove the orphan column lines and bump the schema version. Mirrors the same hand-curated baseline that #1183 left in place.
- importer_job_spec adds two examples pinning the customer's exact failure mode (StatementInvalid on current_run): status flips to Failed, error class/message recorded, and the exception propagates.

Related: #1183, #443 (original parents removal that deleted the migration), #487 (added the column_exists? guard that allowed half-renamed children columns).