### PR TITLE
Don't load wings custom query if Hyrax has disabled wings.

### DIFF
--- a/lib/wings/custom_queries/find_by_source_identifier.rb
+++ b/lib/wings/custom_queries/find_by_source_identifier.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return if defined?(Hyrax) && Hyrax.try(:config).try(:disable_wings)
+
 module Wings
   module CustomQueries
     class FindBySourceIdentifier


### PR DESCRIPTION
Avoids creating `Wings` when Hyrax will not be using it.