### PR TITLE
Resolve CSV file references with spaces against nested attachments

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -372,12 +372,17 @@ module Bulkrax
         raise StandardError, "Record references local files but no files directory could be resolved from the import path" if files_dir.nil?
 
         r[file_mapping].split(split_pattern).map do |f|
-          file = File.join(files_dir, f.strip.tr(' ', '_'))
-          if File.exist?(file) # rubocop:disable Style/GuardClause
-            file
-          else
-            raise "File #{file} does not exist"
-          end
+          reference = f.strip
+          # Try the reference as written first, then the space->underscore
+          # variant produced by #remove_spaces_from_filenames. The rename only
+          # rewrites the top level of files/ (see unzip_spec), so nested
+          # attachments keep their spaces on disk and only match as written.
+          file = [reference, reference.tr(' ', '_')].uniq
+                                                    .map { |candidate| File.join(files_dir, candidate) }
+                                                    .find { |candidate| File.exist?(candidate) }
+          raise "File #{File.join(files_dir, reference)} does not exist" if file.nil?
+
+          file
         end
       end.flatten.compact.uniq
     end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -622,6 +622,30 @@ module Bulkrax
         end
       end
 
+      context 'when a record references file names containing spaces' do
+        before do
+          allow(subject).to receive(:records).and_return([{ file: 'subdir/has space.jpg|top space.jpg' }])
+          allow(subject).to receive(:path_to_files).and_return('spec/fixtures/csv/files')
+        end
+
+        it 'resolves nested files as written and top-level files via the underscored variant' do
+          allow(File).to receive(:exist?).and_return(false)
+          allow(File).to receive(:exist?).with('spec/fixtures/csv/files/subdir/has space.jpg').and_return(true)
+          allow(File).to receive(:exist?).with('spec/fixtures/csv/files/top_space.jpg').and_return(true)
+
+          expect(subject.file_paths).to contain_exactly(
+            'spec/fixtures/csv/files/subdir/has space.jpg',
+            'spec/fixtures/csv/files/top_space.jpg'
+          )
+        end
+
+        it 'raises naming the as-written reference when neither variant exists' do
+          allow(File).to receive(:exist?).and_return(false)
+
+          expect { subject.file_paths }.to raise_error(RuntimeError, %r{subdir/has space\.jpg does not exist})
+        end
+      end
+
       context 'when a record file value is blank' do
         before do
           allow(subject).to receive(:records).and_return([{ file: '' }, { file: nil }])


### PR DESCRIPTION
### Summary

`CsvParser#file_paths` transliterates every `file` reference's spaces to underscores before checking existence (`f.strip.tr(' ', '_')`), while `#remove_spaces_from_filenames` only renames the **top level** of `files/` — and the unzip_spec added with the guided importer (#1098) pins that one-level behavior deliberately, on the rationale that renaming nested entries would break CSV references.

Those two halves contradict each other for nested attachments: a CSV referencing `files/subdir/photo name.jpg` can never resolve — the lookup demands the underscored variant, the disk keeps the spaces, and the import aborts with `RuntimeError: File ... does not exist`.

This PR makes `file_paths` try the reference **as written** first, then fall back to the underscored variant (which still matches top-level files renamed by `remove_spaces_from_filenames`). No on-disk renaming behavior changes, so the #1098 spec's intent is preserved.

### Real-world reproduction

Hit on a Hyku 7.1.x tenant importing a per-work-folder zip (`files/<work-slug>/<photos>`, the layout the CSV parser's parents/children conventions encourage) where four photos had spaces in their names:

```
RuntimeError - File tmp/imports/.../files/files/design-square-one/Square_1_Design.png does not exist
```

The file existed at `.../files/files/design-square-one/Square 1 Design.png`. Nothing in the importer UI or validation surfaces the mismatch; the run simply dies on the first spaced reference. Operators have no reason to expect underscores: the CSV they wrote matches the files they zipped.

### Notes

A related observation from the same session, possibly worth a follow-up issue: the guided importer's upload validation passed this package, and the failure only surfaced later in `ImporterJob` — the validator and `file_paths` evidently resolve attachment paths differently. Happy to file separately with details.

### Changes

- `file_paths`: candidate list `[as-written, underscored]`, first existing wins; error message names the as-written reference.
- Specs: nested-spaces resolution (as-written) + top-level fallback (underscored) + error case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)