### PR TITLE
Update redirect example fixtures to display flag

### DIFF
--- a/app/services/bulkrax/csv_template/column_builder.rb
+++ b/app/services/bulkrax/csv_template/column_builder.rb
@@ -43,8 +43,8 @@ module Bulkrax
 
       # When a property is the target of one or more `object:` field mappings,
       # emit each of those mappings' `from:` columns (e.g. redirect_path,
-      # redirect_canonical, redirect_sequence) rather than the bare property
-      # name (redirects). Otherwise fall back to the standard 1:1 mapping.
+      # redirect_display_url) rather than the bare property name (redirects).
+      # Otherwise fall back to the standard 1:1 mapping.
       def columns_for_property(property)
         nested = @service.mapping_manager.object_columns_for(property)
         return nested if nested.any?

--- a/app/services/bulkrax/csv_template/mapping_manager.rb
+++ b/app/services/bulkrax/csv_template/mapping_manager.rb
@@ -35,11 +35,11 @@ module Bulkrax
 
       # Returns the column names that target a given object name via the
       # `object:` field-mapping pattern. The template generator uses this to
-      # emit the per-child columns (e.g. redirect_path, redirect_canonical,
-      # redirect_sequence) instead of the bare property name (redirects).
-      # Numbering is intentionally omitted — the template shows the column
-      # shape once; CSV rows can repeat the column with numeric suffixes
-      # (e.g. redirect_path_1, redirect_path_2) at import time.
+      # emit the per-child columns (e.g. redirect_path, redirect_display_url)
+      # instead of the bare property name (redirects). Numbering is
+      # intentionally omitted — the template shows the column shape once;
+      # CSV rows can repeat the column with numeric suffixes (e.g.
+      # redirect_path_1, redirect_path_2) at import time.
       def object_columns_for(object_name)
         @mappings
           .select { |_k, v| v.is_a?(Hash) && v["object"] == object_name }

--- a/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser/csv_validation_helpers_spec.rb
@@ -294,16 +294,14 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
     # `nested_attributes: true` mappings (introduced for objects whose form
     # populator strips the bare property name) emit data through the
     # `<object>_attributes` key. The CSV side still uses the per-child
-    # column names (e.g. `redirect_path`, `redirect_canonical`,
-    # `redirect_sequence`) — both bare and numbered — and the validator
-    # must accept all three forms.
+    # column names (e.g. `redirect_path`, `redirect_display_url`) — both
+    # bare and numbered — and the validator must accept both forms.
     context 'when a mapping declares nested_attributes: true' do
       let(:mappings) do
         {
           'title' => { 'from' => ['title'], 'split' => '\\|' },
           'path' => { 'from' => ['redirect_path'], 'object' => 'redirects', 'nested_attributes' => true },
-          'canonical' => { 'from' => ['redirect_canonical'], 'object' => 'redirects', 'nested_attributes' => true },
-          'sequence' => { 'from' => ['redirect_sequence'], 'object' => 'redirects', 'nested_attributes' => true }
+          'display_url' => { 'from' => ['redirect_display_url'], 'object' => 'redirects', 'nested_attributes' => true }
         }
       end
       let(:field_metadata) do
@@ -326,7 +324,7 @@ RSpec.describe Bulkrax::CsvParser::CsvValidationHelpers do
       end
 
       it 'does not flag any of the per-child columns together' do
-        result = unrecognized(%w[title redirect_path_1 redirect_canonical_1 redirect_sequence_1 redirect_path_2])
+        result = unrecognized(%w[title redirect_path_1 redirect_display_url_1 redirect_path_2 redirect_display_url_2])
         expect(result).to be_empty
       end
 

--- a/spec/services/bulkrax/csv_template/column_builder_spec.rb
+++ b/spec/services/bulkrax/csv_template/column_builder_spec.rb
@@ -205,13 +205,13 @@ RSpec.describe Bulkrax::CsvTemplate::ColumnBuilder do
             .with(model_name: 'AnotherWork').and_return({})
 
           allow(mapping_manager).to receive(:object_columns_for).with('redirects')
-                                                                .and_return(['redirect_path', 'redirect_canonical', 'redirect_sequence'])
+                                                                .and_return(['redirect_path', 'redirect_display_url'])
         end
 
         it 'emits the object\'s child columns instead of the bare property name' do
           result = column_builder.send(:property_columns)
 
-          expect(result).to include('redirect_path', 'redirect_canonical', 'redirect_sequence')
+          expect(result).to include('redirect_path', 'redirect_display_url')
           # Bare property name does not appear (no `xredirects` in the output).
           expect(result).not_to include('xredirects')
         end

--- a/spec/services/bulkrax/csv_template/mapping_manager_spec.rb
+++ b/spec/services/bulkrax/csv_template/mapping_manager_spec.rb
@@ -242,8 +242,7 @@ RSpec.describe Bulkrax::CsvTemplate::MappingManager do
                                                               'Bulkrax::CsvParser' => {
                                                                 'title' => { 'from' => ['title'] },
                                                                 'path' => { 'from' => ['redirect_path'], 'object' => 'redirects', 'nested_attributes' => true },
-                                                                'canonical' => { 'from' => ['redirect_canonical'], 'object' => 'redirects', 'nested_attributes' => true },
-                                                                'sequence' => { 'from' => ['redirect_sequence'], 'object' => 'redirects', 'nested_attributes' => true },
+                                                                'display_url' => { 'from' => ['redirect_display_url'], 'object' => 'redirects', 'nested_attributes' => true },
                                                                 'creator_first_name' => { 'from' => ['creator_first_name'], 'object' => 'creator' }
                                                               }
                                                             })
@@ -253,7 +252,7 @@ RSpec.describe Bulkrax::CsvTemplate::MappingManager do
 
     it 'returns the from-columns of every mapping that targets the given object' do
       expect(object_manager.object_columns_for('redirects'))
-        .to contain_exactly('redirect_path', 'redirect_canonical', 'redirect_sequence')
+        .to contain_exactly('redirect_path', 'redirect_display_url')
     end
 
     it 'returns an empty array when no mapping targets the given object' do


### PR DESCRIPTION
## Summary
Renames the example fixtures used in CSV template tests and inline comments from `redirect_canonical` / `redirect_sequence` to `redirect_display`, matching the Hyrax rename in samvera/hyrax#7451.

## Details
- Pure documentation-and-fixture rename. No production behavior changes. No public API changes.
- Bulkrax has never had its own redirects mapping; the affected references were illustrative examples of the `nested_attributes: true` pattern that happened to use the previous Hyrax column names.
- Five files touched: two production-file comment blocks and three spec fixtures.