### PR TITLE
Add nested_attributes flag for object: mappings

### DIFF
--- a/app/factories/bulkrax/object_factory_interface.rb
+++ b/app/factories/bulkrax/object_factory_interface.rb
@@ -468,7 +468,24 @@ module Bulkrax
     # Regardless of what the Parser gives us, these are the properties we are
     # prepared to accept.
     def permitted_attributes
-      klass.properties.keys.map(&:to_sym) + base_permitted_attributes
+      bare = klass.properties.keys.map(&:to_sym) + base_permitted_attributes
+      bare + nested_attributes_keys(bare)
+    end
+
+    # Permits `*_attributes` virtual keys when the corresponding bare property
+    # is itself permitted. Field mappings declaring `nested_attributes: true`
+    # (see Bulkrax::HasMatchers#set_parsed_object_data) emit data under keys
+    # like `redirects_attributes`; without this, the slice in
+    # #transform_attributes would drop them and downstream form populators
+    # would receive nothing.
+    def nested_attributes_keys(bare_permitted)
+      bare_set = bare_permitted.map(&:to_sym).to_set
+      attributes.keys.filter_map do |key|
+        key_str = key.to_s
+        next unless key_str.end_with?('_attributes')
+        bare_name = key_str.sub(/_attributes\z/, '').to_sym
+        key.to_sym if bare_set.include?(bare_name)
+      end.uniq
     end
 
     # Return a copy of the given attributes, such that all values that are empty

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -498,14 +498,15 @@ module Bulkrax
     #
     # @return [Array<Symbols>]
     def permitted_attributes
-      @permitted_attributes ||= (
-        base_permitted_attributes + if klass.respond_to?(:schema)
-                                      admin_set_id = attributes[:admin_set_id] || attributes['admin_set_id']
-                                      Bulkrax::ValkyrieObjectFactory.schema_properties(klass: klass, admin_set_id: admin_set_id)
-                                    else
-                                      klass.properties.keys.map(&:to_sym)
-                                    end
-      ).uniq
+      @permitted_attributes ||= begin
+        bare = base_permitted_attributes + if klass.respond_to?(:schema)
+                                             admin_set_id = attributes[:admin_set_id] || attributes['admin_set_id']
+                                             Bulkrax::ValkyrieObjectFactory.schema_properties(klass: klass, admin_set_id: admin_set_id)
+                                           else
+                                             klass.properties.keys.map(&:to_sym)
+                                           end
+        (bare + nested_attributes_keys(bare)).uniq
+      end
     end
 
     def update_work(attrs)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -329,15 +329,14 @@ module Bulkrax
     end
 
     def object_metadata(data)
-      # NOTE: What is `d` in this case:
-      #
-      #  "[{\"single_object_first_name\"=>\"Fake\", \"single_object_last_name\"=>\"Fakerson\", \"single_object_position\"=>\"Leader, Jester, Queen\", \"single_object_language\"=>\"english\"}]"
-      #
-      # The above is a stringified version of a Ruby string.  Using eval is a very bad idea as it
-      # will execute the value of `d` within the full Ruby interpreter context.
-      #
-      # TODO: Would it be possible to store this as a non-string?  Maybe the actual Ruby Array and Hash?
-      data = data.map { |d| eval(d) }.flatten # rubocop:disable Security/Eval
+      # Each `d` may be either a stringified Ruby hash literal (legacy
+      # ActiveFedora persistence) or a plain Hash (Valkyrie/Postgres
+      # JSONB). For the legacy stringified form we eval to recover the
+      # hash; for plain Hashes we pass through. Using eval is a very bad
+      # idea as it will execute the value of `d` within the full Ruby
+      # interpreter context — only do it when we know the input is a
+      # stringified hash.
+      data = data.map { |d| d.is_a?(Hash) ? d : eval(d) }.flatten # rubocop:disable Security/Eval
 
       data.each_with_index do |obj, index|
         next if obj.nil?

--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -38,7 +38,7 @@ module Bulkrax
 
         if object_name
           Rails.logger.info("Bulkrax Column automatically matched object #{node_name}, #{node_content}")
-          parsed_metadata[object_name] ||= object_multiple ? [{}] : {}
+          init_object_container(object_name, object_multiple)
         end
 
         value = if matcher
@@ -60,6 +60,30 @@ module Bulkrax
       mapping&.[](field)&.[]('object')
     end
 
+    # When any field-mapping sibling under `object_name` carries
+    # `nested_attributes: true`, Bulkrax routes the imported data through
+    # `parsed_metadata["#{object_name}_attributes"]` as a numbered-key hash
+    # (with `_destroy: 'false'` per row) — the shape consumed by Reform's
+    # nested-attributes machinery and other `*_attributes`-style populators.
+    def nested_attributes_object?(object_name)
+      return false unless mapping.is_a?(Hash) && object_name.present?
+      mapping.any? { |_, cfg| cfg.is_a?(Hash) && cfg['object'] == object_name && cfg['nested_attributes'] }
+    end
+
+    def parsed_object_target_key(object_name)
+      nested_attributes_object?(object_name) ? "#{object_name}_attributes" : object_name
+    end
+
+    def init_object_container(object_name, object_multiple)
+      target_key = parsed_object_target_key(object_name)
+      default = if object_multiple
+                  nested_attributes_object?(object_name) ? {} : [{}]
+                else
+                  {}
+                end
+      parsed_metadata[target_key] ||= default
+    end
+
     def set_parsed_data(name, value)
       return parsed_metadata[name] = value unless multiple?(name)
 
@@ -69,22 +93,33 @@ module Bulkrax
     end
 
     def set_parsed_object_data(object_multiple, object_name, name, index, value)
-      if object_multiple
-        index ||= 0
-        parsed_metadata[object_name][index] ||= {}
-        parsed_metadata[object_name][index][name] ||= []
-        if value.is_a?(Array)
-          parsed_metadata[object_name][index][name] += value
-        else
-          parsed_metadata[object_name][index][name] = value
-        end
+      target_key = parsed_object_target_key(object_name)
+      target = object_target_for(target_key, object_name, object_multiple, index)
+      assign_object_value(target, name, value)
+    end
+
+    # Resolve the hash slot that `name` should be written into, initializing
+    # any intermediate containers. Returns the leaf hash so the caller can
+    # assign the value with a single statement.
+    def object_target_for(target_key, object_name, object_multiple, index)
+      return parsed_metadata[target_key] unless object_multiple
+
+      idx = index || 0
+      if nested_attributes_object?(object_name)
+        parsed_metadata[target_key][idx.to_s] ||= { '_destroy' => 'false' }
+        parsed_metadata[target_key][idx.to_s]
       else
-        parsed_metadata[object_name][name] ||= []
-        if value.is_a?(Array)
-          parsed_metadata[object_name][name] += value
-        else
-          parsed_metadata[object_name][name] = value
-        end
+        parsed_metadata[target_key][idx] ||= {}
+        parsed_metadata[target_key][idx]
+      end
+    end
+
+    def assign_object_value(target, name, value)
+      target[name] ||= []
+      if value.is_a?(Array)
+        target[name] += value
+      else
+        target[name] = value
       end
     end
 

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -84,7 +84,14 @@ module Bulkrax
           all_models    = field_metadata.keys
           valid_headers = build_valid_validation_headers(mapping_manager, field_analyzer,
                                                          all_models, mappings, field_metadata)
-          suffixed      = headers.select { |h| h.match?(/_\d+\z/) }
+          # Only allow a suffixed header (e.g. `creator_1`, `redirect_path_2`)
+          # when its base name is itself recognised. The blanket allow that
+          # used to live here let through any *_<digits> column, which masked
+          # typos in numbered columns at validation time even though the real
+          # importer would fail to map them.
+          suffixed = headers.select do |h|
+            h.match?(/_\d+\z/) && header_base_recognized?(h, valid_headers, mapping_manager, field_metadata)
+          end
           valid_headers = (valid_headers + suffixed).uniq
 
           {
@@ -94,6 +101,19 @@ module Bulkrax
                                                                field_metadata: field_metadata),
             empty_columns: find_empty_column_positions(headers, raw_csv)
           }
+        end
+
+        # Mirrors the recognition rule used by
+        # find_unrecognized_validation_headers: a header's base name is
+        # recognised if it appears in valid_headers directly or if its
+        # mapping_manager#mapped_to_key resolves to a known model property.
+        def header_base_recognized?(header, valid_headers, mapping_manager, field_metadata)
+          base = header.sub(/_\d+\z/, '')
+          return true if valid_headers.include?(base)
+
+          known_property_keys = (field_metadata || {}).values.flat_map { |m| Array(m[:properties]) }.to_set
+          mapped_key = mapping_manager&.mapped_to_key(base)
+          mapped_key.present? && known_property_keys.include?(mapped_key)
         end
 
         def extract_hierarchy_items(csv_data, all_ids, find_record, mappings)

--- a/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
+++ b/app/parsers/concerns/bulkrax/csv_parser/csv_validation.rb
@@ -89,8 +89,9 @@ module Bulkrax
           # used to live here let through any *_<digits> column, which masked
           # typos in numbered columns at validation time even though the real
           # importer would fail to map them.
+          known_property_keys = (field_metadata || {}).values.flat_map { |m| Array(m[:properties]) }.to_set
           suffixed = headers.select do |h|
-            h.match?(/_\d+\z/) && header_base_recognized?(h, valid_headers, mapping_manager, field_metadata)
+            h.match?(/_\d+\z/) && header_base_recognized?(h, valid_headers, mapping_manager, known_property_keys)
           end
           valid_headers = (valid_headers + suffixed).uniq
 
@@ -107,11 +108,12 @@ module Bulkrax
         # find_unrecognized_validation_headers: a header's base name is
         # recognised if it appears in valid_headers directly or if its
         # mapping_manager#mapped_to_key resolves to a known model property.
-        def header_base_recognized?(header, valid_headers, mapping_manager, field_metadata)
+        # known_property_keys is precomputed by check_headers so this can be
+        # called per-header without rebuilding the set each time.
+        def header_base_recognized?(header, valid_headers, mapping_manager, known_property_keys)
           base = header.sub(/_\d+\z/, '')
           return true if valid_headers.include?(base)
 
-          known_property_keys = (field_metadata || {}).values.flat_map { |m| Array(m[:properties]) }.to_set
           mapped_key = mapping_manager&.mapped_to_key(base)
           mapped_key.present? && known_property_keys.include?(mapped_key)
         end

--- a/app/services/bulkrax/csv_template/column_builder.rb
+++ b/app/services/bulkrax/csv_template/column_builder.rb
@@ -35,10 +35,20 @@ module Bulkrax
         properties = field_lists
                      .flat_map { |item| item.values.flat_map { |config| config["properties"] || [] } }
                      .uniq
-                     .map { |property| @service.mapping_manager.key_to_mapped_column(property) }
+                     .flat_map { |property| columns_for_property(property) }
                      .uniq
 
         (properties - required_columns).sort
+      end
+
+      # When a property is the target of one or more `object:` field mappings,
+      # emit each of those mappings' `from:` columns (e.g. redirect_path,
+      # redirect_canonical, redirect_sequence) rather than the bare property
+      # name (redirects). Otherwise fall back to the standard 1:1 mapping.
+      def columns_for_property(property)
+        nested = @service.mapping_manager.object_columns_for(property)
+        return nested if nested.any?
+        [@service.mapping_manager.key_to_mapped_column(property)]
       end
 
       def relationship_columns

--- a/app/services/bulkrax/csv_template/mapping_manager.rb
+++ b/app/services/bulkrax/csv_template/mapping_manager.rb
@@ -26,6 +26,13 @@ module Bulkrax
         @mappings.dig(key, "from")&.first || key
       end
 
+      # Returns the `object:` value for a given mapping key, or nil. Mirrors
+      # the importer-side `Bulkrax::HasMatchers#get_object_name` for callers
+      # working with the template-side mapping manager.
+      def get_object_name(key)
+        @mappings.dig(key, "object")
+      end
+
       # Returns the column names that target a given object name via the
       # `object:` field-mapping pattern. The template generator uses this to
       # emit the per-child columns (e.g. redirect_path, redirect_canonical,

--- a/app/services/bulkrax/csv_template/mapping_manager.rb
+++ b/app/services/bulkrax/csv_template/mapping_manager.rb
@@ -26,6 +26,21 @@ module Bulkrax
         @mappings.dig(key, "from")&.first || key
       end
 
+      # Returns the column names that target a given object name via the
+      # `object:` field-mapping pattern. The template generator uses this to
+      # emit the per-child columns (e.g. redirect_path, redirect_canonical,
+      # redirect_sequence) instead of the bare property name (redirects).
+      # Numbering is intentionally omitted — the template shows the column
+      # shape once; CSV rows can repeat the column with numeric suffixes
+      # (e.g. redirect_path_1, redirect_path_2) at import time.
+      def object_columns_for(object_name)
+        @mappings
+          .select { |_k, v| v.is_a?(Hash) && v["object"] == object_name }
+          .values
+          .flat_map { |v| Array(v["from"]) }
+          .uniq
+      end
+
       def find_by_flag(field_name, default)
         @mappings.find { |_k, v| v[field_name] == true }&.first || default
       end

--- a/app/services/bulkrax/csv_template/value_determiner.rb
+++ b/app/services/bulkrax/csv_template/value_determiner.rb
@@ -12,9 +12,16 @@ module Bulkrax
       def determine_value(column, model_name, field_list)
         key = @service.mapping_manager.mapped_to_key(column)
         required_terms = field_list.dig(model_name, 'required_terms')
+        properties = field_list.dig(model_name, "properties") || []
+        object_name = @service.mapping_manager.get_object_name(key)
 
-        if field_list.dig(model_name, "properties")&.include?(key)
+        if properties.include?(key)
           mark_required_or_optional(key, required_terms)
+        elsif object_name && properties.include?(object_name)
+          # Column belongs to an `object:` mapping (e.g. `redirect_path` → object
+          # `redirects`). Treat the column as required/optional based on the
+          # parent property's required-terms list.
+          mark_required_or_optional(object_name, required_terms)
         elsif special_column?(column, key)
           special_value(column, key, model_name, required_terms)
         end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -1070,6 +1070,75 @@ module Bulkrax
       end
     end
 
+    describe 'round-tripping' do
+      context 'a nested_attributes mapping (import -> resource -> export)' do
+        # Confirms a single mapping declaration drives both directions:
+        # imported numbered columns become _attributes-shaped data the form
+        # consumes, and the persisted plain-hash array exports back to the
+        # same numbered columns.
+        let(:import_field_mapping) do
+          {
+            'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects', nested_attributes: true },
+            'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects', nested_attributes: true }
+          }
+        end
+
+        let(:export_field_mapping) do
+          import_field_mapping.merge('id' => { from: ['id'], source_identifier: true })
+        end
+
+        let(:csv_columns) do
+          {
+            'source_identifier' => '2',
+            'title' => 'some title',
+            'multiple_objects_first_name_1' => 'Fake',
+            'multiple_objects_last_name_1' => 'Fakerson',
+            'multiple_objects_first_name_2' => 'Judge',
+            'multiple_objects_last_name_2' => 'Hines'
+          }
+        end
+
+        let(:importer) { FactoryBot.create(:bulkrax_importer_csv, field_mapping: import_field_mapping) }
+        let(:exporter) { FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: export_field_mapping) }
+        let(:import_entry) { described_class.new(importerexporter: importer) }
+        let(:export_entry) { described_class.new(importerexporter: exporter) }
+        let(:work_obj) { Work.new(title: ['test']) }
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(import_entry).to receive(:raw_metadata).and_return(csv_columns)
+
+          allow(export_entry).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return('test123')
+          allow(work_obj).to receive(:member_of_work_ids).and_return([])
+          allow(work_obj).to receive(:in_work_ids).and_return([])
+          allow(work_obj).to receive(:member_work_ids).and_return([])
+        end
+
+        it 'produces the original numbered columns on export' do
+          # Import: the flag routes data to multiple_objects_attributes in
+          # numbered-key form. A form populator would consume this and
+          # ultimately assign the plain-hash array to the resource.
+          import_metadata = import_entry.build_metadata
+          expect(import_metadata['multiple_objects_attributes']['0']).to include('first_name' => 'Fake', 'last_name' => 'Fakerson')
+          expect(import_metadata['multiple_objects_attributes']['1']).to include('first_name' => 'Judge', 'last_name' => 'Hines')
+
+          # Simulate the form populator's effect: the resource's accessor
+          # returns the plain-hash array (Valkyrie/JSONB shape).
+          persisted = import_metadata['multiple_objects_attributes'].values.map { |row| row.except('_destroy') }
+          allow(work_obj).to receive(:multiple_objects).and_return(persisted)
+
+          # Export: the same mapping reads from the bare accessor and
+          # produces the original numbered-column shape.
+          export_metadata = export_entry.build_export_metadata
+          expect(export_metadata['multiple_objects_first_name_1']).to eq('Fake')
+          expect(export_metadata['multiple_objects_last_name_1']).to eq('Fakerson')
+          expect(export_metadata['multiple_objects_first_name_2']).to eq('Judge')
+          expect(export_metadata['multiple_objects_last_name_2']).to eq('Hines')
+        end
+      end
+    end
+
     describe '#build_relationship_metadata' do
       subject(:entry) { described_class.new(importerexporter: exporter) }
       let(:exporter) { create(:bulkrax_exporter, :with_relationships_mappings) }

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -626,6 +626,50 @@ module Bulkrax
         end
       end
 
+      context 'with multiple objects and the nested_attributes: true flag' do
+        # When the field-mapping declares nested_attributes: true, Bulkrax
+        # writes to parsed_metadata['<name>_attributes'] as a numbered-key
+        # hash with '_destroy' markers — the shape Hyrax form populators
+        # built on Reform's nested-attributes machinery consume.
+        let(:importer) do
+          FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
+                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects', nested_attributes: true },
+                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects', nested_attributes: true }
+                            })
+        end
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:raw_metadata).and_return(
+            'source_identifier' => '2',
+            'title' => 'some title',
+            'multiple_objects_first_name_1' => 'Fake',
+            'multiple_objects_last_name_1' => 'Fakerson',
+            'multiple_objects_first_name_2' => 'Judge',
+            'multiple_objects_last_name_2' => 'Hines'
+          )
+        end
+
+        it 'writes a numbered-key hash to <object>_attributes with _destroy markers' do
+          metadata = subject.build_metadata
+          # The bare object key is not populated when the flag is on.
+          expect(metadata).not_to have_key('multiple_objects')
+          # Routed to the _attributes key for Hyrax form populators.
+          expect(metadata['multiple_objects_attributes']).to be_a(Hash)
+          expect(metadata['multiple_objects_attributes'].keys).to contain_exactly('0', '1')
+
+          row0 = metadata['multiple_objects_attributes']['0']
+          expect(row0['first_name']).to eq('Fake')
+          expect(row0['last_name']).to eq('Fakerson')
+          expect(row0['_destroy']).to eq('false')
+
+          row1 = metadata['multiple_objects_attributes']['1']
+          expect(row1['first_name']).to eq('Judge')
+          expect(row1['last_name']).to eq('Hines')
+          expect(row1['_destroy']).to eq('false')
+        end
+      end
+
       context 'with object fields not prefixed and properties with multiple values' do
         let(:importer) do
           FactoryBot.create(:bulkrax_importer_csv, field_mapping: {
@@ -949,6 +993,44 @@ module Bulkrax
           expect(metadata['multiple_objects_position_2_1']).to eq('King')
           expect(metadata['multiple_objects_position_2_2']).to eq('Lord')
           expect(metadata['multiple_objects_position_2_3']).to eq('Duke')
+        end
+      end
+
+      context 'when the resource returns plain hashes (no stringification)' do
+        # Valkyrie / Postgres JSONB attributes return Ruby hashes directly,
+        # not the legacy stringified-hash literal that ActiveFedora produced.
+        # object_metadata must accept either form.
+        let(:exporter) do
+          FactoryBot.create(:bulkrax_exporter_worktype, field_mapping: {
+                              'id' => { from: ['id'], source_identifier: true },
+                              'first_name' => { from: ['multiple_objects_first_name'], object: 'multiple_objects' },
+                              'last_name' => { from: ['multiple_objects_last_name'], object: 'multiple_objects' }
+                            })
+        end
+
+        let(:work_obj) { Work.new(title: ['test']) }
+
+        before do
+          allow_any_instance_of(ObjectFactory).to receive(:run!)
+          allow(subject).to receive(:hyrax_record).and_return(work_obj)
+          allow(work_obj).to receive(:id).and_return('test123')
+          allow(work_obj).to receive(:member_of_work_ids).and_return([])
+          allow(work_obj).to receive(:in_work_ids).and_return([])
+          allow(work_obj).to receive(:member_work_ids).and_return([])
+          # Simulate the Valkyrie/JSONB shape: the accessor returns plain
+          # hashes directly, not the stringified form ActiveFedora produces.
+          allow(work_obj).to receive(:multiple_objects).and_return([
+                                                                     { 'first_name' => 'Fake', 'last_name' => 'Fakerson' },
+                                                                     { 'first_name' => 'Judge', 'last_name' => 'Hines' }
+                                                                   ])
+        end
+
+        it 'produces numbered columns from plain-hash entries without eval' do
+          metadata = subject.build_export_metadata
+          expect(metadata['multiple_objects_first_name_1']).to eq('Fake')
+          expect(metadata['multiple_objects_last_name_1']).to eq('Fakerson')
+          expect(metadata['multiple_objects_first_name_2']).to eq('Judge')
+          expect(metadata['multiple_objects_last_name_2']).to eq('Hines')
         end
       end
 

--- a/spec/models/bulkrax/object_factory_spec.rb
+++ b/spec/models/bulkrax/object_factory_spec.rb
@@ -55,6 +55,46 @@ module Bulkrax
             .to eq({ empty_array: [], empty_string: nil, filled_array: ["A", "B"], filled_string: "A" }.stringify_keys)
         end
       end
+
+      context 'with `*_attributes` keys whose bare property is permitted' do
+        # When a field mapping declares `nested_attributes: true`, parsed_metadata
+        # arrives at the factory with a `<name>_attributes` key. The transform
+        # must keep that key even though it's not declared on the model schema —
+        # otherwise the slice in #transform_attributes drops it before the form
+        # populator can consume it.
+        it 'preserves the `<name>_attributes` key alongside the bare property' do
+          attributes = {
+            redirects_attributes: {
+              '0' => { 'path' => '/foo', '_destroy' => 'false' }
+            },
+            title: ['Test']
+          }
+          factory = described_class.new(attributes: attributes,
+                                        source_identifier_value: 123,
+                                        work_identifier: "title",
+                                        work_identifier_search_field: 'title_sim')
+          factory.base_permitted_attributes = %i[redirects title]
+
+          result = factory.send(:transform_attributes)
+          expect(result.keys).to include('redirects_attributes', 'title')
+          expect(result['redirects_attributes']).to eq('0' => { 'path' => '/foo', '_destroy' => 'false' })
+        end
+
+        it 'drops `*_attributes` keys whose bare property is not permitted' do
+          attributes = {
+            unknown_attributes: { '0' => { 'foo' => 'bar' } },
+            title: ['Test']
+          }
+          factory = described_class.new(attributes: attributes,
+                                        source_identifier_value: 123,
+                                        work_identifier: "title",
+                                        work_identifier_search_field: 'title_sim')
+          factory.base_permitted_attributes = %i[title]
+
+          result = factory.send(:transform_attributes)
+          expect(result.keys).not_to include('unknown_attributes')
+        end
+      end
     end
   end
 end

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -291,6 +291,50 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       expect(unrecognized(%w[title totally_made_up])).to have_key('totally_made_up')
     end
 
+    # `nested_attributes: true` mappings (introduced for objects whose form
+    # populator strips the bare property name) emit data through the
+    # `<object>_attributes` key. The CSV side still uses the per-child
+    # column names (e.g. `redirect_path`, `redirect_canonical`,
+    # `redirect_sequence`) — both bare and numbered — and the validator
+    # must accept all three forms.
+    context 'when a mapping declares nested_attributes: true' do
+      let(:mappings) do
+        {
+          'title' => { 'from' => ['title'], 'split' => '\\|' },
+          'path' => { 'from' => ['redirect_path'], 'object' => 'redirects', 'nested_attributes' => true },
+          'canonical' => { 'from' => ['redirect_canonical'], 'object' => 'redirects', 'nested_attributes' => true },
+          'sequence' => { 'from' => ['redirect_sequence'], 'object' => 'redirects', 'nested_attributes' => true }
+        }
+      end
+      let(:field_metadata) do
+        { 'GenericWorkResource' =>
+          { properties: %w[title redirects], required_terms: [], controlled_vocab_terms: [] } }
+      end
+
+      before do
+        allow(field_analyzer).to receive(:find_or_create_field_list_for)
+          .with(model_name: 'GenericWorkResource')
+          .and_return('GenericWorkResource' => { 'properties' => %w[title redirects] })
+      end
+
+      it 'does not flag the bare per-child column name' do
+        expect(unrecognized(%w[title redirect_path])).not_to have_key('redirect_path')
+      end
+
+      it 'does not flag a numbered per-child column' do
+        expect(unrecognized(%w[title redirect_path_1])).not_to have_key('redirect_path_1')
+      end
+
+      it 'does not flag any of the per-child columns together' do
+        result = unrecognized(%w[title redirect_path_1 redirect_canonical_1 redirect_sequence_1 redirect_path_2])
+        expect(result).to be_empty
+      end
+
+      it 'still flags an unrelated column even when nested_attributes mappings are present' do
+        expect(unrecognized(%w[title redirect_path totally_made_up])).to have_key('totally_made_up')
+      end
+    end
+
     # Bulkrax ships `rights_statement` with `generated: true`. The validator
     # must still honour its `from:` aliases so a CSV with a `rights` column
     # isn't flagged as unrecognised (and, via #find_missing_required_headers,

--- a/spec/services/bulkrax/csv_template/column_builder_spec.rb
+++ b/spec/services/bulkrax/csv_template/column_builder_spec.rb
@@ -150,6 +150,10 @@ RSpec.describe Bulkrax::CsvTemplate::ColumnBuilder do
         allow(field_analyzer).to receive(:find_or_create_field_list_for)
           .with(model_name: 'AnotherWork').and_return(field_list_2)
 
+        # Default: no property is the target of an `object:` mapping. Tests
+        # that exercise nested-attribute properties override this.
+        allow(mapping_manager).to receive(:object_columns_for).and_return([])
+
         # Mock the mapping manager to return mapped column names
         allow(mapping_manager).to receive(:key_to_mapped_column) do |key|
           "x#{key}" # Simple mapping for testing
@@ -185,6 +189,32 @@ RSpec.describe Bulkrax::CsvTemplate::ColumnBuilder do
         result = column_builder.send(:property_columns)
 
         expect(result).to eq([])
+      end
+
+      context 'when a property is the target of `object:` field mappings' do
+        let(:field_list_with_redirects) do
+          {
+            'MyWork' => { 'properties' => ['title', 'redirects'] }
+          }
+        end
+
+        before do
+          allow(field_analyzer).to receive(:find_or_create_field_list_for)
+            .with(model_name: 'MyWork').and_return(field_list_with_redirects)
+          allow(field_analyzer).to receive(:find_or_create_field_list_for)
+            .with(model_name: 'AnotherWork').and_return({})
+
+          allow(mapping_manager).to receive(:object_columns_for).with('redirects')
+                                                                .and_return(['redirect_path', 'redirect_canonical', 'redirect_sequence'])
+        end
+
+        it 'emits the object\'s child columns instead of the bare property name' do
+          result = column_builder.send(:property_columns)
+
+          expect(result).to include('redirect_path', 'redirect_canonical', 'redirect_sequence')
+          # Bare property name does not appear (no `xredirects` in the output).
+          expect(result).not_to include('xredirects')
+        end
       end
     end
 
@@ -268,6 +298,7 @@ RSpec.describe Bulkrax::CsvTemplate::ColumnBuilder do
           .with("related_children_field_mapping", 'children').and_return('children')
         allow(mapping_manager).to receive(:find_by_flag)
           .with("related_parents_field_mapping", 'parents').and_return('parents')
+        allow(mapping_manager).to receive(:object_columns_for).and_return([])
 
         allow(service).to receive(:all_models).and_return(['MyWork'])
         allow(field_analyzer).to receive(:find_or_create_field_list_for)

--- a/spec/services/bulkrax/csv_template/csv_parser_template_spec.rb
+++ b/spec/services/bulkrax/csv_template/csv_parser_template_spec.rb
@@ -159,6 +159,24 @@ RSpec.describe Bulkrax::CsvParser do
       end
     end
 
+    context 'with misspelled suffixed headers' do
+      # Pre-2026, headers ending in `_<digits>` were unconditionally accepted
+      # regardless of the base name. The validator now requires the base name
+      # to be recognised, so a typo like `creater_1` is flagged the same way
+      # `creater` (without the suffix) is.
+      let(:csv_content) do
+        <<~CSV
+          source_identifier,title,creater_1,creater_2,model
+          work1,Test Work 1,Author 1,Author 2,GenericWork
+        CSV
+      end
+
+      it 'flags a numbered column whose base name is misspelled' do
+        result = described_class.validate_csv(csv_file: csv_file, zip_file: nil)
+        expect(result[:unrecognized].keys).to include('creater_1')
+      end
+    end
+
     context 'source_identifier generation' do
       context 'when fill_in_blank_source_identifiers is not configured' do
         before { allow(Bulkrax).to receive(:fill_in_blank_source_identifiers).and_return(nil) }

--- a/spec/services/bulkrax/csv_template/mapping_manager_spec.rb
+++ b/spec/services/bulkrax/csv_template/mapping_manager_spec.rb
@@ -235,4 +235,38 @@ RSpec.describe Bulkrax::CsvTemplate::MappingManager do
       end
     end
   end
+
+  describe '#object_columns_for' do
+    before do
+      allow(Bulkrax).to receive(:field_mappings).and_return({
+                                                              'Bulkrax::CsvParser' => {
+                                                                'title' => { 'from' => ['title'] },
+                                                                'path' => { 'from' => ['redirect_path'], 'object' => 'redirects', 'nested_attributes' => true },
+                                                                'canonical' => { 'from' => ['redirect_canonical'], 'object' => 'redirects', 'nested_attributes' => true },
+                                                                'sequence' => { 'from' => ['redirect_sequence'], 'object' => 'redirects', 'nested_attributes' => true },
+                                                                'creator_first_name' => { 'from' => ['creator_first_name'], 'object' => 'creator' }
+                                                              }
+                                                            })
+    end
+
+    let(:object_manager) { described_class.new }
+
+    it 'returns the from-columns of every mapping that targets the given object' do
+      expect(object_manager.object_columns_for('redirects'))
+        .to contain_exactly('redirect_path', 'redirect_canonical', 'redirect_sequence')
+    end
+
+    it 'returns an empty array when no mapping targets the given object' do
+      expect(object_manager.object_columns_for('unknown')).to eq([])
+    end
+
+    it 'works for a single-mapping object' do
+      expect(object_manager.object_columns_for('creator'))
+        .to contain_exactly('creator_first_name')
+    end
+
+    it 'returns an empty array for a property without an `object:` flag' do
+      expect(object_manager.object_columns_for('title')).to eq([])
+    end
+  end
 end

--- a/spec/services/bulkrax/csv_template/value_determiner_spec.rb
+++ b/spec/services/bulkrax/csv_template/value_determiner_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe Bulkrax::CsvTemplate::ValueDeterminer do
     allow(service).to receive(:mapping_manager).and_return(mapping_manager)
     allow(service).to receive(:mappings).and_return(mappings)
     allow(mapping_manager).to receive(:find_by_flag).and_return(nil)
+    # Default: no column maps to an object. Tests that exercise object: mappings
+    # override this for specific keys.
+    allow(mapping_manager).to receive(:get_object_name).and_return(nil)
   end
 
   describe '#determine_value' do
@@ -148,6 +151,48 @@ RSpec.describe Bulkrax::CsvTemplate::ValueDeterminer do
         result = value_determiner.determine_value('xlocalfiles', collection_model, collection_field_list)
 
         expect(result).to be_nil
+      end
+    end
+
+    # When a mapping declares `object:`, the per-child column (e.g.
+    # `redirect_path`) doesn't appear in the model's properties list — but its
+    # parent (e.g. `redirects`) does. Without recognising this case, the row
+    # builder leaves the cell blank and the CsvBuilder's empty-column pruning
+    # drops the column from the downloaded template.
+    context 'when column belongs to an `object:` mapping' do
+      let(:object_field_list) do
+        {
+          'GenericWork' => {
+            'properties' => ['title', 'redirects'],
+            'required_terms' => ['title']
+          }
+        }
+      end
+
+      before do
+        allow(mapping_manager).to receive(:mapped_to_key).with('redirect_path').and_return('path')
+        allow(mapping_manager).to receive(:get_object_name).with('path').and_return('redirects')
+      end
+
+      it 'marks the column as Optional based on the parent property' do
+        result = value_determiner.determine_value('redirect_path', model_name, object_field_list)
+        expect(result).to eq('Optional')
+      end
+
+      context 'when the parent property is required' do
+        let(:object_field_list) do
+          {
+            'GenericWork' => {
+              'properties' => ['title', 'redirects'],
+              'required_terms' => ['redirects']
+            }
+          }
+        end
+
+        it 'marks the column as Required' do
+          result = value_determiner.determine_value('redirect_path', model_name, object_field_list)
+          expect(result).to eq('Required')
+        end
       end
     end
   end


### PR DESCRIPTION
> **Backport for the 9.5.0 release.** This PR targets `9-stable`. The parallel PR for `main` (which carries the same change forward into the upcoming v10 release) is #1193.

## Summary

- Adds full support for `object:` field mappings that route through Reform-style `*_attributes` virtual properties — a single mapping declaration now drives import, export, and the downloadable CSV template, with no per-attribute factory code required.
- Refs notch8/palni_palci_knapsack#621.

## Details

### The problem

Bulkrax's `object:` field-mapping pattern groups numbered CSV columns (e.g. `creator_first_name_1`, `creator_first_name_2`) into a single nested attribute on the resource. This works for resources whose attribute setter accepts a plain array of hashes — but many form objects (notably Reform-based `Hyrax::Forms::ResourceForm` subclasses) strip the bare attribute name during deserialization and only accept the `*_attributes` form: a numbered-key hash with `_destroy` markers per row.

For those targets, the only existing path was a hardcoded translator in `Bulkrax::ValkyrieObjectFactory#transform_attributes` (the `convert_based_near_to_attributes` method). Every new nested-attribute property would require a parallel translator. There was no declarative mapping option, and several other parts of the pipeline silently broke when the data shape didn't fit:

- The factory's `permitted_attributes` slice dropped any `*_attributes` key before it reached the form.
- The exporter's `object_metadata` called `eval` on each entry, which fails on plain hashes from JSONB-backed resources.
- The CSV template emitted the bare property name (e.g. `redirects`) instead of the per-child columns adopters actually need.
- The empty-column pruner removed those columns from downloaded templates because the row builder didn't know to fill them.
- Pre-existing: any `_<digits>`-suffixed header was accepted unconditionally, masking typos in numbered columns.

### The change

Each piece of the pipeline now treats `object:` mappings as first-class:

- **New `nested_attributes: true` mapping flag.** When set, Bulkrax writes imported data to `parsed_metadata['<object>_attributes']` as a numbered-key hash with `_destroy: 'false'` per row — the shape Reform's nested-attributes machinery consumes. Adopters declare the flag in their field mapping; no factory edit required.
- **Object factory keeps `*_attributes` keys.** When the bare property is permitted, the corresponding `*_attributes` key passes through `transform_attributes` instead of being sliced out. Generic — any nested-attribute property added in the future works without further changes.
- **Exporter tolerates plain hashes.** `object_metadata` accepts either a stringified Ruby hash literal (legacy ActiveFedora form) or a plain Hash (Valkyrie/JSONB form). The legacy path still works.
- **CSV template emits per-child columns.** When a property is the target of one or more `object:` mappings, the template emits each mapping's `from:` column instead of the bare property name. Numbering is intentionally omitted — adopters add `_1`, `_2`, etc. at import time.
- **Template row builder fills the cells.** A column whose mapping has an `object:` value is treated as belonging to its parent property, so the empty-column pruner doesn't drop it from the download.
- **Suffix validation now requires a known base.** A header ending in `_<digits>` is recognized only when its base name is itself a known property or mapping alias. This fixes a pre-existing typo-masking issue surfaced during this work.

### Backward compatibility

The existing `convert_based_near_to_attributes` translator stays in place. Adopters using based_near keep working without changes. A follow-up issue (#1194) tracks deprecating that translator in favor of the new flag.

## Testing

- [ ] Configure a CSV mapping with `nested_attributes: true` against a Reform-based form (e.g. a Hyrax `ResourceForm` subclass with a virtual `*_attributes` property). Import a CSV and confirm the data populates the resource end-to-end.
- [ ] Confirm an existing `object:` mapping without the flag still produces the original array-of-hashes shape on `parsed_metadata[<name>]` (no regression on unflagged callers).
- [ ] Export a record whose `object:`-mapped attribute returns plain Ruby hashes (Valkyrie/JSONB-backed) and confirm the numbered CSV columns are populated correctly.
- [ ] Export a record whose `object:`-mapped attribute returns the legacy stringified-hash form and confirm it still round-trips.
- [ ] Download a CSV template for a model that exposes a nested-attribute property. Confirm the per-child columns (e.g. `redirect_path`, `redirect_canonical`) appear in the downloaded file with explanation rows populated.
- [ ] Submit a CSV with a misspelled numbered column (e.g. `creater_1`). Confirm the validator flags it as unrecognized.
